### PR TITLE
Add UUID in value strategy

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/UuidInValueStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/UuidInValueStrategy.java
@@ -1,0 +1,28 @@
+package com.mongodb.kafka.connect.sink.processor.id.strategy;
+
+import com.mongodb.kafka.connect.sink.converter.SinkDocument;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.bson.*;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.ID_FIELD;
+
+public class UuidInValueStrategy implements IdStrategy {
+    @Override
+    public BsonValue generateId(SinkDocument doc, SinkRecord orig) {
+        Optional<BsonDocument> optionalDoc = doc.getValueDoc();
+
+        BsonValue id = optionalDoc.map(d -> d.get(ID_FIELD))
+                .orElseThrow(() -> new DataException("Error: provided id strategy is used but the document structure either contained"
+                        + " no _id field or it was null"));
+
+        if (id instanceof BsonNull) {
+            throw new DataException("Error: provided id strategy used but the document structure contained an _id of type BsonNull");
+        }
+
+        return new BsonBinary(UUID.fromString(id.asString().getValue()), UuidRepresentation.STANDARD);
+    }
+}

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/UuidInValueStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/UuidInValueStrategy.java
@@ -1,20 +1,43 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: Apache License, Version 2.0, Copyright 2017 Hans-Peter Grahsl.
+ */
 package com.mongodb.kafka.connect.sink.processor.id.strategy;
 
-import com.mongodb.kafka.connect.sink.converter.SinkDocument;
-import org.apache.kafka.connect.errors.DataException;
-import org.apache.kafka.connect.sink.SinkRecord;
-import org.bson.*;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.ID_FIELD;
 
 import java.util.Optional;
 import java.util.UUID;
 
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.ID_FIELD;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import org.bson.BsonBinary;
+import org.bson.BsonDocument;
+import org.bson.BsonNull;
+import org.bson.BsonValue;
+import org.bson.UuidRepresentation;
+
+import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 
 public class UuidInValueStrategy implements IdStrategy {
-    @Override
-    public BsonValue generateId(SinkDocument doc, SinkRecord orig) {
-        Optional<BsonDocument> optionalDoc = doc.getValueDoc();
 
+    @Override
+    public BsonValue generateId(final SinkDocument doc, final SinkRecord orig) {
+        Optional<BsonDocument> optionalDoc = doc.getValueDoc();
         BsonValue id = optionalDoc.map(d -> d.get(ID_FIELD))
                 .orElseThrow(() -> new DataException("Error: provided id strategy is used but the document structure either contained"
                         + " no _id field or it was null"));
@@ -25,4 +48,5 @@ public class UuidInValueStrategy implements IdStrategy {
 
         return new BsonBinary(UUID.fromString(id.asString().getValue()), UuidRepresentation.STANDARD);
     }
+
 }

--- a/src/test/java/com/mongodb/kafka/connect/sink/processor/id/strategy/IdStrategyTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/processor/id/strategy/IdStrategyTest.java
@@ -24,7 +24,10 @@ import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTI
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_TYPE_CONFIG;
 import static com.mongodb.kafka.connect.sink.SinkTestHelper.createTopicConfig;
 import static java.lang.String.format;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
 import java.util.ArrayList;
@@ -33,13 +36,21 @@ import java.util.UUID;
 
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
-import org.bson.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
+
+import org.bson.BsonBinary;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonNull;
+import org.bson.BsonObjectId;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.UuidRepresentation;
 
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;

--- a/src/test/java/com/mongodb/kafka/connect/sink/processor/id/strategy/IdStrategyTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/processor/id/strategy/IdStrategyTest.java
@@ -24,30 +24,22 @@ import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTI
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_TYPE_CONFIG;
 import static com.mongodb.kafka.connect.sink.SinkTestHelper.createTopicConfig;
 import static java.lang.String.format;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.bson.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
-
-import org.bson.BsonDocument;
-import org.bson.BsonInt32;
-import org.bson.BsonNull;
-import org.bson.BsonObjectId;
-import org.bson.BsonString;
-import org.bson.BsonValue;
 
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
@@ -155,6 +147,29 @@ class IdStrategyTest {
             );
             assertEquals(new BsonDocument(), idS6.generateId(sdWithoutKeyDoc, null));
         }));
+
+        IdStrategy idS7 = new UuidInValueStrategy();
+        idTests.add(dynamicTest(UuidInValueStrategy.class.getSimpleName() + " in value", () -> {
+            String idValue = "6d01622d-b3d5-466d-ae48-e414901af8f2";
+            UUID idUuid = UUID.fromString(idValue);
+            SinkDocument sdWithIdInValueDoc = new SinkDocument(null, new BsonDocument("_id", new BsonString(idValue)));
+            SinkDocument sdWithoutIdInValueDoc = new SinkDocument(null, new BsonDocument());
+            SinkDocument sdWithBsonNullIdInValueDoc = new SinkDocument(null, new BsonDocument());
+            BsonValue id = idS7.generateId(sdWithIdInValueDoc, null);
+
+            assertAll("id checks",
+                    () -> assertTrue(id instanceof BsonBinary),
+                    () -> {
+                        BsonBinary bin = (BsonBinary) id;
+                        UUID foundUuid = bin.asUuid(UuidRepresentation.STANDARD);
+                        assertEquals(idUuid, foundUuid);
+                        assertEquals(idValue, foundUuid.toString());
+                    }
+            );
+            assertThrows(DataException.class, () -> idS7.generateId(sdWithoutIdInValueDoc, null));
+            assertThrows(DataException.class, () -> idS7.generateId(sdWithBsonNullIdInValueDoc, null));
+        }));
+
         return idTests;
     }
 

--- a/src/test/java/com/mongodb/kafka/connect/sink/processor/id/strategy/IdStrategyTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/processor/id/strategy/IdStrategyTest.java
@@ -166,6 +166,7 @@ class IdStrategyTest {
             SinkDocument sdWithIdInValueDoc = new SinkDocument(null, new BsonDocument("_id", new BsonString(idValue)));
             SinkDocument sdWithoutIdInValueDoc = new SinkDocument(null, new BsonDocument());
             SinkDocument sdWithBsonNullIdInValueDoc = new SinkDocument(null, new BsonDocument());
+            SinkDocument sdWithInvalidUuidInValueDoc = new SinkDocument(null, new BsonDocument("_id", new BsonString("invalid")));
             BsonValue id = idS7.generateId(sdWithIdInValueDoc, null);
 
             assertAll("id checks",
@@ -179,6 +180,7 @@ class IdStrategyTest {
             );
             assertThrows(DataException.class, () -> idS7.generateId(sdWithoutIdInValueDoc, null));
             assertThrows(DataException.class, () -> idS7.generateId(sdWithBsonNullIdInValueDoc, null));
+            assertThrows(DataException.class, () -> idS7.generateId(sdWithInvalidUuidInValueDoc, null));
         }));
 
         return idTests;


### PR DESCRIPTION
- Adds an IdStrategy that creates a UUID from a provided string in the _id field. Supports UUIDs with or without dashes.
- Adds tests.