### PR TITLE
Add ReplaceOneShardKeyStrategy

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/Configurable.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/Configurable.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: Apache License, Version 2.0, Copyright 2017 Hans-Peter Grahsl.
+ */
+
+package com.mongodb.kafka.connect.sink;
+
+import org.apache.kafka.common.config.AbstractConfig;
+
+public interface Configurable {
+    void configure(AbstractConfig configuration);
+}

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
@@ -57,7 +57,6 @@ import com.mongodb.kafka.connect.sink.processor.id.strategy.PartialKeyStrategy;
 import com.mongodb.kafka.connect.sink.processor.id.strategy.PartialValueStrategy;
 import com.mongodb.kafka.connect.sink.processor.id.strategy.ProvidedInKeyStrategy;
 import com.mongodb.kafka.connect.sink.writemodel.strategy.DeleteOneDefaultStrategy;
-import com.mongodb.kafka.connect.sink.writemodel.strategy.ReplaceOneShardKeyStrategy;
 import com.mongodb.kafka.connect.sink.writemodel.strategy.WriteModelStrategy;
 import com.mongodb.kafka.connect.util.ConfigHelper;
 import com.mongodb.kafka.connect.util.ConnectConfigException;
@@ -264,9 +263,8 @@ public class MongoSinkTopicConfig extends AbstractConfig {
                     WriteModelStrategy.class);
         }
 
-        if (writeModelStrategy instanceof ReplaceOneShardKeyStrategy) {
-            ((ReplaceOneShardKeyStrategy) writeModelStrategy)
-                .setShardKeys(getString(SHARD_KEY_CONFIG).split(","));
+        if (writeModelStrategy instanceof Configurable) {
+            ((Configurable) writeModelStrategy).configure(this);
         }
 
         return writeModelStrategy;

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
@@ -265,7 +265,8 @@ public class MongoSinkTopicConfig extends AbstractConfig {
         }
 
         if (writeModelStrategy instanceof ReplaceOneShardKeyStrategy) {
-            ((ReplaceOneShardKeyStrategy) writeModelStrategy).setConfig(this);
+            ((ReplaceOneShardKeyStrategy) writeModelStrategy)
+                .setShardKeys(getString(SHARD_KEY_CONFIG).split(","));
         }
 
         return writeModelStrategy;

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
@@ -57,6 +57,7 @@ import com.mongodb.kafka.connect.sink.processor.id.strategy.PartialKeyStrategy;
 import com.mongodb.kafka.connect.sink.processor.id.strategy.PartialValueStrategy;
 import com.mongodb.kafka.connect.sink.processor.id.strategy.ProvidedInKeyStrategy;
 import com.mongodb.kafka.connect.sink.writemodel.strategy.DeleteOneDefaultStrategy;
+import com.mongodb.kafka.connect.sink.writemodel.strategy.ReplaceOneShardKeyStrategy;
 import com.mongodb.kafka.connect.sink.writemodel.strategy.WriteModelStrategy;
 import com.mongodb.kafka.connect.util.ConfigHelper;
 import com.mongodb.kafka.connect.util.ConnectConfigException;
@@ -117,6 +118,11 @@ public class MongoSinkTopicConfig extends AbstractConfig {
     private static final String VALUE_PROJECTION_LIST_DISPLAY = "The value projection list";
     private static final String VALUE_PROJECTION_LIST_DOC = "A comma separated list of field names for value projection";
     private static final String VALUE_PROJECTION_LIST_DEFAULT = "";
+
+    public static final String SHARD_KEY_CONFIG = "shard.key.list";
+    private static final String SHARD_KEY_DISPLAY = "The shard key list";
+    private static final String SHARD_KEY_DOC = "A comma separated list of shard key field names to be added to upserts.";
+    private static final String SHARD_KEY_DEFAULT = "_id";
 
     public static final String FIELD_RENAMER_MAPPING_CONFIG = "field.renamer.mapping";
     private static final String FIELD_RENAMER_MAPPING_DISPLAY = "The field renamer mapping";
@@ -257,6 +263,11 @@ public class MongoSinkTopicConfig extends AbstractConfig {
             writeModelStrategy = createInstance(WRITEMODEL_STRATEGY_CONFIG, getString(WRITEMODEL_STRATEGY_CONFIG),
                     WriteModelStrategy.class);
         }
+
+        if (writeModelStrategy instanceof ReplaceOneShardKeyStrategy) {
+            ((ReplaceOneShardKeyStrategy) writeModelStrategy).setConfig(this);
+        }
+
         return writeModelStrategy;
     }
 
@@ -452,6 +463,16 @@ public class MongoSinkTopicConfig extends AbstractConfig {
                 ++orderInGroup,
                 ConfigDef.Width.MEDIUM,
                 WRITEMODEL_STRATEGY_DISPLAY);
+        configDef.define(SHARD_KEY_CONFIG,
+                ConfigDef.Type.STRING,
+                SHARD_KEY_DEFAULT,
+                Validators.nonEmptyString(),
+                ConfigDef.Importance.HIGH,
+                SHARD_KEY_DOC,
+                group,
+                ++orderInGroup,
+                ConfigDef.Width.MEDIUM,
+                SHARD_KEY_DISPLAY);
         configDef.define(MAX_BATCH_SIZE_CONFIG,
                 ConfigDef.Type.INT,
                 MAX_BATCH_SIZE_DEFAULT,

--- a/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/ReplaceOneShardKeyStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/ReplaceOneShardKeyStrategy.java
@@ -1,6 +1,27 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: Apache License, Version 2.0, Copyright 2017 Hans-Peter Grahsl.
+ */
+
 package com.mongodb.kafka.connect.sink.writemodel.strategy;
 
 
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.SHARD_KEY_CONFIG;
+
+import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.errors.DataException;
 
 import org.bson.BsonDocument;
@@ -10,9 +31,10 @@ import com.mongodb.client.model.ReplaceOneModel;
 import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.WriteModel;
 
+import com.mongodb.kafka.connect.sink.Configurable;
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 
-public class ReplaceOneShardKeyStrategy implements WriteModelStrategy {
+public class ReplaceOneShardKeyStrategy implements WriteModelStrategy, Configurable {
 
     private static final ReplaceOptions REPLACE_OPTIONS = new ReplaceOptions().upsert(true);
 
@@ -38,7 +60,13 @@ public class ReplaceOneShardKeyStrategy implements WriteModelStrategy {
         return new ReplaceOneModel<>(shardKeyTargetQuery, vd, REPLACE_OPTIONS);
     }
 
-    public void setShardKeys(String[] shardKeys) {
+    @Override
+    public void configure(final AbstractConfig configuration) {
+        String[] shardKeys = configuration.getString(SHARD_KEY_CONFIG).split(",");
+        setShardKeys(shardKeys);
+    }
+
+    protected void setShardKeys(final String[] shardKeys) {
         this.shardKeys = shardKeys;
     }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/ReplaceOneShardKeyStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/ReplaceOneShardKeyStrategy.java
@@ -18,7 +18,6 @@
 
 package com.mongodb.kafka.connect.sink.writemodel.strategy;
 
-
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.SHARD_KEY_CONFIG;
 
 import org.apache.kafka.common.config.AbstractConfig;

--- a/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/ReplaceOneShardKeyStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/ReplaceOneShardKeyStrategy.java
@@ -14,31 +14,31 @@ import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 
 public class ReplaceOneShardKeyStrategy implements WriteModelStrategy {
 
-  private static final ReplaceOptions REPLACE_OPTIONS = new ReplaceOptions().upsert(true);
+    private static final ReplaceOptions REPLACE_OPTIONS = new ReplaceOptions().upsert(true);
 
-  private String[] shardKeys;
+    private String[] shardKeys;
 
-  @Override
-  public WriteModel<BsonDocument> createWriteModel(final SinkDocument document) {
-    BsonDocument vd = document.getValueDoc().orElseThrow(
-        () -> new DataException("Error: cannot build the WriteModel since the value document was missing unexpectedly"));
+    @Override
+    public WriteModel<BsonDocument> createWriteModel(final SinkDocument document) {
+        BsonDocument vd = document.getValueDoc().orElseThrow(
+                () -> new DataException(
+                        "Error: cannot build the WriteModel since the value document was missing unexpectedly"));
+        final BsonDocument shardKeyTargetQuery = new BsonDocument();
 
-    final BsonDocument shardKeyTargetQuery = new BsonDocument();
+        for (String shardKey : shardKeys) {
+            final BsonValue shardKeyValue = vd.get(shardKey);
 
-    for (String shardKey : shardKeys) {
-      final BsonValue shardKeyValue = vd.get(shardKey);
+            if (shardKeyValue == null) {
+                throw new DataException("Value document does not contain required shard key: " + shardKey);
+            }
 
-      if (shardKeyValue == null) {
-        throw new DataException("Value document does not contain required shard key: " + shardKey);
-      }
+            shardKeyTargetQuery.put(shardKey, shardKeyValue);
+        }
 
-      shardKeyTargetQuery.put(shardKey, shardKeyValue);
+        return new ReplaceOneModel<>(shardKeyTargetQuery, vd, REPLACE_OPTIONS);
     }
 
-    return new ReplaceOneModel<>(shardKeyTargetQuery, vd, REPLACE_OPTIONS);
-  }
-
-  public void setShardKeys(String[] shardKeys) {
-    this.shardKeys = shardKeys;
-  }
+    public void setShardKeys(String[] shardKeys) {
+        this.shardKeys = shardKeys;
+    }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/ReplaceOneShardKeyStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/ReplaceOneShardKeyStrategy.java
@@ -1,40 +1,44 @@
 package com.mongodb.kafka.connect.sink.writemodel.strategy;
 
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.SHARD_KEY_CONFIG;
 
 import org.apache.kafka.connect.errors.DataException;
 
 import org.bson.BsonDocument;
+import org.bson.BsonValue;
 
 import com.mongodb.client.model.ReplaceOneModel;
 import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.WriteModel;
 
-import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 
 public class ReplaceOneShardKeyStrategy implements WriteModelStrategy {
 
   private static final ReplaceOptions REPLACE_OPTIONS = new ReplaceOptions().upsert(true);
 
-  private MongoSinkTopicConfig config;
+  private String[] shardKeys;
 
   @Override
   public WriteModel<BsonDocument> createWriteModel(final SinkDocument document) {
     BsonDocument vd = document.getValueDoc().orElseThrow(
         () -> new DataException("Error: cannot build the WriteModel since the value document was missing unexpectedly"));
 
-    final String[] shardKeys = config.getString(SHARD_KEY_CONFIG).split(",");
     final BsonDocument shardKeyTargetQuery = new BsonDocument();
 
     for (String shardKey : shardKeys) {
-      shardKeyTargetQuery.put(shardKey, vd.get(shardKey));
+      final BsonValue shardKeyValue = vd.get(shardKey);
+
+      if (shardKeyValue == null) {
+        throw new DataException("Value document does not contain required shard key: " + shardKey);
+      }
+
+      shardKeyTargetQuery.put(shardKey, shardKeyValue);
     }
 
     return new ReplaceOneModel<>(shardKeyTargetQuery, vd, REPLACE_OPTIONS);
   }
 
-  public void setConfig(MongoSinkTopicConfig config) {
-    this.config = config;
+  public void setShardKeys(String[] shardKeys) {
+    this.shardKeys = shardKeys;
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/ReplaceOneShardKeyStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/ReplaceOneShardKeyStrategy.java
@@ -69,4 +69,8 @@ public class ReplaceOneShardKeyStrategy implements WriteModelStrategy, Configura
     protected void setShardKeys(final String[] shardKeys) {
         this.shardKeys = shardKeys;
     }
+
+    protected String[] getShardKeys() {
+        return this.shardKeys;
+    }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/ReplaceOneShardKeyStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/ReplaceOneShardKeyStrategy.java
@@ -1,0 +1,40 @@
+package com.mongodb.kafka.connect.sink.writemodel.strategy;
+
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.SHARD_KEY_CONFIG;
+
+import org.apache.kafka.connect.errors.DataException;
+
+import org.bson.BsonDocument;
+
+import com.mongodb.client.model.ReplaceOneModel;
+import com.mongodb.client.model.ReplaceOptions;
+import com.mongodb.client.model.WriteModel;
+
+import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
+import com.mongodb.kafka.connect.sink.converter.SinkDocument;
+
+public class ReplaceOneShardKeyStrategy implements WriteModelStrategy {
+
+  private static final ReplaceOptions REPLACE_OPTIONS = new ReplaceOptions().upsert(true);
+
+  private MongoSinkTopicConfig config;
+
+  @Override
+  public WriteModel<BsonDocument> createWriteModel(final SinkDocument document) {
+    BsonDocument vd = document.getValueDoc().orElseThrow(
+        () -> new DataException("Error: cannot build the WriteModel since the value document was missing unexpectedly"));
+
+    final String[] shardKeys = config.getString(SHARD_KEY_CONFIG).split(",");
+    final BsonDocument shardKeyTargetQuery = new BsonDocument();
+
+    for (String shardKey : shardKeys) {
+      shardKeyTargetQuery.put(shardKey, vd.get(shardKey));
+    }
+
+    return new ReplaceOneModel<>(shardKeyTargetQuery, vd, REPLACE_OPTIONS);
+  }
+
+  public void setConfig(MongoSinkTopicConfig config) {
+    this.config = config;
+  }
+}

--- a/src/main/java/com/mongodb/kafka/connect/util/Validators.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/Validators.java
@@ -55,6 +55,15 @@ public final class Validators {
         });
     }
 
+    public static ValidatorWithOperators nonEmptyString() {
+        return withStringDef("An non-empty string", (name, value) -> {
+            // value type already validated when parsed as String, hence ignoring ClassCastException
+            if (((String) value).isEmpty()) {
+                throw new ConfigException(name, value, "String is empty");
+            }
+        });
+    }
+
     public static ValidatorWithOperators matching(final Pattern pattern) {
         return withStringDef(format("A string matching `%s`", pattern), (name, value) -> {
             // type already validated when parsing config, hence ignoring ClassCastException

--- a/src/main/java/com/mongodb/kafka/connect/util/Validators.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/Validators.java
@@ -56,7 +56,7 @@ public final class Validators {
     }
 
     public static ValidatorWithOperators nonEmptyString() {
-        return withStringDef("An non-empty string", (name, value) -> {
+        return withStringDef("A non-empty string", (name, value) -> {
             // value type already validated when parsed as String, hence ignoring ClassCastException
             if (((String) value).isEmpty()) {
                 throw new ConfigException(name, value, "String is empty");

--- a/src/test/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyTest.java
@@ -77,8 +77,8 @@ class WriteModelStrategyTest {
     }
 
     @Test
-    @DisplayName("when key document is missing for ShardKeyStrategy then DataException")
-    void testShardKeyStrategyWithMissingValueDocument() {
+    @DisplayName("when value document is missing for ShardKeyStrategy then DataException")
+    void testReplaceOneShardKeyStrategyWithMissingValueDocument() {
 
         assertThrows(DataException.class, () ->
             REPLACE_ONE_SHARD_KEY_STRATEGY.createWriteModel(
@@ -90,7 +90,7 @@ class WriteModelStrategyTest {
 
     @Test
     @DisplayName("when document is missing shard key for ShardKeyStrategy then DataException")
-    void testShardKeyStrategyWithValueDocumentMissingShardKey() {
+    void testReplaceOneShardKeyStrategyWithValueDocumentMissingShardKey() {
         REPLACE_ONE_SHARD_KEY_STRATEGY.setShardKeys(new String[] {"_id", "test"});
         assertThrows(DataException.class, () ->
             REPLACE_ONE_SHARD_KEY_STRATEGY.createWriteModel(
@@ -102,7 +102,7 @@ class WriteModelStrategyTest {
 
     @Test
     @DisplayName("when key document is missing for ShardKeyStrategy then DataException")
-    void testShardKeyStrategyWithValidValueDocument() {
+    void testReplaceOneShardKeyStrategyWithValidValueDocument() {
         BsonDocument validDocument = BsonDocument.parse("{_id: 1234, test: 23, testTwo: 'two'}");
         BsonDocument expectedFilterDocument = BsonDocument.parse("{_id: 1234, test: 23}");
         REPLACE_ONE_SHARD_KEY_STRATEGY.setShardKeys(new String[] {"_id", "test"});

--- a/src/test/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyTest.java
@@ -39,7 +39,10 @@ import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 import org.mockito.Mockito;
 
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.SHARD_KEY_CONFIG;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 @RunWith(JUnitPlatform.class)
 class WriteModelStrategyTest {

--- a/src/test/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
-import org.mockito.MockitoAnnotations;
 
 import org.bson.BsonDateTime;
 import org.bson.BsonDocument;
@@ -60,7 +59,6 @@ class WriteModelStrategyTest {
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.initMocks(this);
         REPLACE_ONE_SHARD_KEY_STRATEGY.setShardKeys(new String[] {"_id"});
     }
 

--- a/src/test/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyTest.java
@@ -18,10 +18,7 @@
 
 package com.mongodb.kafka.connect.sink.writemodel.strategy;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
+import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.errors.DataException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -39,6 +36,10 @@ import com.mongodb.client.model.UpdateOneModel;
 import com.mongodb.client.model.WriteModel;
 
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
+import org.mockito.Mockito;
+
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.SHARD_KEY_CONFIG;
+import static org.junit.jupiter.api.Assertions.*;
 
 @RunWith(JUnitPlatform.class)
 class WriteModelStrategyTest {
@@ -96,6 +97,19 @@ class WriteModelStrategyTest {
             )
         );
 
+    }
+
+    @Test
+    @DisplayName("ReplaceOneShardKeyStrategy correctly sets shard keys from configuration class")
+    void name() {
+        final ReplaceOneShardKeyStrategy strategy = new ReplaceOneShardKeyStrategy();
+        final AbstractConfig mockedConfig = Mockito.mock(AbstractConfig.class);
+        Mockito.doReturn("_id,test_key,test_key_two").when(mockedConfig).getString(SHARD_KEY_CONFIG);
+        String[] expectedShardKeys = new String[]{"_id", "test_key", "test_key_two"};
+
+        strategy.configure(mockedConfig);
+
+        assertArrayEquals(expectedShardKeys, strategy.getShardKeys());
     }
 
     @Test

--- a/src/test/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyTest.java
@@ -101,7 +101,7 @@ class WriteModelStrategyTest {
 
     @Test
     @DisplayName("ReplaceOneShardKeyStrategy correctly sets shard keys from configuration class")
-    void name() {
+    void testReplaceOneShardKeyStrategyConfiguresCorrectly() {
         final ReplaceOneShardKeyStrategy strategy = new ReplaceOneShardKeyStrategy();
         final AbstractConfig mockedConfig = Mockito.mock(AbstractConfig.class);
         Mockito.doReturn("_id,test_key,test_key_two").when(mockedConfig).getString(SHARD_KEY_CONFIG);

--- a/src/test/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyTest.java
@@ -18,6 +18,12 @@
 
 package com.mongodb.kafka.connect.sink.writemodel.strategy;
 
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.SHARD_KEY_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.errors.DataException;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,6 +31,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 
 import org.bson.BsonDateTime;
 import org.bson.BsonDocument;
@@ -36,13 +43,6 @@ import com.mongodb.client.model.UpdateOneModel;
 import com.mongodb.client.model.WriteModel;
 
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
-import org.mockito.Mockito;
-
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.SHARD_KEY_CONFIG;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 @RunWith(JUnitPlatform.class)
 class WriteModelStrategyTest {

--- a/src/test/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyTest.java
@@ -99,7 +99,7 @@ class WriteModelStrategyTest {
     }
 
     @Test
-    @DisplayName("when key document is missing for ShardKeyStrategy then DataException")
+    @DisplayName("when sink document is valid for ReplaceOneShardKeyStrategy then correct ReplaceOneModel")
     void testReplaceOneShardKeyStrategyWithValidValueDocument() {
         BsonDocument validDocument = BsonDocument.parse("{_id: 1234, test: 23, testTwo: 'two'}");
         BsonDocument expectedFilterDocument = BsonDocument.parse("{_id: 1234, test: 23}");


### PR DESCRIPTION
- Adds ReplaceOneShardKeyStrategy which creates an upsert which matches on additional fields specified in the shard.key.list configuration. This is intended to be used to create update queries which match the full shard key definition.
- Adds tests.