### PR TITLE
Add json properties

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/MongoSourceConnector.java
+++ b/src/main/java/com/mongodb/kafka/connect/MongoSourceConnector.java
@@ -93,5 +93,6 @@ public class MongoSourceConnector extends SourceConnector {
 
   @Override
   public String version() {
-    return Versions.VERSION; }
+    return Versions.VERSION;
+  }
 }

--- a/src/main/java/com/mongodb/kafka/connect/MongoSourceConnector.java
+++ b/src/main/java/com/mongodb/kafka/connect/MongoSourceConnector.java
@@ -93,6 +93,6 @@ public class MongoSourceConnector extends SourceConnector {
 
   @Override
   public String version() {
-    return Versions.VERSION;
+    return "null"; /*Versions.VERSION; */
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/MongoSourceConnector.java
+++ b/src/main/java/com/mongodb/kafka/connect/MongoSourceConnector.java
@@ -92,7 +92,5 @@ public class MongoSourceConnector extends SourceConnector {
   }
 
   @Override
-  public String version() {
-    return "null"; /*Versions.VERSION; */
-  }
+  public String version() { return Versions.VERSION; }
 }

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -58,7 +58,8 @@ public class MongoSourceConfig extends AbstractConfig {
           + "eg: ``mongodb://user@pass@locahost/``.";
 
   public static final String JSON_FORMAT = "json.format";
-  private static final String JSON_DOC = "This will provide in which type of JSON the output will be, we will have 3 type of mods : "
+  private static final String JSON_DOC =
+      "This will provide in which type of JSON the output will be, we will have 3 type of mods : "
           + " * Mod Canonical Format : json.format=canonical "
           + " * Mod Relaxed Format json.format=relaxed";
   public static final String JSON_FORMAT_DEFAULT = "canonical";
@@ -133,7 +134,6 @@ public class MongoSourceConfig extends AbstractConfig {
           + "watched.";
   private static final String COLLECTION_DEFAULT = "";
 
-
   public static final String COPY_EXISTING_CONFIG = "copy.existing";
   private static final String COPY_EXISTING_DISPLAY = "Copy existing data";
   private static final String COPY_EXISTING_DOC =
@@ -191,7 +191,7 @@ public class MongoSourceConfig extends AbstractConfig {
     return collationFromJson(getString(COLLATION_CONFIG));
   }
 
-  public String getJsonType(){
+  public String getJsonType() {
     return getString(JSON_FORMAT);
   }
 
@@ -268,17 +268,15 @@ public class MongoSourceConfig extends AbstractConfig {
         COPY_EXISTING_DISPLAY);
 
     configDef.define(
-            JSON_FORMAT,
-            Type.STRING,
-            JSON_FORMAT_DEFAULT,
-            Importance.MEDIUM,
-            JSON_DOC,
-            group,
-            ++orderInGroup,
-            Width.MEDIUM,
-            JSON_FORMAT_DISPLAY
-    );
-
+        JSON_FORMAT,
+        Type.STRING,
+        JSON_FORMAT_DEFAULT,
+        Importance.MEDIUM,
+        JSON_DOC,
+        group,
+        ++orderInGroup,
+        Width.MEDIUM,
+        JSON_FORMAT_DISPLAY);
 
     configDef.define(
         COPY_EXISTING_MAX_THREADS_CONFIG,

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -191,6 +191,8 @@ public class MongoSourceConfig extends AbstractConfig {
     return collationFromJson(getString(COLLATION_CONFIG));
   }
 
+  public String getJsonType(){ return getString(JSON_FORMAT);  }
+
   public Optional<FullDocument> getFullDocument() {
     if (getBoolean(PUBLISH_FULL_DOCUMENT_ONLY_CONFIG)) {
       return Optional.of(FullDocument.UPDATE_LOOKUP);

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -56,10 +56,13 @@ public class MongoSourceConfig extends AbstractConfig {
   private static final String CONNECTION_URI_DOC =
       "The connection URI as supported by the official drivers. "
           + "eg: ``mongodb://user@pass@locahost/``.";
+
   public static final String JSON_FORMAT = "json.format";
   private static final String JSON_DOC = "This will provide in which type of JSON the output will be, we will have 3 type of mods : "
           + " * Mod Canonical Format : json.format=canonical "
           + " * Mod Relaxed Format json.format=relaxed";
+  public static final String JSON_FORMAT_DEFAULT = "canonical";
+  public static final String JSON_FORMAT_DISPLAY= " The format of your json output";
 
   public static final String TOPIC_PREFIX_CONFIG = "topic.prefix";
   private static final String TOPIC_PREFIX_DOC =
@@ -259,6 +262,19 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         COPY_EXISTING_DISPLAY);
+
+    configDef.define(
+            JSON_FORMAT,
+            Type.STRING,
+            JSON_FORMAT_DEFAULT,
+            Importance.MEDIUM,
+            JSON_DOC,
+            group,
+            ++orderInGroup,
+            Width.MEDIUM,
+            JSON_FORMAT_DISPLAY
+    );
+
 
     configDef.define(
         COPY_EXISTING_MAX_THREADS_CONFIG,

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -56,6 +56,10 @@ public class MongoSourceConfig extends AbstractConfig {
   private static final String CONNECTION_URI_DOC =
       "The connection URI as supported by the official drivers. "
           + "eg: ``mongodb://user@pass@locahost/``.";
+  public static final String JSON_FORMAT = "json.format";
+  private static final String JSON_DOC = "This will provide in which type of JSON the output will be, we will have 3 type of mods : "
+          + " * Mod Canonical Format : json.format=canonical "
+          + " * Mod Relaxed Format json.format=relaxed";
 
   public static final String TOPIC_PREFIX_CONFIG = "topic.prefix";
   private static final String TOPIC_PREFIX_DOC =
@@ -125,6 +129,7 @@ public class MongoSourceConfig extends AbstractConfig {
       "The collection in the database to watch. If not set then all collections will be "
           + "watched.";
   private static final String COLLECTION_DEFAULT = "";
+
 
   public static final String COPY_EXISTING_CONFIG = "copy.existing";
   private static final String COPY_EXISTING_DISPLAY = "Copy existing data";

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -150,6 +150,7 @@ public class MongoSourceTask extends SourceTask {
 
   @Override
   public List<SourceRecord> poll() {
+    System.out.println("Je passe bien ici");
     final long startPoll = time.milliseconds();
     LOGGER.debug("Polling Start: {}", startPoll);
     List<SourceRecord> sourceRecords = new ArrayList<>();

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -175,6 +175,15 @@ public class MongoSourceTask extends SourceTask {
 
         Map<String, String> sourceOffset = new HashMap<>();
         //TODO : add here test for the Sourceonfig Format
+        if(){
+
+        }
+        else if(){
+
+        }
+        else{
+          throw()
+        }
         sourceOffset.put("_id", changeStreamDocument.getDocument("_id").toJson());
         if (isCopying.get()) {
           sourceOffset.put("copy", "true");

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -174,6 +174,7 @@ public class MongoSourceTask extends SourceTask {
         BsonDocument changeStreamDocument = next.get();
 
         Map<String, String> sourceOffset = new HashMap<>();
+        //TODO : add here test for the Sourceonfig Format
         sourceOffset.put("_id", changeStreamDocument.getDocument("_id").toJson());
         if (isCopying.get()) {
           sourceOffset.put("copy", "true");

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -175,14 +175,20 @@ public class MongoSourceTask extends SourceTask {
 
         Map<String, String> sourceOffset = new HashMap<>();
         //TODO : add here test for the Sourceonfig Format
-        if(){
+        if(sourceConfig.getJsonType().equals("canonical")){
 
         }
-        else if(){
+        else if(sourceConfig.getJsonType().equals("relaxed")){
 
         }
         else{
-          throw()
+
+          try {
+            throw new Exception("This Json format is not supported or Unknown please choose : \"relaxed\", \"canonical\" ");
+          } catch (Exception e) {
+            e.printStackTrace();
+          }
+
         }
         sourceOffset.put("_id", changeStreamDocument.getDocument("_id").toJson());
         if (isCopying.get()) {


### PR DESCRIPTION
# Description
Following the [Add MongoDb Issue](https://code.euranova.eu/david/data_supply_chain/digazu/-/issues/2), we are adding a properties directly on the connector to add JSON output options. 

We have now to options : 

`relaxed` : it's the standard way of JSON format
`canonical` [default] : it's the model `extended` of JSON

you can find [here](https://github.com/mongodb/specifications/blob/master/source/extended-json.rst#conversion-table) the differences. 

Here the followings steps that i had : 

1) I add the configurations in the [`MongoSourceConfig`]
2) We are receiving a Schema with the values, and the flatten keys of the previous json. (see [here](https://code.euranova.eu/david/data_supply_chain/core-mario-display/-/issues/155#note_168703) the schema )
3) We will create a new record with the key words from the previous schema and the value that we retrieve from the kafka's json.

# Checklist

**IMPORTANT**: *if an item is not needed, do not tick the box but instead remove it from the list.*

- [x] This MR references an issue with a proper description
- 🍭 Features
  - [x] Serialized and Unserialized value
  - [x] Parse Json
  - [x] Get values
  - [x] Bind values and name from the schema
- ⭐ Code Quality
  - [x] Tests have been added / changed
  - [x] Code is commented where it is complex
  - [x] Tests pass
  - [x] Code was reviewed
  - [x] branch was squashed/rebased to limit the number of commits
  - [x] Branch is up to date with master
- 📖 Repo Documentation
  - [x] Update the CHANGELOG
  - [x] Update the README