### PR TITLE
Add json properties (#2)

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -46,6 +46,7 @@ import com.mongodb.client.model.changestream.FullDocument;
 import com.mongodb.kafka.connect.util.ConfigHelper;
 import com.mongodb.kafka.connect.util.ConnectConfigException;
 import com.mongodb.kafka.connect.util.Validators;
+import org.bson.json.JsonMode;
 
 public class MongoSourceConfig extends AbstractConfig {
 
@@ -56,6 +57,23 @@ public class MongoSourceConfig extends AbstractConfig {
   private static final String CONNECTION_URI_DOC =
       "The connection URI as supported by the official drivers. "
           + "eg: ``mongodb://user@pass@locahost/``.";
+
+  public static final String JSON_OUTPUT_MODE = "json.format";
+  private static final String JSON_OUTPUT_MODE_DOC =
+      "The output mode of the ``JSONWriter``. The accepted values are ``strict`` "
+          + "(Legacy representation. Though now deprecated, this is still the default mode when writing JSON"
+          + " in order to avoid breaking backward compatibility.), "
+          + "``relaxed`` (Relaxed representation that loses type information for BSON numeric types and uses "
+          + "a more human-readable representation of BSON dates.)."
+          + "``shell`` (While not formally documented, this output mode will attempt to produce output that "
+          + " corresponds to what the MongoDB shell actually produces when showing query results.) and "
+          + "``extended``(Standard extended JSON representation, keep more data from BSON)"
+          + " * Mode Strict Format: json.format=strict "
+          + " * Mode Relaxed Format: json.format=relaxed"
+          + " * Mode Shell Format: json.format=shell"
+          + " * Mode Extended Format: json.format=extended";
+  public static final String JSON_OUTPUT_MODE_DEFAULT = "strict";
+  public static final String JSON_OUTPUT_MODE_DISPLAY = " The format of your json output";
 
   public static final String TOPIC_PREFIX_CONFIG = "topic.prefix";
   private static final String TOPIC_PREFIX_DOC =
@@ -183,6 +201,10 @@ public class MongoSourceConfig extends AbstractConfig {
     return collationFromJson(getString(COLLATION_CONFIG));
   }
 
+  public JsonMode getJsonOutputMode() {
+    return JsonMode.valueOf(getString(JSON_OUTPUT_MODE).toUpperCase());
+  }
+
   public Optional<FullDocument> getFullDocument() {
     if (getBoolean(PUBLISH_FULL_DOCUMENT_ONLY_CONFIG)) {
       return Optional.of(FullDocument.UPDATE_LOOKUP);
@@ -254,6 +276,18 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         COPY_EXISTING_DISPLAY);
+
+    configDef.define(
+        JSON_OUTPUT_MODE,
+        Type.STRING,
+        JSON_OUTPUT_MODE_DEFAULT,
+        Validators.EnumValidatorAndRecommender.in(JsonMode.values()),
+        Importance.MEDIUM,
+        JSON_OUTPUT_MODE_DOC,
+        group,
+        ++orderInGroup,
+        Width.MEDIUM,
+        JSON_OUTPUT_MODE_DISPLAY);
 
     configDef.define(
         COPY_EXISTING_MAX_THREADS_CONFIG,

--- a/src/test/java/com/mongodb/kafka/connect/source/MongoSourceConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/MongoSourceConfigTest.java
@@ -16,14 +16,15 @@
 
 package com.mongodb.kafka.connect.source;
 
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.PIPELINE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.CONNECTION_URI_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.BATCH_SIZE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COLLATION_CONFIG;
-import static com.mongodb.kafka.connect.source.MongoSourceConfig.CONNECTION_URI_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.FULL_DOCUMENT_CONFIG;
-import static com.mongodb.kafka.connect.source.MongoSourceConfig.PIPELINE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.TOPIC_PREFIX_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_AWAIT_TIME_MS_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_MAX_BATCH_SIZE_CONFIG;
-import static com.mongodb.kafka.connect.source.MongoSourceConfig.TOPIC_PREFIX_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.JSON_OUTPUT_MODE;
 import static com.mongodb.kafka.connect.source.SourceTestHelper.CLIENT_URI_AUTH_SETTINGS;
 import static com.mongodb.kafka.connect.source.SourceTestHelper.CLIENT_URI_DEFAULT_SETTINGS;
 import static com.mongodb.kafka.connect.source.SourceTestHelper.createConfigMap;
@@ -40,6 +41,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.apache.kafka.common.config.ConfigException;
+import org.bson.json.JsonMode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -58,7 +60,7 @@ class MongoSourceConfigTest {
 
   @Test
   @DisplayName("build config doc (no test)")
-  // CHECKSTYLE:OFF
+    // CHECKSTYLE:OFF
   void doc() {
     System.out.println(MongoSourceConfig.CONFIG.toRst());
     System.out.println(MarkdownFormatter.toMarkdown(MongoSourceConfig.CONFIG));
@@ -215,6 +217,20 @@ class MongoSourceConfigTest {
                 createSourceConfig(POLL_AWAIT_TIME_MS_CONFIG, "100")
                     .getLong(POLL_AWAIT_TIME_MS_CONFIG)),
         () -> assertInvalid(POLL_AWAIT_TIME_MS_CONFIG, "0"));
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  @DisplayName("test json config entry")
+  void testJsonProperties() {
+    assertAll(
+        () -> assertEquals(JsonMode.STRICT, createSourceConfig().getJsonOutputMode()),
+        () ->
+            assertEquals(
+                JsonMode.EXTENDED,
+                createSourceConfig(JSON_OUTPUT_MODE, "extended")
+                    .getJsonOutputMode()),
+        () -> assertInvalid(JSON_OUTPUT_MODE, "test"));
   }
 
   private void assertInvalid(final String key, final String value) {


### PR DESCRIPTION
# Description
Following some needs in intern of EURA NOVA, we are adding a properties directly on the connector to add JSON output options. 

We have now several options : 

`relaxed` : it's the standard way of JSON format
`strict` [default] : it's the model `strict` of JSON
`extended` : it's the  extended JSON format
`shell`  : it's the model `shell` mode that mongodb answers will give you as JSON

you can find [here](https://github.com/mongodb/specifications/blob/master/source/extended-json.rst#conversion-table) the differences. 

Here the followings steps that i had : 

1) I add the configurations in the [`MongoSourceConfig`](https://github.com/euranova/mongo-kafka/blob/bc1f1ddceecb4b17f0da620cac049471fe486541/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java#L60) 
2) Next i added the JSON type of parser that we want to use
3) And last i use the parser `parseJSON()` from the [MongoDB doc](https://mongodb.github.io/mongo-java-driver/4.0/bson/extended-json/) in the case of `strict` type that is the `legacy` type for `3.12` or older


It should help you as well to upgrade you driver mongoDB from `3.12` to `4.*` and will still be able to use `Strict` mode for previous use