### PR TITLE
Allow outputting in all JSON formats supported by the MongoDB driver 

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -46,6 +46,7 @@ import com.mongodb.client.model.changestream.FullDocument;
 import com.mongodb.kafka.connect.util.ConfigHelper;
 import com.mongodb.kafka.connect.util.ConnectConfigException;
 import com.mongodb.kafka.connect.util.Validators;
+import org.bson.json.JsonMode;
 
 public class MongoSourceConfig extends AbstractConfig {
 
@@ -56,6 +57,23 @@ public class MongoSourceConfig extends AbstractConfig {
   private static final String CONNECTION_URI_DOC =
       "The connection URI as supported by the official drivers. "
           + "eg: ``mongodb://user@pass@locahost/``.";
+
+  public static final String JSON_OUTPUT_MODE = "json.format";
+  private static final String JSON_OUTPUT_MODE_DOC =
+      "The output mode of the ``JSONWriter``. The accepted values are ``strict`` "
+          + "(Legacy representation. Though now deprecated, this is still the default mode when writing JSON"
+          + " in order to avoid breaking backward compatibility.), "
+          + "``relaxed`` (Relaxed representation that loses type information for BSON numeric types and uses "
+          + "a more human-readable representation of BSON dates.)."
+          + "``shell`` (While not formally documented, this output mode will attempt to produce output that "
+          + " corresponds to what the MongoDB shell actually produces when showing query results.) and "
+          + "``extended``(Standard extended JSON representation, keep more data from BSON)"
+          + " * Mode Strict Format: json.format=strict "
+          + " * Mode Relaxed Format: json.format=relaxed"
+          + " * Mode Shell Format: json.format=shell"
+          + " * Mode Extended Format: json.format=extended";
+  public static final String JSON_OUTPUT_MODE_DEFAULT = "strict";
+  public static final String JSON_OUTPUT_MODE_DISPLAY = " The format of your json output";
 
   public static final String TOPIC_PREFIX_CONFIG = "topic.prefix";
   private static final String TOPIC_PREFIX_DOC =
@@ -183,6 +201,10 @@ public class MongoSourceConfig extends AbstractConfig {
     return collationFromJson(getString(COLLATION_CONFIG));
   }
 
+  public JsonMode getJsonOutputMode() {
+    return JsonMode.valueOf(getString(JSON_OUTPUT_MODE).toUpperCase());
+  }
+
   public Optional<FullDocument> getFullDocument() {
     if (getBoolean(PUBLISH_FULL_DOCUMENT_ONLY_CONFIG)) {
       return Optional.of(FullDocument.UPDATE_LOOKUP);
@@ -254,6 +276,18 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         COPY_EXISTING_DISPLAY);
+
+    configDef.define(
+        JSON_OUTPUT_MODE,
+        Type.STRING,
+        JSON_OUTPUT_MODE_DEFAULT,
+        Validators.EnumValidatorAndRecommender.in(JsonMode.values()),
+        Importance.MEDIUM,
+        JSON_OUTPUT_MODE_DOC,
+        group,
+        ++orderInGroup,
+        Width.MEDIUM,
+        JSON_OUTPUT_MODE_DISPLAY);
 
     configDef.define(
         COPY_EXISTING_MAX_THREADS_CONFIG,

--- a/src/test/java/com/mongodb/kafka/connect/source/MongoSourceConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/MongoSourceConfigTest.java
@@ -16,14 +16,15 @@
 
 package com.mongodb.kafka.connect.source;
 
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.PIPELINE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.CONNECTION_URI_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.BATCH_SIZE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COLLATION_CONFIG;
-import static com.mongodb.kafka.connect.source.MongoSourceConfig.CONNECTION_URI_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.FULL_DOCUMENT_CONFIG;
-import static com.mongodb.kafka.connect.source.MongoSourceConfig.PIPELINE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.TOPIC_PREFIX_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_AWAIT_TIME_MS_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_MAX_BATCH_SIZE_CONFIG;
-import static com.mongodb.kafka.connect.source.MongoSourceConfig.TOPIC_PREFIX_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.JSON_OUTPUT_MODE;
 import static com.mongodb.kafka.connect.source.SourceTestHelper.CLIENT_URI_AUTH_SETTINGS;
 import static com.mongodb.kafka.connect.source.SourceTestHelper.CLIENT_URI_DEFAULT_SETTINGS;
 import static com.mongodb.kafka.connect.source.SourceTestHelper.createConfigMap;
@@ -40,6 +41,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.apache.kafka.common.config.ConfigException;
+import org.bson.json.JsonMode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -58,7 +60,7 @@ class MongoSourceConfigTest {
 
   @Test
   @DisplayName("build config doc (no test)")
-  // CHECKSTYLE:OFF
+    // CHECKSTYLE:OFF
   void doc() {
     System.out.println(MongoSourceConfig.CONFIG.toRst());
     System.out.println(MarkdownFormatter.toMarkdown(MongoSourceConfig.CONFIG));
@@ -215,6 +217,20 @@ class MongoSourceConfigTest {
                 createSourceConfig(POLL_AWAIT_TIME_MS_CONFIG, "100")
                     .getLong(POLL_AWAIT_TIME_MS_CONFIG)),
         () -> assertInvalid(POLL_AWAIT_TIME_MS_CONFIG, "0"));
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  @DisplayName("test json config entry")
+  void testJsonProperties() {
+    assertAll(
+        () -> assertEquals(JsonMode.STRICT, createSourceConfig().getJsonOutputMode()),
+        () ->
+            assertEquals(
+                JsonMode.EXTENDED,
+                createSourceConfig(JSON_OUTPUT_MODE, "extended")
+                    .getJsonOutputMode()),
+        () -> assertInvalid(JSON_OUTPUT_MODE, "test"));
   }
 
   private void assertInvalid(final String key, final String value) {


### PR DESCRIPTION
For some specific use cases at EURA NOVA, we needed to be able to output JSON in a relaxed format using `mongo-kafka`. 

To this end, we are proposing a new property (`JSON_OUTPUT_MODE`, `json.format`) to the connector configuration that manages the JSON output format.

It would give the user 4 options, as described in the [mongo-java-driver documentation](https://mongodb.github.io/mongo-java-driver/4.0/bson/extended-json/) :

* `relaxed` 
* `strict` [default] 
* `extended` 
* `shell` 

In order to maintain the current behavior of version `1.1.0` of `mongo-kafka` we have set the default mode to `strict`. 

To produce the JSON in `strict` mode, we are using the function [`BsonDocument.toJson()`](https://github.com/mongodb/mongo-java-driver/blob/3.12.x/bson/src/main/org/bson/BsonDocument.java#L824).
For the other modes we are using `JsonWriterSettings.builder()`. We did this because using `JSONMode.STRICT` with `JsonWriterSettings.builder()`  is deprecated.

As an added benefit, it should help as well when the mongoDB driver will be upgraded from `3.12` to `4.*`, since the default format for certain function of the driver will change.

If need be, you can check our [internal review](https://github.com/euranova/mongo-kafka/pull/1) of the code.

Please tell us if there is anything we need to change to be consistent with the rest of the project, or if you feel we should implement this feature differently. 