### PR TITLE
Fix mispelling with tes*.

### DIFF
--- a/src/test/java/com/mongodb/kafka/connect/source/MongoSourceConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/MongoSourceConfigTest.java
@@ -68,7 +68,7 @@ class MongoSourceConfigTest {
 
   @Test
   @DisplayName("test client uri")
-  void tesClientUri() {
+  void testClientUri() {
     assertAll(
         "Client uri",
         () ->
@@ -179,7 +179,7 @@ class MongoSourceConfigTest {
 
   @Test
   @DisplayName("test topic prefix")
-  void tesTopicPrefix() {
+  void testTopicPrefix() {
     assertAll(
         "Topic prefix",
         () -> assertEquals("", createSourceConfig().getString(TOPIC_PREFIX_CONFIG)),


### PR DESCRIPTION
Fix mispelling with ``tesClientUri`` and ``tesTopicPrefix``.

A really small modification, so i ignore issue.
If jira's issue is necessary, please close this pr directly