### PR TITLE
Added schema support for source

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,7 +57,7 @@ repositories {
 extra.apply {
     set("mongodbDriverVersion", "[3.11.0,3.12.99)")
     set("kafkaVersion", "2.5.0")
-    set("confluentVersion", "5.5.1")
+    set("avroVersion", "1.9.2")
 
     // Testing dependencies
     set("junitJupiterVersion", "5.4.0")
@@ -66,17 +66,16 @@ extra.apply {
     set("mockitoVersion", "2.27.0")
 
     // Integration test dependencies
-    set("avroVersion", "1.8.2")
-    set("scalaVersion", "2.12.11")
-    set("scalaMajMinVersion", "2.12")
+    set("confluentVersion", "5.5.1")
+    set("scalaVersion", "2.12")
     set("curatorVersion", "2.9.0")
     set("connectUtilsVersion", "0.4+")
-    set("guavaVersion", "20.0")
 }
 
 dependencies {
     api("org.apache.kafka:connect-api:${extra["kafkaVersion"]}")
     implementation("org.mongodb:mongodb-driver-sync:${extra["mongodbDriverVersion"]}")
+    implementation("org.apache.avro:avro:${extra["avroVersion"]}")
 
     // Unit Tests
     testImplementation("org.junit.jupiter:junit-jupiter:${extra["junitJupiterVersion"]}")
@@ -85,20 +84,19 @@ dependencies {
     testImplementation("org.mockito:mockito-junit-jupiter:${extra["mockitoVersion"]}")
 
     // Integration Tests
-    testImplementation("org.apache.avro:avro:${extra["avroVersion"]}")
     testImplementation("org.apache.curator:curator-test:${extra["curatorVersion"]}")
-    testImplementation("org.apache.kafka:connect-runtime:${extra["kafkaVersion"]}")
-    testImplementation("org.apache.kafka:kafka-clients:${extra["kafkaVersion"]}:test")
-    testImplementation("org.apache.kafka:kafka-streams:${extra["kafkaVersion"]}")
-    testImplementation("org.apache.kafka:kafka-streams:${extra["kafkaVersion"]}:test")
-    testImplementation("org.scala-lang:scala-library:${extra["scalaVersion"]}")
-    testImplementation("org.apache.kafka:kafka_${extra["scalaMajMinVersion"]}:${extra["kafkaVersion"]}")
-    testImplementation("org.apache.kafka:kafka_${extra["scalaMajMinVersion"]}:${extra["kafkaVersion"]}:test")
     testImplementation("com.github.jcustenborder.kafka.connect:connect-utils:${extra["connectUtilsVersion"]}")
-    testImplementation("com.google.guava:guava:${extra["guavaVersion"]}")
     testImplementation(platform("io.confluent:kafka-schema-registry-parent:${extra["confluentVersion"]}"))
+    testImplementation(group = "com.google.guava", name = "guava")
     testImplementation(group = "io.confluent", name = "kafka-schema-registry")
     testImplementation(group = "io.confluent", name = "kafka-connect-avro-converter")
+    testImplementation(group = "org.apache.kafka", name = "connect-runtime")
+    testImplementation(group = "org.apache.kafka", name = "kafka-clients", classifier = "test")
+    testImplementation(group = "org.apache.kafka", name = "kafka-streams")
+    testImplementation(group = "org.apache.kafka", name = "kafka-streams", classifier = "test")
+    testImplementation(group = "org.scala-lang", name = "scala-library")
+    testImplementation(group = "org.apache.kafka", name = "kafka_${extra["scalaVersion"]}")
+    testImplementation(group = "org.apache.kafka", name = "kafka_${extra["scalaVersion"]}", classifier = "test")
 }
 
 tasks.withType<JavaCompile> {

--- a/src/integrationTest/java/com/mongodb/kafka/connect/FullDocumentRoundTripTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/FullDocumentRoundTripTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.kafka.connect;
+
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.COLLECTION_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.COPY_EXISTING_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.DATABASE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.OUTPUT_FORMAT_VALUE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.OUTPUT_JSON_FORMATTER_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.OUTPUT_SCHEMA_VALUE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.PUBLISH_FULL_DOCUMENT_ONLY_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.TOPIC_PREFIX_CONFIG;
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.IntStream;
+
+import org.apache.kafka.connect.converters.ByteArrayConverter;
+import org.apache.kafka.connect.storage.StringConverter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.bson.Document;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+
+import com.mongodb.kafka.connect.mongodb.MongoKafkaTestCase;
+import com.mongodb.kafka.connect.source.MongoSourceConfig.OutputFormat;
+
+public class FullDocumentRoundTripTest extends MongoKafkaTestCase {
+
+  @BeforeEach
+  void setUp() {
+    assumeTrue(isReplicaSetOrSharded());
+  }
+
+  @AfterEach
+  void tearDown() {
+    getMongoClient()
+        .listDatabaseNames()
+        .into(new ArrayList<>())
+        .forEach(
+            i -> {
+              if (i.startsWith(getDatabaseName())) {
+                getMongoClient().getDatabase(i).drop();
+              }
+            });
+  }
+
+  private static final String FULL_DOCUMENT_JSON =
+      "{\"_id\": %s,"
+          + " \"myObjectId\": {\"$oid\": \"5f15aab12435743f9bd126a4\"},"
+          + " \"myString\": \"some foo bla text\","
+          + " \"myInt\": {\"$numberInt\": \"42\"},"
+          + " \"myDouble\": {\"$numberDouble\": \"20.21\"},"
+          + " \"mySubDoc\": {\"A\": {\"$binary\": {\"base64\": \"S2Fma2Egcm9ja3Mh\", \"subType\": \"00\"}},"
+          + " \"B\": {\"$date\": {\"$numberLong\": \"1577863627000\"}},"
+          + " \"C\": {\"$numberDecimal\": \"12345.6789\"}},"
+          + " \"myArray\": [{\"$numberInt\": \"1\"}, {\"$numberInt\": \"2\"}, {\"$numberInt\": \"3\"}],"
+          + " \"myBytes\": {\"$binary\": {\"base64\": \"S2Fma2Egcm9ja3Mh\", \"subType\": \"00\"}},"
+          + " \"myDate\": {\"$date\": {\"$numberLong\": \"1234567890\"}},"
+          + " \"myDecimal\": {\"$numberDecimal\": \"12345.6789\"}"
+          + "}";
+
+  private static final String SIMPLIFIED_FULL_DOCUMENT_JSON =
+      "{\"_id\": %s, "
+          + "\"myObjectId\": \"5f15aab12435743f9bd126a4\", "
+          + "\"myString\": \"some foo bla text\", "
+          + "\"myInt\": 42, "
+          + "\"myDouble\": 20.21, "
+          + "\"mySubDoc\": {\"A\": \"S2Fma2Egcm9ja3Mh\", \"B\": \"2020-01-01T07:27:07Z\", \"C\": \"12345.6789\"}, "
+          + "\"myArray\": [1, 2, 3], "
+          + "\"myBytes\": \"S2Fma2Egcm9ja3Mh\", "
+          + "\"myDate\": \"1970-01-15T06:56:07.89Z\", "
+          + "\"myDecimal\": \"12345.6789\"}";
+
+  private static final String AVRO_VALUE_SCHEMA =
+      "{\"type\" : \"record\", \"name\" : \"fullDocument\","
+          + "\"fields\" : ["
+          + "  {\"name\": \"_id\", \"type\": \"int\"}, "
+          + "  {\"name\": \"myObjectId\", \"type\": \"string\"}, "
+          + "  {\"name\": \"myString\", \"type\": \"string\"}, "
+          + "  {\"name\": \"myInt\", \"type\": \"int\"}, "
+          + "  {\"name\": \"myDouble\", \"type\": \"double\"}, "
+          + "  {\"name\": \"mySubDoc\", \"type\": {"
+          + "      \"type\" : \"record\", \"name\" : \"mySubDocWithStringValues\","
+          + "      \"fields\" : ["
+          + "       {\"name\" : \"A\", \"type\" : \"string\"}, "
+          + "       {\"name\" : \"B\", \"type\" : \"string\"}, "
+          + "       {\"name\" : \"C\", \"type\" : \"string\"}"
+          + "      ]"
+          + "    }"
+          + "  }, "
+          + "  {\"name\": \"myArray\", \"type\": {\"type\" : \"array\", \"items\" : \"int\"}}, "
+          + "  {\"name\": \"myBytes\", \"type\": \"string\"}, "
+          + "  {\"name\": \"myDate\", \"type\": \"string\"}, "
+          + "  {\"name\": \"myDecimal\", \"type\": \"string\"}"
+          + "]}";
+
+  private static final Properties EMPTY_PROPERTIES = new Properties();
+
+  @Test
+  @DisplayName("Ensure collection round trip default settings")
+  void testRoundTripDefault() {
+    assertRoundTrip(
+        IntStream.range(1, 100)
+            .mapToObj(i -> Document.parse(format(FULL_DOCUMENT_JSON, i)))
+            .collect(toList()));
+  }
+
+  @Test
+  @DisplayName("Ensure collection round trip simple json format settings")
+  void testRoundTripSimpleJsonFormat() {
+    Properties sourceProperties = new Properties();
+    sourceProperties.put(
+        OUTPUT_JSON_FORMATTER_CONFIG,
+        "com.mongodb.kafka.connect.source.json.formatter.SimplifiedJson");
+    assertRoundTrip(
+        IntStream.range(1, 100)
+            .mapToObj(i -> Document.parse(format(FULL_DOCUMENT_JSON, i)))
+            .collect(toList()),
+        IntStream.range(1, 100)
+            .mapToObj(i -> Document.parse(format(SIMPLIFIED_FULL_DOCUMENT_JSON, i)))
+            .collect(toList()),
+        sourceProperties);
+  }
+
+  @Test
+  @DisplayName("Ensure collection round trip using BSON")
+  void testRoundTripBSON() {
+    Properties sourceProperties = new Properties();
+    sourceProperties.put(OUTPUT_FORMAT_VALUE_CONFIG, OutputFormat.BSON.name());
+    sourceProperties.put("value.converter", ByteArrayConverter.class.getName());
+
+    Properties sinkProperties = new Properties();
+    sinkProperties.put("value.converter", ByteArrayConverter.class.getName());
+
+    assertRoundTrip(
+        IntStream.range(1, 100)
+            .mapToObj(i -> Document.parse(format(FULL_DOCUMENT_JSON, i)))
+            .collect(toList()),
+        sourceProperties,
+        sinkProperties);
+  }
+
+  @Test
+  @DisplayName("Ensure collection round trip using Avro Schema")
+  void testRoundTripSchema() {
+    Properties sourceProperties = new Properties();
+    sourceProperties.put(
+        OUTPUT_JSON_FORMATTER_CONFIG,
+        "com.mongodb.kafka.connect.source.json.formatter.SimplifiedJson");
+    sourceProperties.put(OUTPUT_FORMAT_VALUE_CONFIG, OutputFormat.SCHEMA.name());
+    sourceProperties.put(OUTPUT_SCHEMA_VALUE_CONFIG, AVRO_VALUE_SCHEMA);
+    sourceProperties.put("value.converter", "io.confluent.connect.avro.AvroConverter");
+    sourceProperties.put("value.converter.schema.registry.url", KAFKA.schemaRegistryUrl());
+
+    Properties sinkProperties = new Properties();
+    sinkProperties.put("value.converter", "io.confluent.connect.avro.AvroConverter");
+    sinkProperties.put("value.converter.schema.registry.url", KAFKA.schemaRegistryUrl());
+
+    assertRoundTrip(
+        IntStream.range(1, 100)
+            .mapToObj(i -> Document.parse(format(FULL_DOCUMENT_JSON, i)))
+            .collect(toList()),
+        IntStream.range(1, 100)
+            .mapToObj(i -> Document.parse(format(SIMPLIFIED_FULL_DOCUMENT_JSON, i)))
+            .collect(toList()),
+        sourceProperties,
+        sinkProperties);
+  }
+
+  void assertRoundTrip(final List<Document> originals) {
+    assertRoundTrip(originals, originals, EMPTY_PROPERTIES);
+  }
+
+  void assertRoundTrip(
+      final List<Document> originals,
+      final Properties sourcePropertyOverrides,
+      final Properties sinkPropertyOverrides) {
+    assertRoundTrip(originals, originals, sourcePropertyOverrides, sinkPropertyOverrides);
+  }
+
+  void assertRoundTrip(
+      final List<Document> originals,
+      final List<Document> expected,
+      final Properties sourcePropertyOverrides) {
+    assertRoundTrip(originals, expected, sourcePropertyOverrides, EMPTY_PROPERTIES);
+  }
+
+  void assertRoundTrip(
+      final List<Document> originals,
+      final List<Document> expected,
+      final Properties sourcePropertyOverrides,
+      final Properties sinkPropertyOverrides) {
+
+    MongoDatabase database = getDatabaseWithPostfix();
+    MongoCollection<Document> source = database.getCollection("source");
+    MongoCollection<Document> destination = database.getCollection("destination");
+
+    Properties sourceProperties = new Properties();
+    sourceProperties.put(DATABASE_CONFIG, source.getNamespace().getDatabaseName());
+    sourceProperties.put(COLLECTION_CONFIG, source.getNamespace().getCollectionName());
+    sourceProperties.put(TOPIC_PREFIX_CONFIG, "copy");
+    sourceProperties.put(COPY_EXISTING_CONFIG, "true");
+    sourceProperties.put(PUBLISH_FULL_DOCUMENT_ONLY_CONFIG, "true");
+    sourceProperties.putAll(sourcePropertyOverrides);
+    addSourceConnector(sourceProperties);
+
+    Properties sinkProperties = new Properties();
+    sinkProperties.put(
+        "topics",
+        format(
+            "copy.%s.%s",
+            source.getNamespace().getDatabaseName(), source.getNamespace().getCollectionName()));
+    sinkProperties.put(DATABASE_CONFIG, destination.getNamespace().getDatabaseName());
+    sinkProperties.put(COLLECTION_CONFIG, destination.getNamespace().getCollectionName());
+    sinkProperties.put("key.converter", StringConverter.class.getName());
+    sinkProperties.put("value.converter", StringConverter.class.getName());
+    sinkProperties.putAll(sinkPropertyOverrides);
+
+    addSinkConnector(sinkProperties);
+    source.insertMany(originals);
+
+    assertCollection(expected, destination);
+  }
+}

--- a/src/integrationTest/java/com/mongodb/kafka/connect/MongoSinkConnectorTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/MongoSinkConnectorTest.java
@@ -223,7 +223,6 @@ class MongoSinkConnectorTest extends MongoKafkaTestCase {
                           topicName, RANDOM.nextInt(partitionCount), tweet.getId$1(), tweet)));
       producer.commitTransaction();
 
-      assertProduced(topicName, 50);
       assertEventuallyEquals(
           50L, () -> getCollection(collectionName).countDocuments(), collectionName);
 
@@ -240,8 +239,6 @@ class MongoSinkConnectorTest extends MongoKafkaTestCase {
                       new ProducerRecord<>(
                           topicName, RANDOM.nextInt(partitionCount), tweet.getId$1(), tweet)));
       producer.commitTransaction();
-
-      assertProduced(topicName, 100);
       assertEventuallyEquals(
           100L, () -> getCollection(collectionName).countDocuments(), collectionName);
     }

--- a/src/integrationTest/java/com/mongodb/kafka/connect/MongoSourceConnectorTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/MongoSourceConnectorTest.java
@@ -522,17 +522,6 @@ public class MongoSourceConnectorTest extends MongoKafkaTestCase {
     assertProduced(createInserts(1, 50), coll);
   }
 
-  private MongoDatabase getDatabaseWithPostfix() {
-    return getMongoClient()
-        .getDatabase(format("%s%s", getDatabaseName(), POSTFIX.incrementAndGet()));
-  }
-
-  private MongoCollection<Document> getAndCreateCollection() {
-    MongoDatabase database = getDatabaseWithPostfix();
-    database.createCollection("coll");
-    return database.getCollection("coll");
-  }
-
   private static final String SIMPLE_DOCUMENT = "{_id: %s}";
 
   private List<Document> insertMany(

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -62,6 +62,7 @@ import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 
 import com.mongodb.kafka.connect.Versions;
+import com.mongodb.kafka.connect.source.MongoSourceConfig.OutputFormat;
 import com.mongodb.kafka.connect.source.producer.SchemaAndValueProducer;
 
 /**
@@ -215,8 +216,11 @@ public class MongoSourceTask extends SourceTask {
         valueDocument.ifPresent(
             (valueDoc) -> {
               LOGGER.trace("Adding {} to {}: {}", valueDoc, topicName, sourceOffset);
+
               BsonDocument keyDocument =
-                  new BsonDocument(ID_FIELD, changeStreamDocument.get(ID_FIELD));
+                  sourceConfig.getKeyOutputFormat() == OutputFormat.SCHEMA
+                      ? changeStreamDocument
+                      : new BsonDocument(ID_FIELD, changeStreamDocument.get(ID_FIELD));
 
               SchemaAndValue keySchemaAndValue = keySchemaAndValueProducer.get(keyDocument);
               SchemaAndValue valueSchemaAndValue = valueSchemaAndValueProducer.get(valueDoc);

--- a/src/main/java/com/mongodb/kafka/connect/source/producer/AvroSchemaAndValueProducer.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/producer/AvroSchemaAndValueProducer.java
@@ -16,19 +16,26 @@
 
 package com.mongodb.kafka.connect.source.producer;
 
-import static com.mongodb.kafka.connect.source.schema.BsonValueToSchemaAndValue.documentToByteArray;
-
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 
 import org.bson.BsonDocument;
+import org.bson.json.JsonWriterSettings;
 
-final class BsonSchemaAndValueProducer implements SchemaAndValueProducer {
+import com.mongodb.kafka.connect.source.schema.AvroSchema;
+import com.mongodb.kafka.connect.source.schema.BsonValueToSchemaAndValue;
 
-  BsonSchemaAndValueProducer() {}
+final class AvroSchemaAndValueProducer implements SchemaAndValueProducer {
+  private final Schema schema;
+  private final BsonValueToSchemaAndValue bsonValueToSchemaAndValue;
+
+  AvroSchemaAndValueProducer(final String jsonSchema, final JsonWriterSettings jsonWriterSettings) {
+    schema = AvroSchema.fromJson(jsonSchema);
+    bsonValueToSchemaAndValue = new BsonValueToSchemaAndValue(jsonWriterSettings);
+  }
 
   @Override
   public SchemaAndValue get(final BsonDocument changeStreamDocument) {
-    return new SchemaAndValue(Schema.BYTES_SCHEMA, documentToByteArray(changeStreamDocument));
+    return bsonValueToSchemaAndValue.toSchemaAndValue(schema, changeStreamDocument);
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/source/producer/RawJsonStringSchemaAndValueProducer.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/producer/RawJsonStringSchemaAndValueProducer.java
@@ -20,15 +20,18 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 
 import org.bson.BsonDocument;
+import org.bson.json.JsonWriterSettings;
 
-import com.mongodb.kafka.connect.source.MongoSourceConfig;
+final class RawJsonStringSchemaAndValueProducer implements SchemaAndValueProducer {
+  private final JsonWriterSettings jsonWriterSettings;
 
-class RawJsonStringSchemaAndValueProducer implements SchemaAndValueProducer {
+  RawJsonStringSchemaAndValueProducer(final JsonWriterSettings jsonWriterSettings) {
+    this.jsonWriterSettings = jsonWriterSettings;
+  }
 
   @Override
-  public SchemaAndValue create(
-      final MongoSourceConfig config, final BsonDocument changeStreamDocument) {
+  public SchemaAndValue get(final BsonDocument changeStreamDocument) {
     return new SchemaAndValue(
-        Schema.STRING_SCHEMA, changeStreamDocument.toJson(config.getJsonWriterSettings()));
+        Schema.STRING_SCHEMA, changeStreamDocument.toJson(jsonWriterSettings));
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducer.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducer.java
@@ -20,8 +20,6 @@ import org.apache.kafka.connect.data.SchemaAndValue;
 
 import org.bson.BsonDocument;
 
-import com.mongodb.kafka.connect.source.MongoSourceConfig;
-
 public interface SchemaAndValueProducer {
-  SchemaAndValue create(MongoSourceConfig config, BsonDocument changeStreamDocument);
+  SchemaAndValue get(BsonDocument changeStreamDocument);
 }

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/AvroSchema.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/AvroSchema.java
@@ -68,9 +68,7 @@ public final class AvroSchema {
         validateAvroSchema(avroSchema.getValueType(), fieldPath, recordList);
         break;
       case UNION:
-        if (avroSchema.getTypes().size() == 1) {
-          validateAvroSchema(avroSchema.getTypes().get(0), fieldPath, recordList);
-        } else if (avroSchema.getTypes().size() > 2
+        if (avroSchema.getTypes().size() != 2
             || avroSchema.getTypes().stream()
                 .noneMatch(s -> s.getType() == org.apache.avro.Schema.Type.NULL)) {
           throw createConnectException(

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/AvroSchema.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/AvroSchema.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.source.schema;
+
+import static java.lang.String.format;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.avro.Schema.Parser;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+
+public final class AvroSchema {
+  public static org.apache.avro.Schema validateJsonSchema(final String jsonSchema) {
+    org.apache.avro.Schema avroSchema = parseSchema(jsonSchema);
+    if (avroSchema.getType() != org.apache.avro.Schema.Type.RECORD) {
+      throw new ConnectException("Only Record schemas are supported at the top-level.");
+    }
+    validateAvroSchema(avroSchema, "", new ArrayList<>());
+    return avroSchema;
+  }
+
+  private static void validateAvroSchema(
+      final org.apache.avro.Schema avroSchema,
+      final String fieldPath,
+      final List<String> recordList) {
+    switch (avroSchema.getType()) {
+      case RECORD:
+        if (!recordList.contains(avroSchema.getFullName())) {
+          recordList.add(avroSchema.getFullName());
+          avroSchema
+              .getFields()
+              .forEach(
+                  f -> {
+                    String newFieldPath =
+                        fieldPath.isEmpty() ? f.name() : format("%s.%s", fieldPath, f.name());
+                    validateAvroSchema(f.schema(), newFieldPath, recordList);
+                  });
+        }
+        break;
+      case ARRAY:
+        validateAvroSchema(avroSchema.getElementType(), fieldPath, recordList);
+        break;
+      case MAP:
+        validateAvroSchema(avroSchema.getValueType(), fieldPath, recordList);
+        break;
+      case UNION:
+        if (avroSchema.getTypes().size() == 1) {
+          validateAvroSchema(avroSchema.getTypes().get(0), fieldPath, recordList);
+        } else if (avroSchema.getTypes().size() > 2
+            || avroSchema.getTypes().stream()
+                .noneMatch(s -> s.getType() == org.apache.avro.Schema.Type.NULL)) {
+          throw createConnectException(
+              "Union Schemas are not supported, unless one value is "
+                  + "null to represent an optional value.",
+              fieldPath);
+        }
+        break;
+      case FIXED:
+        throw createConnectException(
+            format(
+                "Unsupported Avro schema type: '%s'. The connector will not validate the length. "
+                    + "Use bytes instead.",
+                avroSchema.getType()),
+            fieldPath);
+      case ENUM:
+        throw createConnectException(
+            format(
+                "Unsupported Avro schema type: '%s'. The connector will not validate the values. "
+                    + "Use string instead.",
+                avroSchema.getType()),
+            fieldPath);
+      case STRING:
+      case BYTES:
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+      case BOOLEAN:
+        return;
+      case NULL:
+      default:
+        throw createConnectException(
+            format("Unsupported Avro schema type: '%s'.", avroSchema.getType()), fieldPath);
+    }
+  }
+
+  public static Schema fromJson(final String jsonSchema) {
+    org.apache.avro.Schema parsedSchema = validateJsonSchema(jsonSchema);
+    return createSchema(parsedSchema);
+  }
+
+  static org.apache.avro.Schema parseSchema(final String jsonSchema) {
+    try {
+      return new Parser().parse(jsonSchema);
+    } catch (Exception e) {
+      throw new ConnectException(format("Invalid Avro schema. %s\n%s", e.getMessage(), jsonSchema));
+    }
+  }
+
+  static Schema createSchema(final org.apache.avro.Schema avroSchema) {
+    return createSchema(avroSchema, false, new Context());
+  }
+
+  static Schema createSchema(
+      final org.apache.avro.Schema avroSchema, final boolean isOptional, final Context context) {
+    return createSchema(avroSchema, isOptional, null, context);
+  }
+
+  static Schema createSchema(
+      final org.apache.avro.Schema avroSchema,
+      final boolean isOptional,
+      final Object defaultValue,
+      final Context context) {
+    SchemaBuilder builder;
+    switch (avroSchema.getType()) {
+      case RECORD:
+        SchemaBuilder structBuilder = SchemaBuilder.struct();
+        context.schemaCache.put(avroSchema, structBuilder);
+        structBuilder.name(avroSchema.getName());
+        avroSchema
+            .getFields()
+            .forEach(
+                f -> {
+                  if (context.schemaCache.containsKey(f.schema())) {
+                    context.detectedCycles.add(f.schema());
+                    structBuilder.field(f.name(), context.schemaCache.get(f.schema()));
+                  } else {
+                    Schema fieldSchema = createSchema(f.schema(), false, f.defaultVal(), context);
+                    structBuilder.field(f.name(), fieldSchema);
+                  }
+                });
+        builder = structBuilder;
+        break;
+      case MAP:
+        builder =
+            SchemaBuilder.map(
+                Schema.STRING_SCHEMA,
+                createSchemaCheckCycles(avroSchema.getValueType(), defaultValue, context));
+        break;
+      case ARRAY:
+        builder =
+            SchemaBuilder.array(
+                createSchemaCheckCycles(avroSchema.getElementType(), defaultValue, context));
+        break;
+      case STRING:
+        builder = SchemaBuilder.string();
+        break;
+      case BYTES:
+      case FIXED:
+        builder = SchemaBuilder.bytes();
+        break;
+      case INT:
+        builder = SchemaBuilder.int32();
+        break;
+      case LONG:
+        builder = SchemaBuilder.int64();
+        break;
+      case FLOAT:
+        builder = SchemaBuilder.float32();
+        break;
+      case DOUBLE:
+        builder = SchemaBuilder.float64();
+        break;
+      case BOOLEAN:
+        builder = SchemaBuilder.bool();
+        break;
+      case UNION:
+        Optional<org.apache.avro.Schema> optionalSchema =
+            avroSchema.getTypes().stream()
+                .filter(s -> s.getType() != org.apache.avro.Schema.Type.NULL)
+                .findFirst();
+        if (optionalSchema.isPresent()) {
+          return createSchema(optionalSchema.get(), true, context);
+        }
+        throw new IllegalStateException();
+      case NULL:
+      case ENUM:
+      default:
+        throw new IllegalStateException();
+    }
+
+    if (isOptional) {
+      builder.optional();
+    }
+
+    if (defaultValue != null) {
+      builder.defaultValue(processDefaultValue(builder, defaultValue));
+    }
+
+    if (!context.detectedCycles.contains(avroSchema)) {
+      context.schemaCache.remove(avroSchema);
+    }
+
+    return builder.build();
+  }
+
+  static Object processDefaultValue(final SchemaBuilder schemaBuilder, final Object value) {
+    if (schemaBuilder.type() == Type.STRUCT) {
+      Struct structValue = new Struct(schemaBuilder);
+      if (value instanceof Map) {
+        Map<?, ?> defaultMap = (Map<?, ?>) value;
+        structValue
+            .schema()
+            .fields()
+            .forEach(
+                f -> {
+                  if (defaultMap.containsKey(f.name())) {
+                    structValue.put(f, defaultMap.get(f.name()));
+                  }
+                });
+      }
+      return structValue;
+    }
+    return value;
+  }
+
+  static Schema createSchemaCheckCycles(
+      final org.apache.avro.Schema avroSchema, final Object defaultValue, final Context context) {
+    Schema resolvedSchema;
+    if (context.schemaCache.containsKey(avroSchema)) {
+      context.detectedCycles.add(avroSchema);
+      resolvedSchema = context.schemaCache.get(avroSchema).schema();
+    } else {
+      resolvedSchema = createSchema(avroSchema, false, defaultValue, context);
+    }
+    return resolvedSchema;
+  }
+
+  private static ConnectException createConnectException(
+      final String message, final String fieldPath) {
+    String errorMessage = message;
+    if (!fieldPath.isEmpty()) {
+      errorMessage = format("Field '%s' is invalid. %s", fieldPath, message);
+    }
+    return new ConnectException(errorMessage);
+  }
+
+  private static final class Context {
+    private final Map<org.apache.avro.Schema, Schema> schemaCache;
+    private final Set<org.apache.avro.Schema> detectedCycles;
+
+    /**
+     * schemaCache - map that caches connect Schema references to resolve any schema cycles
+     * detectedCycles - avro schemas that have been detected to have cycles
+     */
+    private Context() {
+      this.schemaCache = new IdentityHashMap<>();
+      this.detectedCycles = new HashSet<>();
+    }
+  }
+
+  private AvroSchema() {}
+}

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/AvroSchemaDefaults.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/AvroSchemaDefaults.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.source.schema;
+
+import org.apache.kafka.connect.data.Schema;
+
+public final class AvroSchemaDefaults {
+
+  public static final String DEFAULT_AVRO_KEY_SCHEMA =
+      "{"
+          + "  \"type\": \"record\","
+          + "  \"name\": \"keySchema\","
+          + "  \"fields\" : [{\"name\": \"_id\", \"type\": \"string\"}]"
+          + "}";
+
+  public static final String DEFAULT_AVRO_VALUE_SCHEMA =
+      "{"
+          + "  \"name\": \"ChangeStream\","
+          + "  \"type\": \"record\","
+          + "  \"fields\": ["
+          + "    { \"name\": \"_id\", \"type\": \"string\" },"
+          + "    { \"name\": \"operationType\", \"type\": [\"string\", \"null\"] },"
+          + "    { \"name\": \"fullDocument\", \"type\": [\"string\", \"null\"] },"
+          + "    { \"name\": \"ns\","
+          + "      \"type\": [{\"name\": \"ns\", \"type\": \"record\", \"fields\": ["
+          + "                {\"name\": \"db\", \"type\": \"string\"},"
+          + "                {\"name\": \"coll\", \"type\": [\"string\", \"null\"] } ]"
+          + "               }, \"null\" ] },"
+          + "    { \"name\": \"to\","
+          + "      \"type\": [{\"name\": \"to\", \"type\": \"record\",  \"fields\": ["
+          + "                {\"name\": \"db\", \"type\": \"string\"},"
+          + "                {\"name\": \"coll\", \"type\": [\"string\", \"null\"] } ]"
+          + "               }, \"null\" ] },"
+          + "    { \"name\": \"documentKey\", \"type\": [\"string\", \"null\"] },"
+          + "    { \"name\": \"updateDescription\","
+          + "      \"type\": [{\"name\": \"updateDescription\",  \"type\": \"record\", \"fields\": ["
+          + "                 {\"name\": \"updatedFields\", \"type\": [\"string\", \"null\"]},"
+          + "                 {\"name\": \"removedFields\","
+          + "                  \"type\": [{\"type\": \"array\", \"items\": \"string\"}, \"null\"]"
+          + "                  }] }, \"null\"] },"
+          + "    { \"name\": \"clusterTime\", \"type\": [\"string\", \"null\"] },"
+          + "    { \"name\": \"txnNumber\", \"type\": [\"long\", \"null\"]},"
+          + "    { \"name\": \"lsid\", \"type\": [{\"name\": \"lsid\", \"type\": \"record\","
+          + "               \"fields\": [ {\"name\": \"id\", \"type\": \"string\"},"
+          + "                             {\"name\": \"uid\", \"type\": \"string\"}] }, \"null\"] }"
+          + "  ]"
+          + "}";
+
+  public static final Schema DEFAULT_KEY_SCHEMA = AvroSchema.fromJson(DEFAULT_AVRO_KEY_SCHEMA);
+
+  public static final Schema DEFAULT_VALUE_SCHEMA = AvroSchema.fromJson(DEFAULT_AVRO_VALUE_SCHEMA);
+
+  private AvroSchemaDefaults() {}
+}

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValue.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValue.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.source.schema;
+
+import static java.lang.String.format;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
+
+import org.bson.BsonBinaryWriter;
+import org.bson.BsonDocument;
+import org.bson.BsonNumber;
+import org.bson.BsonValue;
+import org.bson.RawBsonDocument;
+import org.bson.codecs.BsonValueCodec;
+import org.bson.codecs.Codec;
+import org.bson.codecs.EncoderContext;
+import org.bson.io.BasicOutputBuffer;
+import org.bson.json.JsonWriterSettings;
+
+public class BsonValueToSchemaAndValue {
+  private static final Codec<BsonValue> BSON_VALUE_CODEC = new BsonValueCodec();
+  private final JsonWriterSettings jsonWriterSettings;
+
+  public BsonValueToSchemaAndValue(final JsonWriterSettings jsonWriterSettings) {
+    this.jsonWriterSettings = jsonWriterSettings;
+  }
+
+  public SchemaAndValue toSchemaAndValue(final Schema schema, final BsonValue bsonValue) {
+    SchemaAndValue schemaAndValue;
+    switch (schema.type()) {
+      case INT8:
+      case INT16:
+      case INT32:
+      case INT64:
+      case FLOAT32:
+      case FLOAT64:
+        schemaAndValue = numberToSchemaAndValue(schema, bsonValue);
+        break;
+      case BOOLEAN:
+        schemaAndValue = booleanToSchemaAndValue(schema, bsonValue);
+        break;
+      case STRING:
+        schemaAndValue = stringToSchemaAndValue(schema, bsonValue);
+        break;
+      case BYTES:
+        schemaAndValue = bytesToSchemaAndValue(schema, bsonValue);
+        break;
+      case ARRAY:
+        schemaAndValue = arrayToSchemaAndValue(schema, bsonValue);
+        break;
+      case MAP:
+        schemaAndValue = mapToSchemaAndValue(schema, bsonValue);
+        break;
+      case STRUCT:
+        schemaAndValue = recordToSchemaAndValue(schema, bsonValue);
+        break;
+      default:
+        throw unsupportedSchemaType(schema);
+    }
+
+    return schemaAndValue;
+  }
+
+  public static byte[] documentToByteArray(final BsonDocument document) {
+    if (document instanceof RawBsonDocument) {
+      RawBsonDocument rawBsonDocument = (RawBsonDocument) document;
+      ByteBuffer byteBuffer = rawBsonDocument.getByteBuffer().asNIO();
+      byte[] byteArray = new byte[byteBuffer.limit()];
+      System.arraycopy(
+          rawBsonDocument.getByteBuffer().array(), 0, byteArray, 0, byteBuffer.limit());
+      return byteArray;
+    } else {
+      BasicOutputBuffer buffer = new BasicOutputBuffer();
+      try (BsonBinaryWriter writer = new BsonBinaryWriter(buffer)) {
+        BSON_VALUE_CODEC.encode(writer, document, EncoderContext.builder().build());
+      }
+      return buffer.toByteArray();
+    }
+  }
+
+  private SchemaAndValue numberToSchemaAndValue(final Schema schema, final BsonValue bsonValue) {
+    if (!bsonValue.isNumber()) {
+      throw unexpectedBsonValueType(schema.type(), bsonValue);
+    }
+    BsonNumber bsonNumber = bsonValue.asNumber();
+    Object value;
+    switch (schema.type()) {
+      case INT8:
+        value = (byte) bsonNumber.intValue();
+        break;
+      case INT16:
+        value = (short) bsonNumber.intValue();
+        break;
+      case INT32:
+        value = bsonNumber.intValue();
+        break;
+      case INT64:
+        value = bsonNumber.longValue();
+        break;
+      case FLOAT32:
+        value = (float) bsonNumber.doubleValue();
+        break;
+      case FLOAT64:
+        value = bsonNumber.doubleValue();
+        break;
+      default:
+        throw unexpectedBsonValueType(schema.type(), bsonValue);
+    }
+    return new SchemaAndValue(schema, value);
+  }
+
+  private SchemaAndValue stringToSchemaAndValue(final Schema schema, final BsonValue bsonValue) {
+    String value;
+    if (bsonValue.isString()) {
+      value = bsonValue.asString().getValue();
+    } else {
+      value = new BsonDocument("v", bsonValue).toJson(jsonWriterSettings);
+      // Strip down to just the value
+      value = value.substring(6, value.length() - 1);
+      // Remove unneccessary quotes of BsonValues converted to Strings.
+      if (value.startsWith("\"") && value.endsWith("\"")) {
+        value = value.substring(1, value.length() - 1);
+      }
+    }
+    return new SchemaAndValue(schema, value);
+  }
+
+  private SchemaAndValue bytesToSchemaAndValue(final Schema schema, final BsonValue bsonValue) {
+    byte[] value;
+    switch (bsonValue.getBsonType()) {
+      case STRING:
+        value = bsonValue.asString().getValue().getBytes(StandardCharsets.UTF_8);
+        break;
+      case BINARY:
+        value = bsonValue.asBinary().getData();
+        break;
+      case DOCUMENT:
+        value = documentToByteArray(bsonValue.asDocument());
+        break;
+      default:
+        throw unexpectedBsonValueType(Type.BYTES, bsonValue);
+    }
+    return new SchemaAndValue(schema, value);
+  }
+
+  private SchemaAndValue arrayToSchemaAndValue(final Schema schema, final BsonValue value) {
+    if (!value.isArray()) {
+      throw unexpectedBsonValueType(Schema.Type.ARRAY, value);
+    }
+    List<Object> values = new ArrayList<>();
+    value.asArray().forEach(v -> values.add(toSchemaAndValue(schema.valueSchema(), v).value()));
+    return new SchemaAndValue(schema, values);
+  }
+
+  private SchemaAndValue mapToSchemaAndValue(final Schema schema, final BsonValue value) {
+    if (!value.isDocument()) {
+      throw unexpectedBsonValueType(schema.type(), value);
+    }
+
+    if (schema.keySchema() != Schema.STRING_SCHEMA) {
+      throw unsupportedSchemaType(schema, ". Unexpected key schema type.");
+    }
+
+    BsonDocument document = value.asDocument();
+    Map<String, Object> mapValue = new LinkedHashMap<>();
+    document.forEach((k, v) -> mapValue.put(k, toSchemaAndValue(schema.valueSchema(), v).value()));
+    return new SchemaAndValue(schema, mapValue);
+  }
+
+  private SchemaAndValue recordToSchemaAndValue(final Schema schema, final BsonValue value) {
+    if (!value.isDocument()) {
+      throw unexpectedBsonValueType(schema.type(), value);
+    }
+    BsonDocument document = value.asDocument();
+
+    Struct structValue = new Struct(schema);
+    schema
+        .fields()
+        .forEach(
+            f -> {
+              boolean optionalField = f.schema().isOptional();
+              if (document.containsKey(f.name())) {
+                SchemaAndValue schemaAndValue =
+                    toSchemaAndValue(f.schema(), document.get(f.name()));
+                structValue.put(f, schemaAndValue.value());
+              } else if (optionalField && f.schema().defaultValue() != null) {
+                structValue.put(f, null);
+              } else if (!optionalField) {
+                throw missingFieldException(f, document);
+              }
+            });
+    return new SchemaAndValue(schema, structValue);
+  }
+
+  private SchemaAndValue booleanToSchemaAndValue(final Schema schema, final BsonValue bsonValue) {
+    if (!bsonValue.isBoolean()) {
+      throw unexpectedBsonValueType(Schema.Type.BOOLEAN, bsonValue);
+    }
+    return new SchemaAndValue(schema, bsonValue.asBoolean().getValue());
+  }
+
+  private ConnectException unsupportedSchemaType(final Schema schema) {
+    return unsupportedSchemaType(schema, "");
+  }
+
+  private ConnectException unsupportedSchemaType(final Schema schema, final String extra) {
+    return new ConnectException(format("Unsupported Schema type: %s %s", schema.type(), extra));
+  }
+
+  private DataException unexpectedBsonValueType(final Schema.Type type, final BsonValue value) {
+    return new DataException(
+        format(
+            "Schema type of %s but value was of type: %s",
+            type.getName(), value.getBsonType().toString().toLowerCase()));
+  }
+
+  private DataException missingFieldException(final Field field, final BsonDocument value) {
+    return new DataException(
+        format("Missing field '%s' in: '%s'", field.name(), value.toJson(jsonWriterSettings)));
+  }
+}

--- a/src/test/java/com/mongodb/kafka/connect/source/MongoSourceConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/MongoSourceConfigTest.java
@@ -102,8 +102,18 @@ class MongoSourceConfigTest {
             assertEquals(
                 OutputFormat.BSON,
                 createSourceConfig(OUTPUT_FORMAT_VALUE_CONFIG, "bson").getValueOutputFormat()),
+        () ->
+            assertEquals(
+                OutputFormat.SCHEMA,
+                createSourceConfig(OUTPUT_FORMAT_KEY_CONFIG, "schema").getKeyOutputFormat()),
+        () ->
+            assertEquals(
+                OutputFormat.SCHEMA,
+                createSourceConfig(OUTPUT_FORMAT_VALUE_CONFIG, "schema").getValueOutputFormat()),
         () -> assertInvalid(OUTPUT_FORMAT_KEY_CONFIG, "avro"),
-        () -> assertInvalid(OUTPUT_FORMAT_VALUE_CONFIG, "avro"));
+        () -> assertInvalid(OUTPUT_FORMAT_VALUE_CONFIG, "avro"),
+        () -> assertInvalid(OUTPUT_FORMAT_KEY_CONFIG, "[]"),
+        () -> assertInvalid(OUTPUT_FORMAT_VALUE_CONFIG, "[]"));
   }
 
   @Test

--- a/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
@@ -16,49 +16,220 @@
 
 package com.mongodb.kafka.connect.source.producer;
 
-import static com.mongodb.kafka.connect.source.SourceTestHelper.createSourceConfig;
-import static com.mongodb.kafka.connect.source.producer.SchemaAndValueProducers.BSON_SCHEMA_AND_VALUE_PRODUCER;
-import static com.mongodb.kafka.connect.source.producer.SchemaAndValueProducers.RAW_JSON_STRING_SCHEMA_AND_VALUE_PRODUCER;
+import static com.mongodb.kafka.connect.source.schema.AvroSchemaDefaults.DEFAULT_AVRO_KEY_SCHEMA;
+import static com.mongodb.kafka.connect.source.schema.AvroSchemaDefaults.DEFAULT_AVRO_VALUE_SCHEMA;
+import static com.mongodb.kafka.connect.source.schema.AvroSchemaDefaults.DEFAULT_KEY_SCHEMA;
+import static com.mongodb.kafka.connect.source.schema.AvroSchemaDefaults.DEFAULT_VALUE_SCHEMA;
+import static com.mongodb.kafka.connect.source.schema.SchemaUtils.assertSchemaAndValueEquals;
+import static java.lang.String.format;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
+import org.bson.BsonDocument;
 import org.bson.RawBsonDocument;
+import org.bson.json.JsonWriterSettings;
+
+import com.mongodb.kafka.connect.source.json.formatter.ExtendedJson;
+import com.mongodb.kafka.connect.source.json.formatter.SimplifiedJson;
 
 @RunWith(JUnitPlatform.class)
 public class SchemaAndValueProducerTest {
 
-  private static final RawBsonDocument TEST_DOCUMENT =
-      RawBsonDocument.parse(
-          "{'_id': {'_id': 1}, "
-              + "'operationType': 'insert', 'ns': {'db': 'myDB', 'coll': 'myColl'}, "
-              + "'documentKey': {'_id': 1}, "
-              + "'fullDocument': {'_id': 1, 'a': 'a', 'b': 121}}");
+  private static final String FULL_DOCUMENT_JSON =
+      "{\"_id\": {\"$oid\": \"5f15aab12435743f9bd126a4\"},"
+          + " \"myString\": \"some foo bla text\","
+          + " \"myInt\": {\"$numberInt\": \"42\"},"
+          + " \"myDouble\": {\"$numberDouble\": \"20.21\"},"
+          + " \"mySubDoc\": {\"A\": {\"$binary\": {\"base64\": \"S2Fma2Egcm9ja3Mh\", \"subType\": \"00\"}},"
+          + " \"B\": {\"$date\": {\"$numberLong\": \"1577863627000\"}},"
+          + " \"C\": {\"$numberDecimal\": \"12345.6789\"}},"
+          + " \"myArray\": [{\"$numberInt\": \"1\"}, {\"$numberInt\": \"2\"}, {\"$numberInt\": \"3\"}],"
+          + " \"myBytes\": {\"$binary\": {\"base64\": \"S2Fma2Egcm9ja3Mh\", \"subType\": \"00\"}},"
+          + " \"myDate\": {\"$date\": {\"$numberLong\": \"1234567890\"}},"
+          + " \"myDecimal\": {\"$numberDecimal\": \"12345.6789\"}"
+          + "}";
+
+  private static final String SIMPLIFIED_FULL_DOCUMENT_JSON =
+      "{\"_id\": \"5f15aab12435743f9bd126a4\", "
+          + "\"myString\": \"some foo bla text\", "
+          + "\"myInt\": 42, "
+          + "\"myDouble\": 20.21, "
+          + "\"mySubDoc\": {\"A\": \"S2Fma2Egcm9ja3Mh\", \"B\": \"2020-01-01T07:27:07Z\", \"C\": \"12345.6789\"}, "
+          + "\"myArray\": [1, 2, 3], "
+          + "\"myBytes\": \"S2Fma2Egcm9ja3Mh\", "
+          + "\"myDate\": \"1970-01-15T06:56:07.89Z\", "
+          + "\"myDecimal\": \"12345.6789\"}";
+
+  private static final String CHANGE_STREAM_DOCUMENT_JSON = generateJson(false);
+  private static final String SIMPLIFIED_CHANGE_STREAM_DOCUMENT_JSON = generateJson(true);
+
+  private static final BsonDocument CHANGE_STREAM_DOCUMENT =
+      BsonDocument.parse(CHANGE_STREAM_DOCUMENT_JSON);
+
+  private static final JsonWriterSettings SIMPLE_JSON_WRITER_SETTINGS =
+      new SimplifiedJson().getJsonWriterSettings();
+
+  private static final JsonWriterSettings EXTENDED_JSON_WRITER_SETTINGS =
+      new ExtendedJson().getJsonWriterSettings();
+
+  @Test
+  @DisplayName("test avro schema and value producer")
+  void testAvroSchemaAndValueProducer() {
+    SchemaAndValue expectedKey =
+        new SchemaAndValue(
+            DEFAULT_KEY_SCHEMA,
+            new Struct(DEFAULT_KEY_SCHEMA).put("_id", "{\"_data\": \"5f15aab12435743f9bd126a4\"}"));
+
+    SchemaAndValue expectedValue =
+        new SchemaAndValue(DEFAULT_VALUE_SCHEMA, generateExpectedValue(true));
+    SchemaAndValue expectedExtendedValue =
+        new SchemaAndValue(DEFAULT_VALUE_SCHEMA, generateExpectedValue(false));
+
+    AvroSchemaAndValueProducer keyProducer =
+        new AvroSchemaAndValueProducer(DEFAULT_AVRO_KEY_SCHEMA, SIMPLE_JSON_WRITER_SETTINGS);
+
+    AvroSchemaAndValueProducer valueProducer =
+        new AvroSchemaAndValueProducer(DEFAULT_AVRO_VALUE_SCHEMA, SIMPLE_JSON_WRITER_SETTINGS);
+
+    AvroSchemaAndValueProducer extendedJsonValueProducer =
+        new AvroSchemaAndValueProducer(DEFAULT_AVRO_VALUE_SCHEMA, EXTENDED_JSON_WRITER_SETTINGS);
+
+    assertSchemaAndValueEquals(expectedKey, keyProducer.get(CHANGE_STREAM_DOCUMENT));
+    assertSchemaAndValueEquals(expectedValue, valueProducer.get(CHANGE_STREAM_DOCUMENT));
+    assertSchemaAndValueEquals(
+        expectedExtendedValue, extendedJsonValueProducer.get(CHANGE_STREAM_DOCUMENT));
+  }
 
   @Test
   @DisplayName("test raw json string schema and value producer")
   void testRawJsonStringSchemaAndValueProducer() {
     assertEquals(
-        new SchemaAndValue(Schema.STRING_SCHEMA, TEST_DOCUMENT.toJson()),
-        RAW_JSON_STRING_SCHEMA_AND_VALUE_PRODUCER.create(createSourceConfig(), TEST_DOCUMENT));
+        new SchemaAndValue(Schema.STRING_SCHEMA, SIMPLIFIED_CHANGE_STREAM_DOCUMENT_JSON),
+        new RawJsonStringSchemaAndValueProducer(SIMPLE_JSON_WRITER_SETTINGS)
+            .get(CHANGE_STREAM_DOCUMENT));
   }
 
   @Test
   @DisplayName("test bson schema and value producer")
   void testBsonSchemaAndValueProducer() {
-    SchemaAndValue actual =
-        BSON_SCHEMA_AND_VALUE_PRODUCER.create(createSourceConfig(), TEST_DOCUMENT);
+    SchemaAndValue actual = new BsonSchemaAndValueProducer().get(CHANGE_STREAM_DOCUMENT);
     assertAll(
         "Assert schema and value matches",
         () -> assertEquals(Schema.BYTES_SCHEMA.schema(), actual.schema()),
         // Ensure the data length is truncated.
-        () -> assertEquals(160, ((byte[]) actual.value()).length),
-        () -> assertEquals(TEST_DOCUMENT, new RawBsonDocument((byte[]) actual.value())));
+        () -> assertEquals(708, ((byte[]) actual.value()).length),
+        () -> assertEquals(CHANGE_STREAM_DOCUMENT, new RawBsonDocument((byte[]) actual.value())));
+  }
+
+  static Struct generateExpectedValue(final boolean simplified) {
+    return new Struct(DEFAULT_VALUE_SCHEMA) {
+      {
+        put("_id", "{\"_data\": \"5f15aab12435743f9bd126a4\"}");
+        put("operationType", "<operation>");
+        put("fullDocument", getFullDocument(simplified));
+        put(
+            "ns",
+            new Struct(DEFAULT_VALUE_SCHEMA.field("ns").schema()) {
+              {
+                put("db", "<database>");
+                put("coll", "<collection>");
+              }
+            });
+        put(
+            "to",
+            new Struct(DEFAULT_VALUE_SCHEMA.field("to").schema()) {
+              {
+                put("db", "<to_database>");
+                put("coll", "<to_collection>");
+              }
+            });
+        put("documentKey", getDocumentKey(simplified));
+        put(
+            "updateDescription",
+            new Struct(DEFAULT_VALUE_SCHEMA.field("updateDescription").schema()) {
+              {
+                put("updatedFields", getUpdatedField(simplified));
+                put("removedFields", singletonList("legacyUUID"));
+              }
+            });
+        put("clusterTime", "{\"$timestamp\": {\"t\": 123456789, \"i\": 42}}");
+        put("txnNumber", 987654321L);
+        put(
+            "lsid",
+            new Struct(DEFAULT_VALUE_SCHEMA.field("lsid").schema()) {
+              {
+                put("id", getLsidId(simplified));
+                put("uid", getLsidUid(simplified));
+              }
+            });
+      }
+    };
+  }
+
+  static String getFullDocument(final boolean simplified) {
+    return simplified ? SIMPLIFIED_FULL_DOCUMENT_JSON : FULL_DOCUMENT_JSON;
+  }
+
+  static String getDocumentKey(final boolean simplified) {
+    return simplified
+        ? "{\"_id\": \"5f15aab12435743f9bd126a4\"}"
+        : "{\"_id\": {\"$oid\": \"5f15aab12435743f9bd126a4\"}}";
+  }
+
+  static String getUpdatedField(final boolean simplified) {
+    return simplified
+        ? "{\"myString\": \"some foo bla text\", \"myInt\": 42}"
+        : "{\"myString\": \"some foo bla text\", \"myInt\": {\"$numberInt\": \"42\"}}";
+  }
+
+  static String getLsidId(final boolean simplified) {
+    return getLsidId(simplified, false);
+  }
+
+  static String getLsidId(final boolean simplified, final boolean quoted) {
+    return simplified
+        ? quoted ? "\"c//SZESzTGmQ6OfR38A11A==\"" : "c//SZESzTGmQ6OfR38A11A=="
+        : "{\"$binary\": {\"base64\": \"c//SZESzTGmQ6OfR38A11A==\", \"subType\": \"04\"}}";
+  }
+
+  static String getLsidUid(final boolean simplified) {
+    return getLsidUid(simplified, false);
+  }
+
+  static String getLsidUid(final boolean simplified, final boolean quoted) {
+    return simplified
+        ? quoted ? "\"1000000000000w==\"" : "1000000000000w=="
+        : "{\"$binary\": {\"base64\": \"1000000000000w==\", \"subType\": \"00\"}}";
+  }
+
+  static String generateJson(final boolean simplified) {
+    return format(
+        "{\"_id\": {\"_data\": \"5f15aab12435743f9bd126a4\"},"
+            + " \"operationType\": \"<operation>\","
+            + " \"fullDocument\": %s,"
+            + " \"ns\": {\"db\": \"<database>\", \"coll\": \"<collection>\"},"
+            + " \"to\": {\"db\": \"<to_database>\", \"coll\": \"<to_collection>\"},"
+            + " \"documentKey\": %s,"
+            + " \"updateDescription\":"
+            + " {\"updatedFields\": %s,"
+            + " \"removedFields\": [\"legacyUUID\"]},"
+            + " \"clusterTime\": {\"$timestamp\": {\"t\": 123456789, \"i\": 42}},"
+            + " \"txnNumber\": 987654321,"
+            + " \"lsid\": {\"id\": %s, \"uid\": %s}"
+            + "}",
+        getFullDocument(simplified),
+        getDocumentKey(simplified),
+        getUpdatedField(simplified),
+        getLsidId(simplified, true),
+        getLsidUid(simplified, true));
   }
 }

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/AvroSchemaTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/AvroSchemaTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.source.schema;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+public class AvroSchemaTest {
+
+  @Test
+  @DisplayName("test supports valid avro schema")
+  void testSupportsValidAvroSchema() {
+    String schema =
+        "{\"type\": \"record\", \"name\":\"Interop\", \"namespace\": \"org.apache.avro\","
+            + " \"fields\": ["
+            + " {\"name\": \"intField\", \"type\": \"int\"},"
+            + " {\"name\": \"longField\", \"type\": \"long\"},"
+            + " {\"name\": \"stringField\", \"type\": \"string\", \"default\" : \"\"},"
+            + " {\"name\": \"boolField\", \"type\": \"boolean\"},"
+            + " {\"name\": \"floatField\", \"type\": \"float\"},"
+            + " {\"name\": \"doubleField\", \"type\": \"double\"},"
+            + " {\"name\": \"bytesField\", \"type\": \"bytes\"},"
+            + " {\"name\": \"arrayField\", \"type\": {\"type\": \"array\", \"items\": \"double\"}},"
+            + " {\"name\": \"mapField\", \"type\": {\"type\": \"map\", \"values\":"
+            + "  {\"type\": \"record\", \"name\": \"Foo\","
+            + "   \"fields\": [{\"name\": \"label\", \"type\": \"string\"}]}}},"
+            + "   {\"name\": \"unionField\", \"type\":"
+            + "    [{\"type\": \"array\", \"items\": \"bytes\"}, \"null\"]},"
+            + " {\"name\": \"recordField\", \"type\": {\"type\": \"record\", \"name\": \"Node\", "
+            + "  \"fields\": ["
+            + "   {\"name\": \"label\", \"type\": \"string\"},"
+            + "   {\"name\": \"children\", \"type\": {\"type\": \"array\", \"items\": \"Node\"}}]}}"
+            + " ]"
+            + "}";
+
+    Schema actual = AvroSchema.fromJson(schema);
+
+    SchemaBuilder nodeBuilder =
+        SchemaBuilder.struct().name("Node").field("label", Schema.STRING_SCHEMA);
+    nodeBuilder.field("children", SchemaBuilder.array(nodeBuilder).build());
+    Schema expected =
+        SchemaBuilder.struct()
+            .name("Interop")
+            .field("intField", Schema.INT32_SCHEMA)
+            .field("longField", Schema.INT64_SCHEMA)
+            .field("stringField", SchemaBuilder.string().defaultValue("").build())
+            .field("boolField", Schema.BOOLEAN_SCHEMA)
+            .field("floatField", Schema.FLOAT32_SCHEMA)
+            .field("doubleField", Schema.FLOAT64_SCHEMA)
+            .field("bytesField", Schema.BYTES_SCHEMA)
+            .field("arrayField", SchemaBuilder.array(Schema.INT64_SCHEMA))
+            .field(
+                "mapField",
+                SchemaBuilder.map(
+                    Schema.STRING_SCHEMA,
+                    SchemaBuilder.struct()
+                        .name("Foo")
+                        .field("label", Schema.STRING_SCHEMA)
+                        .build()))
+            .field(
+                "unionField", SchemaBuilder.array(Schema.OPTIONAL_BYTES_SCHEMA).optional().build())
+            .field("recordField", nodeBuilder)
+            .build();
+
+    SchemaUtils.assertSchemaEquals(expected, actual);
+  }
+
+  @Test
+  @DisplayName("test unsupported avro schema definitions")
+  void testUnsupportedAvroSchema() {
+    assertAll(
+        "Unsupported schema definitions",
+        () -> {
+          Executable enumSchema =
+              createSchema(
+                  "{\"type\": \"record\", \"name\": \"EnumTest\","
+                      + "  \"fields\": ["
+                      + "    {\"name\": \"enumField\", \"type\": {"
+                      + "        \"name\": \"enum\", \"type\": \"enum\","
+                      + "        \"symbols\" : [\"ONE\", \"TWO\", \"THREE\"]}}]"
+                      + "}");
+          ConnectException thrown = assertThrows(ConnectException.class, enumSchema);
+          assertEquals(
+              "Field 'enumField' is invalid. Unsupported Avro schema type: 'ENUM'. "
+                  + "The connector will not validate the values. Use string instead.",
+              thrown.getMessage());
+        },
+        () -> {
+          Executable fixedSchema =
+              createSchema(
+                  "{\"type\": \"record\", \"name\": \"FixedTest\","
+                      + "  \"fields\": ["
+                      + "       {\"name\": \"fixedField\", \"type\":"
+                      + "       {\"type\": \"fixed\", \"name\": \"MD5\", \"size\": 16}}"
+                      + "]}");
+          ConnectException thrown = assertThrows(ConnectException.class, fixedSchema);
+          assertEquals(
+              "Field 'fixedField' is invalid. Unsupported Avro schema type: 'FIXED'. "
+                  + "The connector will not validate the length. Use bytes instead.",
+              thrown.getMessage());
+        },
+        () -> {
+          Executable mapSchema =
+              createSchema(
+                  "{\"type\": \"record\", \"name\": \"MapTest\","
+                      + "  \"fields\": ["
+                      + "    {\"name\": \"mapField\","
+                      + "     \"type\": {\"type\": \"map\", \"values\": \"null\"}}]"
+                      + "}");
+          ConnectException thrown = assertThrows(ConnectException.class, mapSchema);
+          assertEquals(
+              "Field 'mapField' is invalid. Unsupported Avro schema type: 'NULL'.",
+              thrown.getMessage());
+        },
+        () -> {
+          Executable unionSchema =
+              createSchema(
+                  "{\"type\": \"record\", \"name\": \"unionTest1\","
+                      + "  \"fields\": ["
+                      + "    {\"name\": \"unionField\","
+                      + "     \"type\": [{\"type\": \"string\"}, {\"type\": \"int\"}]}]"
+                      + "}");
+          ConnectException thrown = assertThrows(ConnectException.class, unionSchema);
+          assertEquals(
+              "Field 'unionField' is invalid. Union Schemas are not supported, "
+                  + "unless one value is null to represent an optional value.",
+              thrown.getMessage());
+        },
+        () -> {
+          Executable unionSchema =
+              createSchema(
+                  "{\"type\": \"record\", \"name\": \"unionTest2\","
+                      + "  \"fields\": ["
+                      + "    {\"name\": \"unionField\","
+                      + "     \"type\": [{\"type\": \"string\"}, {\"type\": \"int\"}, \"null\"]}]"
+                      + "}");
+          ConnectException thrown = assertThrows(ConnectException.class, unionSchema);
+          assertEquals(
+              "Field 'unionField' is invalid. Union Schemas are not supported, "
+                  + "unless one value is null to represent an optional value.",
+              thrown.getMessage());
+        });
+  }
+
+  @Test
+  @DisplayName("test invalid avro schema definitions")
+  void testInvalidAvroSchema() {
+    assertAll(
+        "Error scenarios",
+        () -> assertThrows(ConnectException.class, createSchema(null)),
+        () -> assertThrows(ConnectException.class, createSchema("[]")),
+        () -> assertThrows(ConnectException.class, createSchema("{}")));
+  }
+
+  private Executable createSchema(final String jsonSchema) {
+    return () -> AvroSchema.validateJsonSchema(jsonSchema);
+  }
+}

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/AvroSchemaTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/AvroSchemaTest.java
@@ -140,6 +140,20 @@ public class AvroSchemaTest {
         () -> {
           Executable unionSchema =
               createSchema(
+                  "{\"type\": \"record\", \"name\": \"unionTest2\","
+                      + "  \"fields\": ["
+                      + "    {\"name\": \"unionField\","
+                      + "     \"type\": [{\"type\": \"string\"}]}]"
+                      + "}");
+          ConnectException thrown = assertThrows(ConnectException.class, unionSchema);
+          assertEquals(
+              "Field 'unionField' is invalid. Union Schemas are not supported, "
+                  + "unless one value is null to represent an optional value.",
+              thrown.getMessage());
+        },
+        () -> {
+          Executable unionSchema =
+              createSchema(
                   "{\"type\": \"record\", \"name\": \"unionTest1\","
                       + "  \"fields\": ["
                       + "    {\"name\": \"unionField\","

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/AvroSchemaTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/AvroSchemaTest.java
@@ -40,7 +40,7 @@ public class AvroSchemaTest {
             + " \"fields\": ["
             + " {\"name\": \"intField\", \"type\": \"int\"},"
             + " {\"name\": \"longField\", \"type\": \"long\"},"
-            + " {\"name\": \"stringField\", \"type\": \"string\", \"default\" : \"\"},"
+            + " {\"name\": \"stringField\", \"type\": \"string\", \"default\" : \"MISSING\"},"
             + " {\"name\": \"boolField\", \"type\": \"boolean\"},"
             + " {\"name\": \"floatField\", \"type\": \"float\"},"
             + " {\"name\": \"doubleField\", \"type\": \"double\"},"
@@ -68,7 +68,7 @@ public class AvroSchemaTest {
             .name("Interop")
             .field("intField", Schema.INT32_SCHEMA)
             .field("longField", Schema.INT64_SCHEMA)
-            .field("stringField", SchemaBuilder.string().defaultValue("").build())
+            .field("stringField", SchemaBuilder.string().defaultValue("MISSING").build())
             .field("boolField", Schema.BOOLEAN_SCHEMA)
             .field("floatField", Schema.FLOAT32_SCHEMA)
             .field("doubleField", Schema.FLOAT64_SCHEMA)

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValueTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValueTest.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.source.schema;
+
+import static com.mongodb.kafka.connect.source.schema.BsonValueToSchemaAndValue.documentToByteArray;
+import static com.mongodb.kafka.connect.source.schema.SchemaUtils.assertSchemaAndValueEquals;
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.RawBsonDocument;
+
+import com.mongodb.kafka.connect.source.json.formatter.SimplifiedJson;
+
+@RunWith(JUnitPlatform.class)
+public class BsonValueToSchemaAndValueTest {
+
+  private static final RawBsonDocument BSON_DOCUMENT =
+      RawBsonDocument.parse(
+          "{\"_id\": {\"$oid\": \"5f15aab12435743f9bd126a4\"},"
+              + " \"myString\": \"some foo bla text\","
+              + " \"myInt\": {\"$numberInt\": \"42\"},"
+              + " \"myDouble\": {\"$numberDouble\": \"20.21\"},"
+              + " \"mySubDoc\": {\"A\": {\"$binary\": {\"base64\": \"S2Fma2Egcm9ja3Mh\", \"subType\": \"00\"}},"
+              + " \"B\": {\"$date\": {\"$numberLong\": \"1577863627000\"}},"
+              + " \"C\": {\"$numberDecimal\": \"12345.6789\"}},"
+              + " \"myArray\": [{\"$numberInt\": \"1\"}, {\"$numberInt\": \"2\"}, {\"$numberInt\": \"3\"}],"
+              + " \"myBytes\": {\"$binary\": {\"base64\": \"S2Fma2Egcm9ja3Mh\", \"subType\": \"00\"}},"
+              + " \"myDate\": {\"$date\": {\"$numberLong\": \"1234567890\"}},"
+              + " \"myDecimal\": {\"$numberDecimal\": \"12345.6789\"}"
+              + "}");
+
+  private static final BsonValueToSchemaAndValue CONVERTER =
+      new BsonValueToSchemaAndValue(new SimplifiedJson().getJsonWriterSettings());
+
+  @Test
+  @DisplayName("test string support")
+  void testStringSupport() {
+    Map<String, String> expected =
+        new HashMap<String, String>() {
+          {
+            put("_id", "5f15aab12435743f9bd126a4");
+            put("myString", "some foo bla text");
+            put("myInt", "42");
+            put("myDouble", "20.21");
+            put(
+                "mySubDoc",
+                "{\"A\": \"S2Fma2Egcm9ja3Mh\", "
+                    + "\"B\": \"2020-01-01T07:27:07Z\", \"C\": \"12345.6789\"}");
+            put("myArray", "[1, 2, 3]");
+            put("myBytes", "S2Fma2Egcm9ja3Mh");
+            put("myDate", "1970-01-15T06:56:07.89Z");
+            put("myDecimal", "12345.6789");
+          }
+        };
+
+    BSON_DOCUMENT.forEach(
+        (k, v) -> {
+          assertSchemaAndValueEquals(
+              new SchemaAndValue(Schema.STRING_SCHEMA, expected.get(k)),
+              CONVERTER.toSchemaAndValue(Schema.STRING_SCHEMA, v));
+        });
+  }
+
+  @Test
+  @DisplayName("test number support")
+  void testNumberSupport() {
+    BsonInt32 bsonInt32 = new BsonInt32(42);
+    BsonInt64 bsonInt64 = new BsonInt64(2020L);
+    BsonDouble bsonDouble = new BsonDouble(20.20);
+
+    assertAll(
+        "Testing int8 support",
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(Schema.INT8_SCHEMA, (byte) 42),
+                CONVERTER.toSchemaAndValue(Schema.INT8_SCHEMA, bsonInt32)),
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(Schema.INT8_SCHEMA, (byte) 2020),
+                CONVERTER.toSchemaAndValue(Schema.INT8_SCHEMA, bsonInt64)),
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(Schema.INT8_SCHEMA, (byte) 20.20),
+                CONVERTER.toSchemaAndValue(Schema.INT8_SCHEMA, bsonDouble)));
+
+    assertAll(
+        "Testing int16 support",
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(Schema.INT16_SCHEMA, (short) 42),
+                CONVERTER.toSchemaAndValue(Schema.INT16_SCHEMA, bsonInt32)),
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(Schema.INT16_SCHEMA, (short) 2020),
+                CONVERTER.toSchemaAndValue(Schema.INT16_SCHEMA, bsonInt64)),
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(Schema.INT16_SCHEMA, (short) 20.20),
+                CONVERTER.toSchemaAndValue(Schema.INT16_SCHEMA, bsonDouble)));
+
+    assertAll(
+        "Testing int32 support",
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(Schema.INT32_SCHEMA, 42),
+                CONVERTER.toSchemaAndValue(Schema.INT32_SCHEMA, bsonInt32)),
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(Schema.INT32_SCHEMA, 2020),
+                CONVERTER.toSchemaAndValue(Schema.INT32_SCHEMA, bsonInt64)),
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(Schema.INT32_SCHEMA, (int) 20.20),
+                CONVERTER.toSchemaAndValue(Schema.INT32_SCHEMA, bsonDouble)));
+
+    assertAll(
+        "Testing int64 support",
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(Schema.INT64_SCHEMA, 42L),
+                CONVERTER.toSchemaAndValue(Schema.INT64_SCHEMA, bsonInt32)),
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(Schema.INT64_SCHEMA, 2020L),
+                CONVERTER.toSchemaAndValue(Schema.INT64_SCHEMA, bsonInt64)),
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(Schema.INT64_SCHEMA, (long) 20.20),
+                CONVERTER.toSchemaAndValue(Schema.INT64_SCHEMA, bsonDouble)));
+
+    assertAll(
+        "Testing float32 support",
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(Schema.FLOAT32_SCHEMA, (float) 42),
+                CONVERTER.toSchemaAndValue(Schema.FLOAT32_SCHEMA, bsonInt32)),
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(Schema.FLOAT32_SCHEMA, (float) 2020L),
+                CONVERTER.toSchemaAndValue(Schema.FLOAT32_SCHEMA, bsonInt64)),
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(Schema.FLOAT32_SCHEMA, (float) 20.20),
+                CONVERTER.toSchemaAndValue(Schema.FLOAT32_SCHEMA, bsonDouble)));
+
+    assertAll(
+        "Testing float64 support",
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(Schema.FLOAT64_SCHEMA, (double) 42),
+                CONVERTER.toSchemaAndValue(Schema.FLOAT64_SCHEMA, bsonInt32)),
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(Schema.FLOAT64_SCHEMA, (double) 2020),
+                CONVERTER.toSchemaAndValue(Schema.FLOAT64_SCHEMA, bsonInt64)),
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(Schema.FLOAT64_SCHEMA, 20.20),
+                CONVERTER.toSchemaAndValue(Schema.FLOAT64_SCHEMA, bsonDouble)));
+
+    List<String> validKeys = asList("myInt", "myDouble");
+    Set<String> invalidKeys =
+        BSON_DOCUMENT.keySet().stream()
+            .filter(k -> !validKeys.contains(k))
+            .collect(Collectors.toSet());
+
+    invalidKeys.forEach(
+        k ->
+            assertThrows(
+                DataException.class,
+                () -> CONVERTER.toSchemaAndValue(Schema.INT64_SCHEMA, BSON_DOCUMENT.get(k)),
+                format("Expected %s to fail", k)));
+  }
+
+  @Test
+  @DisplayName("test boolean support")
+  void testBooleanSupport() {
+    Schema schema = Schema.BOOLEAN_SCHEMA;
+    assertAll(
+        "Testing boolean support",
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(schema, true),
+                CONVERTER.toSchemaAndValue(schema, BsonBoolean.TRUE)),
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(schema, false),
+                CONVERTER.toSchemaAndValue(schema, BsonBoolean.FALSE)));
+
+    Set<String> invalidKeys =
+        BSON_DOCUMENT.keySet().stream()
+            .filter(k -> !k.equals("myBoolean"))
+            .collect(Collectors.toSet());
+
+    invalidKeys.forEach(
+        k ->
+            assertThrows(
+                DataException.class,
+                () -> CONVERTER.toSchemaAndValue(schema, BSON_DOCUMENT.get(k)),
+                format("Expected %s to fail", k)));
+  }
+
+  @Test
+  @DisplayName("test bytes support")
+  void testBytesSupport() {
+    Schema schema = Schema.BYTES_SCHEMA;
+
+    assertAll(
+        "Testing bytes support",
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(
+                    schema,
+                    BSON_DOCUMENT
+                        .getString("myString")
+                        .getValue()
+                        .getBytes(StandardCharsets.UTF_8)),
+                CONVERTER.toSchemaAndValue(Schema.BYTES_SCHEMA, BSON_DOCUMENT.get("myString"))),
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(schema, BSON_DOCUMENT.getBinary("myBytes").getData()),
+                CONVERTER.toSchemaAndValue(schema, BSON_DOCUMENT.getBinary("myBytes"))),
+        () ->
+            assertSchemaAndValueEquals(
+                new SchemaAndValue(Schema.BYTES_SCHEMA, documentToByteArray(BSON_DOCUMENT)),
+                CONVERTER.toSchemaAndValue(Schema.BYTES_SCHEMA, BSON_DOCUMENT)));
+
+    List<String> validKeys = asList("myString", "myBytes", "mySubDoc");
+    Set<String> invalidKeys =
+        BSON_DOCUMENT.keySet().stream()
+            .filter(k -> !validKeys.contains(k))
+            .collect(Collectors.toSet());
+
+    invalidKeys.forEach(
+        k ->
+            assertThrows(
+                DataException.class,
+                () -> CONVERTER.toSchemaAndValue(Schema.BYTES_SCHEMA, BSON_DOCUMENT.get(k)),
+                format("Expected %s to fail", k)));
+  }
+
+  @Test
+  @DisplayName("test array support")
+  void testArraySupport() {
+    Schema schema = SchemaBuilder.array(Schema.INT32_SCHEMA).build();
+
+    assertSchemaAndValueEquals(
+        new SchemaAndValue(schema, asList(1, 2, 3)),
+        CONVERTER.toSchemaAndValue(schema, BSON_DOCUMENT.get("myArray")));
+
+    Set<String> invalidKeys =
+        BSON_DOCUMENT.keySet().stream()
+            .filter(k -> !k.equals("myArray"))
+            .collect(Collectors.toSet());
+
+    invalidKeys.forEach(
+        k ->
+            assertThrows(
+                DataException.class,
+                () -> CONVERTER.toSchemaAndValue(schema, BSON_DOCUMENT.get(k)),
+                format("Expected %s to fail", k)));
+  }
+
+  @Test
+  @DisplayName("test Map support")
+  void testMapSupport() {
+    Schema schema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA);
+    assertSchemaAndValueEquals(
+        new SchemaAndValue(
+            schema,
+            new LinkedHashMap<String, Object>() {
+              {
+                put("A", "S2Fma2Egcm9ja3Mh");
+                put("B", "2020-01-01T07:27:07Z");
+                put("C", "12345.6789");
+              }
+            }),
+        CONVERTER.toSchemaAndValue(schema, BSON_DOCUMENT.get("mySubDoc")));
+
+    Set<String> invalidKeys =
+        BSON_DOCUMENT.keySet().stream()
+            .filter(k -> !k.equals("mySubDoc"))
+            .collect(Collectors.toSet());
+
+    invalidKeys.forEach(
+        k ->
+            assertThrows(
+                DataException.class,
+                () -> CONVERTER.toSchemaAndValue(schema, BSON_DOCUMENT.get(k)),
+                format("Expected %s to fail", k)));
+
+    assertThrows(
+        ConnectException.class,
+        () ->
+            CONVERTER.toSchemaAndValue(
+                SchemaBuilder.map(Schema.INT8_SCHEMA, Schema.INT8_SCHEMA), BSON_DOCUMENT));
+  }
+
+  @Test
+  @DisplayName("test struct support")
+  void testStructSupport() {
+    Schema schema =
+        SchemaBuilder.struct()
+            .field("A", Schema.STRING_SCHEMA)
+            .field("B", Schema.STRING_SCHEMA)
+            .field("C", Schema.STRING_SCHEMA)
+            .build();
+
+    assertSchemaAndValueEquals(
+        new SchemaAndValue(
+            schema,
+            new Struct(schema)
+                .put("A", "S2Fma2Egcm9ja3Mh")
+                .put("B", "2020-01-01T07:27:07Z")
+                .put("C", "12345.6789")),
+        CONVERTER.toSchemaAndValue(schema, BSON_DOCUMENT.get("mySubDoc")));
+
+    Set<String> invalidKeys =
+        BSON_DOCUMENT.keySet().stream()
+            .filter(k -> !k.equals("mySubDoc"))
+            .collect(Collectors.toSet());
+
+    invalidKeys.forEach(
+        k ->
+            assertThrows(
+                DataException.class,
+                () -> CONVERTER.toSchemaAndValue(schema, BSON_DOCUMENT.get(k)),
+                format("Expected %s to fail", k)));
+
+    BsonDocument invalidDoc = BsonDocument.parse(BSON_DOCUMENT.getDocument("mySubDoc").toJson());
+    invalidDoc.remove("A");
+    assertThrows(DataException.class, () -> CONVERTER.toSchemaAndValue(schema, invalidDoc));
+  }
+}

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValueTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValueTest.java
@@ -342,8 +342,8 @@ public class BsonValueToSchemaAndValueTest {
     Schema schema =
         SchemaBuilder.struct()
             .field("A", Schema.STRING_SCHEMA)
-            .field("B", Schema.STRING_SCHEMA)
-            .field("C", Schema.STRING_SCHEMA)
+            .field("B", SchemaBuilder.string().defaultValue("MISSING"))
+            .field("C", SchemaBuilder.string().optional().build())
             .build();
 
     assertSchemaAndValueEquals(
@@ -354,6 +354,11 @@ public class BsonValueToSchemaAndValueTest {
                 .put("B", "2020-01-01T07:27:07Z")
                 .put("C", "12345.6789")),
         CONVERTER.toSchemaAndValue(schema, BSON_DOCUMENT.get("mySubDoc")));
+
+    assertSchemaAndValueEquals(
+        new SchemaAndValue(
+            schema, new Struct(schema).put("A", "Test").put("B", "MISSING").put("C", null)),
+        CONVERTER.toSchemaAndValue(schema, BsonDocument.parse("{A: 'Test'}")));
 
     Set<String> invalidKeys =
         BSON_DOCUMENT.keySet().stream()

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/SchemaUtils.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/SchemaUtils.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.source.schema;
+
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
+
+import junit.framework.AssertionFailedError;
+
+public final class SchemaUtils {
+
+  public static void assertSchemaAndValueEquals(
+      final SchemaAndValue expected, final SchemaAndValue actual) {
+    assertSchemaEquals(expected.schema(), actual.schema());
+
+    Object expectedValue = convertData(expected.value());
+    Object actualValue = convertData(actual.value());
+
+    if (expectedValue instanceof Iterable && actualValue instanceof Iterable) {
+      assertIterableEquals((Iterable<?>) expectedValue, (Iterable<?>) actualValue);
+    } else {
+      assertEquals(expected.value(), actual.value(), "Values differed");
+    }
+  }
+
+  private static Object convertData(final Object value) {
+    if (value instanceof byte[]) {
+      // Doing equals on byte[] just tests instance equals and not the actual values
+      return getBytesData((byte[]) value);
+    }
+
+    if (value instanceof Struct) {
+      // Doing equals on Struct just tests instance equals and not the actual values
+      return getStructData((Struct) value);
+    }
+    return value;
+  }
+
+  private static Object getBytesData(final byte[] value) {
+    List<Object> listValue = new ArrayList<>();
+    for (byte b : value) {
+      listValue.add(b);
+    }
+    return listValue;
+  }
+
+  private static Object getStructData(final Struct value) {
+    List<Object> structValues = new ArrayList<>();
+    value.schema().fields().forEach(f -> structValues.add(convertData(value.get(f))));
+    return structValues;
+  }
+
+  public static void assertSchemaEquals(final Schema expected, final Schema actual) {
+    assertEquals(expected.isOptional(), actual.isOptional(), "Optional value differs");
+    assertEquals(expected.version(), actual.version(), "version differs");
+    assertEquals(expected.name(), actual.name(), "name differs");
+    assertEquals(expected.doc(), actual.doc(), "docs differ");
+    assertEquals(expected.type(), actual.type(), "type differs");
+
+    Object expectedDefaultValue = expected.defaultValue();
+    Object actualDefaultValue = actual.defaultValue();
+    if (expectedDefaultValue instanceof Struct && actualDefaultValue instanceof Struct) {
+      assertStructEquals((Struct) expectedDefaultValue, (Struct) actualDefaultValue);
+    } else {
+      assertEquals(expectedDefaultValue, actualDefaultValue, "values differ");
+    }
+    if (expected.type() == Type.MAP) {
+      assertEquals(expected.keySchema(), actual.keySchema(), "keySchema differs");
+      assertEquals(expected.valueSchema(), actual.valueSchema(), "valueSchema differs");
+    } else if (expected.type() == Type.STRUCT) {
+      assertStructSchemaEquals(expected, actual);
+    }
+    assertEquals(expected.parameters(), actual.parameters(), "parameters differs");
+  }
+
+  static void assertStructSchemaEquals(final Schema expected, final Schema actual) {
+    assertEquals(
+        expected.fields().size(),
+        actual.fields().size(),
+        format(
+            "Different fields length: expected %s, actual: %s",
+            expected.fields().size(), actual.fields().size()));
+    for (int i = 0; i < expected.fields().size(); i++) {
+      Field expectedField = expected.schema().fields().get(i);
+      Field actualField = actual.schema().fields().get(i);
+
+      assertEquals(expectedField.name(), actualField.name(), "Field name differs");
+      assertEquals(expectedField.index(), actualField.index(), "Field index differs");
+
+      try {
+        assertSchemaEquals(expectedField.schema(), actualField.schema());
+      } catch (Throwable e) {
+        throw new AssertionFailedError(
+            format("Field schema differed for: %s : %s", expectedField.name(), e.getMessage()));
+      }
+    }
+  }
+
+  static void assertStructEquals(final Struct expected, final Struct actual) {
+    assertStructSchemaEquals(expected.schema(), actual.schema());
+    for (Field field : expected.schema().fields()) {
+      assertEquals(
+          expected.get(field), actual.get(field), format("Field: '%s' differs", field.name()));
+    }
+  }
+
+  private SchemaUtils() {}
+}


### PR DESCRIPTION
Users will be able to supply a custom Avro schema definition.

  * output.format=schema
  * output.schema.key="" // Add the json avro definition here
  * output.schema.value="" // Add the json avro definition here

There is a default schema for both the SourceRecord key and value.
All changestream event types are supported but any dynamic data will
be represented by raw json strings.

KAFKA-124

https://spruce.mongodb.com/version/5f2961120ae6060c2dd0c50f/tasks