### PR TITLE
Added `copy.existing.pipeline` configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   - [KAFKA-124](https://jira.mongodb.org/browse/KAFKA-124) Added schema support for the source connector.
   - [KAFKA-137](https://jira.mongodb.org/browse/KAFKA-137) Support dotted field lookups when using schemas.
   - [KAFKA-128](https://jira.mongodb.org/browse/KAFKA-128) Sanitized the connection string in the partition map.
+  - [KAFKA-131](https://jira.mongodb.org/browse/KAFKA-131) Added `copy.existing.pipeline` configuration.
+    Note: Allows indexes to be used during the copying process, use when there is any filtering done by the main pipeline.
 
 
 ## 1.2.0

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -207,6 +207,15 @@ public class MongoSourceConfig extends AbstractConfig {
       "The max size of the queue to use when copying data.";
   private static final int COPY_EXISTING_QUEUE_SIZE_DEFAULT = 16000;
 
+  public static final String COPY_EXISTING_PIPELINE_CONFIG = "copy.existing.pipeline";
+  private static final String COPY_EXISTING_PIPELINE_DISPLAY = "Copy existing initial pipeline";
+  private static final String COPY_EXISTING_PIPELINE_DOC =
+      "An inline JSON array with objects describing the pipeline operations to run when copying existing data.\n"
+          + "This can improve the use of indexes by the copying manager and making copying more efficient.\n"
+          + "Use if there is any filtering of collection data in the `pipeline` configuration to speed up the copying process.\n"
+          + "Example: `[{\"$match\": {\"closed\": \"false\"}}]`";
+  private static final String COPY_EXISTING_PIPELINE_DEFAULT = "";
+
   public static final ConfigDef CONFIG = createConfigDef();
   private static final List<Consumer<MongoSourceConfig>> INITIALIZERS =
       singletonList(MongoSourceConfig::validateCollection);
@@ -245,7 +254,11 @@ public class MongoSourceConfig extends AbstractConfig {
   }
 
   public Optional<List<Document>> getPipeline() {
-    return jsonArrayFromString(getString(PIPELINE_CONFIG));
+    return getPipeline(PIPELINE_CONFIG);
+  }
+
+  public Optional<List<Document>> getPipeline(final String configName) {
+    return jsonArrayFromString(getString(configName));
   }
 
   public Optional<Collation> getCollation() {
@@ -419,6 +432,18 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         COPY_EXISTING_QUEUE_SIZE_DISPLAY);
+
+    configDef.define(
+        COPY_EXISTING_PIPELINE_CONFIG,
+        Type.STRING,
+        COPY_EXISTING_PIPELINE_DEFAULT,
+        errorCheckingValueValidator("A valid JSON array", ConfigHelper::jsonArrayFromString),
+        Importance.MEDIUM,
+        COPY_EXISTING_PIPELINE_DOC,
+        group,
+        ++orderInGroup,
+        Width.MEDIUM,
+        COPY_EXISTING_PIPELINE_DISPLAY);
 
     configDef.define(
         DATABASE_CONFIG,

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -355,8 +355,7 @@ public class MongoSourceTask extends SourceTask {
   private Map<String, Object> createPartitionMap(
       final MongoSourceConfig sourceConfig, final boolean recreate) {
     if (recreate) {
-      partitionMap =
-          singletonMap(NS_KEY, createNamespaceString(sourceConfig, false));
+      partitionMap = singletonMap(NS_KEY, createNamespaceString(sourceConfig, false));
     }
     return partitionMap;
   }


### PR DESCRIPTION
Allows indexes to be used during the copying process, use when there is any filtering done by the main pipeline

KAFKA-131
