### PR TITLE
Improve the handling of JSON array configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - [KAFKA-131](https://jira.mongodb.org/browse/KAFKA-131) Added `copy.existing.pipeline` configuration.
     Note: Allows indexes to be used during the copying process, use when there is any filtering done by the main pipeline.
   - [KAFKA-146](https://jira.mongodb.org/browse/KAFKA-146) Improve error handling and messaging for list configuration options.
+  - [KAFKA-154](https://jira.mongodb.org/browse/KAFKA-154) Improve the handling and error messaging for Json array config values.
 
 
 ## 1.2.0

--- a/src/main/java/com/mongodb/kafka/connect/util/ConfigHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/ConfigHelper.java
@@ -40,6 +40,11 @@ public final class ConfigHelper {
   private ConfigHelper() {}
 
   public static Optional<List<Document>> jsonArrayFromString(final String jsonArray) {
+    return jsonArrayFromString(jsonArray, null);
+  }
+
+  private static Optional<List<Document>> jsonArrayFromString(
+      final String jsonArray, final ConfigException originalError) {
     if (jsonArray.isEmpty()) {
       return Optional.empty();
     } else {
@@ -48,7 +53,13 @@ public final class ConfigHelper {
             Document.parse(format("{s: %s}", jsonArray)).getList("s", Document.class);
         return s.isEmpty() ? Optional.empty() : Optional.of(s);
       } catch (Exception e) {
-        throw new ConfigException("Not a valid JSON array");
+        if (originalError != null) {
+          throw originalError;
+        } else {
+          return jsonArrayFromString(
+              jsonArray.replaceAll("\\\\", "\\\\\\\\"),
+              new ConfigException("Not a valid JSON array", e));
+        }
       }
     }
   }

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
@@ -522,6 +522,19 @@ class MongoSinkConfigTest {
           assertEquals(2, pp.size());
           assertTrue(pp.get(1) instanceof RenameByRegExp);
         },
+        () -> {
+          MongoSinkConfig cfg =
+              createSinkConfig(
+                  format(
+                      json,
+                      FIELD_RENAMER_REGEXP_CONFIG,
+                      "[{\"regexp\":\"^key\\\\..*my.*$\",\"pattern\":\"my\",\"replace\":\"\"},"
+                          + "{\"regexp\":\"^value\\\\..*$\",\"pattern\":\"\\\\.\",\"replace\":\"_\"}]"));
+          List<PostProcessor> pp =
+              cfg.getMongoSinkTopicConfig(TEST_TOPIC).getPostProcessors().getPostProcessorList();
+          assertEquals(2, pp.size());
+          assertTrue(pp.get(1) instanceof RenameByRegExp);
+        },
         () ->
             assertInvalid(
                 FIELD_RENAMER_REGEXP_CONFIG,


### PR DESCRIPTION
Includes the original error in the exception.
Tries to auto escape if parsing the initial string fails.

KAFKA-154