### PR TITLE
Support errors.tolerance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   - [KAFKA-78](https://jira.mongodb.org/browse/KAFKA-78) Added dead letter queue support for the source connector.
   - [KAFKA-157](https://jira.mongodb.org/browse/KAFKA-157) Improved error message for business key errors.
   - [KAFKA-155](https://jira.mongodb.org/browse/KAFKA-155) Fix business key update strategies to use dot notation for filters
+  - [KAFKA-105](https://jira.mongodb.org/browse/KAFKA-105) Improve `errors.tolerance=all` support in the sink and source connectors.
 
 
 ## 1.2.0

--- a/src/integrationTest/java/com/mongodb/kafka/connect/log/LogCapture.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/log/LogCapture.java
@@ -45,6 +45,10 @@ public final class LogCapture implements AutoCloseable {
     return new ArrayList<>(loggingEvents);
   }
 
+  public void reset() {
+    loggingEvents.clear();
+  }
+
   @Override
   public void close() {
     logger.removeAppender(APPENDER_NAME);

--- a/src/integrationTest/java/com/mongodb/kafka/connect/sink/MongoSinkTaskIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/sink/MongoSinkTaskIntegrationTest.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.sink;
+
+import static com.mongodb.client.model.Projections.excludeId;
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.IntStream.rangeClosed;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTask;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import org.bson.Document;
+
+import com.mongodb.client.MongoCollection;
+
+import com.mongodb.kafka.connect.mongodb.MongoKafkaTestCase;
+
+@RunWith(JUnitPlatform.class)
+public class MongoSinkTaskIntegrationTest extends MongoKafkaTestCase {
+
+  @BeforeEach
+  void setUp() {
+    cleanUp();
+  }
+
+  @AfterEach
+  void tearDown() {
+    cleanUp();
+  }
+
+  @Test
+  @DisplayName("Ensure sink processes data from Kafka")
+  void testSinkProcessesSinkRecords() {
+    try (AutoCloseableSinkTask task = createSinkTask()) {
+
+      MongoCollection<Document> collection = getCollection();
+      String topic = "topic";
+      HashMap<String, String> cfg =
+          new HashMap<String, String>() {
+            {
+              put(MongoSinkConfig.TOPICS_CONFIG, topic);
+              put(
+                  MongoSinkTopicConfig.DATABASE_CONFIG,
+                  collection.getNamespace().getDatabaseName());
+              put(
+                  MongoSinkTopicConfig.COLLECTION_CONFIG,
+                  collection.getNamespace().getCollectionName());
+            }
+          };
+      task.start(cfg);
+
+      List<Document> documents = createDocuments(rangeClosed(1, 10));
+
+      List<SinkRecord> sinkRecords =
+          documents.stream()
+              .map(
+                  d ->
+                      new SinkRecord(
+                          topic,
+                          0,
+                          Schema.STRING_SCHEMA,
+                          d.toJson(),
+                          Schema.STRING_SCHEMA,
+                          d.toJson(),
+                          d.get("_id", 0)))
+              .collect(toList());
+
+      task.put(sinkRecords);
+
+      assertCollection(documents, collection);
+    }
+  }
+
+  @Test
+  @DisplayName("Ensure sink can handle poison pill invalid key")
+  void testSinkCanHandleInvalidKeyWhenErrorToleranceIsAll() {
+    try (AutoCloseableSinkTask task = createSinkTask()) {
+
+      MongoCollection<Document> collection = getCollection();
+      String topic = "topic";
+      HashMap<String, String> cfg =
+          new HashMap<String, String>() {
+            {
+              put(MongoSinkConfig.TOPICS_CONFIG, topic);
+              put(
+                  MongoSinkTopicConfig.DATABASE_CONFIG,
+                  collection.getNamespace().getDatabaseName());
+              put(
+                  MongoSinkTopicConfig.COLLECTION_CONFIG,
+                  collection.getNamespace().getCollectionName());
+              put(
+                  MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_CONFIG,
+                  "com.mongodb.kafka.connect.sink.processor.id.strategy.PartialKeyStrategy");
+              put(
+                  MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_TYPE_CONFIG,
+                  "AllowList");
+              put(
+                  MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_LIST_CONFIG,
+                  "a,b");
+              put(
+                  MongoSinkTopicConfig.WRITEMODEL_STRATEGY_CONFIG,
+                  "com.mongodb.kafka.connect.sink.writemodel.strategy.ReplaceOneBusinessKeyStrategy");
+              put(MongoSinkTopicConfig.ERRORS_TOLERANCE_CONFIG, "All");
+            }
+          };
+      task.start(cfg);
+
+      List<Document> documents =
+          createDocuments(rangeClosed(1, 11)).stream()
+              .peek(
+                  d -> {
+                    int id = d.get("_id", 0);
+                    d.put("a", format("a%s", id));
+                    d.put("b", "b");
+                    d.put("c", id);
+                    if (id != 4) {
+                      d.remove("_id");
+                    }
+                  })
+              .collect(toList());
+
+      List<SinkRecord> sinkRecords =
+          documents.stream()
+              .map(
+                  d ->
+                      new SinkRecord(
+                          topic,
+                          0,
+                          Schema.STRING_SCHEMA,
+                          d.toJson(),
+                          Schema.STRING_SCHEMA,
+                          d.toJson(),
+                          d.get("c", 0)))
+              .collect(toList());
+
+      task.put(sinkRecords);
+
+      assertIterableEquals(
+          documents.stream().filter(d -> !d.containsKey("_id")).collect(toList()),
+          collection.find().projection(excludeId()).into(new ArrayList<>()));
+
+      task.stop();
+
+      cfg.remove(MongoSinkTopicConfig.ERRORS_TOLERANCE_CONFIG);
+      task.start(cfg);
+
+      DataException e = assertThrows(DataException.class, () -> task.put(sinkRecords));
+      assertTrue(e.getMessage().contains("Could not build the WriteModel"));
+      assertTrue(
+          e.getMessage()
+              .contains(
+                  "If you are including an existing `_id` value in the business "
+                      + "key then ensure `document.id.strategy.overwrite.existing=true`"));
+    }
+  }
+
+  @Test
+  @DisplayName("Ensure sink can handle poison pill invalid value")
+  void testSinkCanHandleInvalidValueWhenErrorToleranceIsAll() {
+    try (AutoCloseableSinkTask task = createSinkTask()) {
+
+      MongoCollection<Document> collection = getCollection();
+      String topic = "topic";
+      HashMap<String, String> cfg =
+          new HashMap<String, String>() {
+            {
+              put(MongoSinkConfig.TOPICS_CONFIG, topic);
+              put(
+                  MongoSinkTopicConfig.DATABASE_CONFIG,
+                  collection.getNamespace().getDatabaseName());
+              put(
+                  MongoSinkTopicConfig.COLLECTION_CONFIG,
+                  collection.getNamespace().getCollectionName());
+              put(
+                  MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_CONFIG,
+                  "com.mongodb.kafka.connect.sink.processor.id.strategy.PartialValueStrategy");
+              put(
+                  MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_TYPE_CONFIG,
+                  "AllowList");
+              put(
+                  MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_LIST_CONFIG,
+                  "a,b");
+              put(
+                  MongoSinkTopicConfig.WRITEMODEL_STRATEGY_CONFIG,
+                  "com.mongodb.kafka.connect.sink.writemodel.strategy.ReplaceOneBusinessKeyStrategy");
+              put(MongoSinkTopicConfig.ERRORS_TOLERANCE_CONFIG, "All");
+            }
+          };
+      task.start(cfg);
+
+      List<Document> documents =
+          createDocuments(rangeClosed(1, 11)).stream()
+              .peek(
+                  d -> {
+                    int id = d.get("_id", 0);
+                    d.put("a", format("a%s", id));
+                    d.put("b", "b");
+                    d.put("c", id);
+                    if (id != 4) {
+                      d.remove("_id");
+                    }
+                  })
+              .collect(toList());
+
+      List<SinkRecord> sinkRecords =
+          documents.stream()
+              .map(
+                  d ->
+                      new SinkRecord(
+                          topic,
+                          0,
+                          Schema.STRING_SCHEMA,
+                          d.toJson(),
+                          Schema.STRING_SCHEMA,
+                          d.toJson(),
+                          d.get("c", 0)))
+              .collect(toList());
+
+      task.put(sinkRecords);
+
+      assertIterableEquals(
+          documents.stream().filter(d -> !d.containsKey("_id")).collect(toList()),
+          collection.find().projection(excludeId()).into(new ArrayList<>()));
+
+      task.stop();
+
+      cfg.remove(MongoSinkTopicConfig.ERRORS_TOLERANCE_CONFIG);
+      task.start(cfg);
+
+      DataException e = assertThrows(DataException.class, () -> task.put(sinkRecords));
+      assertTrue(e.getMessage().contains("Could not build the WriteModel"));
+      assertTrue(
+          e.getMessage()
+              .contains(
+                  "If you are including an existing `_id` value in the business "
+                      + "key then ensure `document.id.strategy.overwrite.existing=true`"));
+    }
+  }
+
+  @Test
+  @DisplayName("Ensure sink can handle poison pill invalid document")
+  void testSinkCanHandleInvalidDocumentWhenErrorToleranceIsAll() {
+    try (AutoCloseableSinkTask task = createSinkTask()) {
+
+      MongoCollection<Document> collection = getCollection();
+      String topic = "topic";
+      HashMap<String, String> cfg =
+          new HashMap<String, String>() {
+            {
+              put(MongoSinkConfig.TOPICS_CONFIG, topic);
+              put(
+                  MongoSinkTopicConfig.DATABASE_CONFIG,
+                  collection.getNamespace().getDatabaseName());
+              put(
+                  MongoSinkTopicConfig.COLLECTION_CONFIG,
+                  collection.getNamespace().getCollectionName());
+              put(MongoSinkTopicConfig.ERRORS_TOLERANCE_CONFIG, "all");
+            }
+          };
+      task.start(cfg);
+
+      List<Document> documents =
+          createDocuments(rangeClosed(1, 11)).stream()
+              .peek(
+                  d -> {
+                    d.put("a", format("a%s", d.get("_id", 0)));
+                    d.put("b", "b");
+                  })
+              .collect(toList());
+
+      List<SinkRecord> sinkRecords =
+          documents.stream()
+              .map(
+                  d ->
+                      new SinkRecord(
+                          topic,
+                          0,
+                          Schema.STRING_SCHEMA,
+                          d.toJson(),
+                          Schema.STRING_SCHEMA,
+                          d.get("_id", 0) != 4 ? d.toJson() : "a",
+                          d.get("c", 0)))
+              .collect(toList());
+
+      task.put(sinkRecords);
+
+      assertIterableEquals(
+          documents.stream().filter(d -> d.get("_id", 0) != 4).collect(toList()),
+          collection.find().into(new ArrayList<>()));
+
+      task.stop();
+
+      cfg.remove(MongoSinkTopicConfig.ERRORS_TOLERANCE_CONFIG);
+      task.start(cfg);
+
+      DataException e = assertThrows(DataException.class, () -> task.put(sinkRecords));
+      assertTrue(e.getMessage().contains("Could not convert value `a` into a BsonDocument"));
+    }
+  }
+
+  @Test
+  @DisplayName("Ensure sink can handle poison pill CDC value")
+  void testSinkCanHandleInvalidCDCWhenErrorToleranceIsAll() {
+    try (AutoCloseableSinkTask task = createSinkTask()) {
+
+      MongoCollection<Document> collection = getCollection();
+      String topic = "topic";
+      HashMap<String, String> cfg =
+          new HashMap<String, String>() {
+            {
+              put(MongoSinkConfig.TOPICS_CONFIG, topic);
+              put(
+                  MongoSinkTopicConfig.DATABASE_CONFIG,
+                  collection.getNamespace().getDatabaseName());
+              put(
+                  MongoSinkTopicConfig.COLLECTION_CONFIG,
+                  collection.getNamespace().getCollectionName());
+              put(
+                  MongoSinkTopicConfig.CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                  "com.mongodb.kafka.connect.sink.cdc.debezium.mongodb.MongoDbHandler");
+              put(MongoSinkTopicConfig.ERRORS_TOLERANCE_CONFIG, "all");
+            }
+          };
+      task.start(cfg);
+
+      List<Document> documents =
+          rangeClosed(1, 11)
+              .mapToObj(i -> Document.parse(format("{_id: %s, a: 1, b: 2}", i)))
+              .collect(toList());
+
+      List<SinkRecord> sinkRecords =
+          documents.stream()
+              .map(
+                  d ->
+                      new SinkRecord(
+                          topic,
+                          0,
+                          Schema.STRING_SCHEMA,
+                          d.toJson(),
+                          Schema.STRING_SCHEMA,
+                          Document.parse(
+                              d.get("_id", 0) != 4
+                                  ? format("{op: 'c', after: '%s'}", d.toJson())
+                                  : "{op: 'c'}"),
+                          d.get("_id", 0)))
+              .collect(toList());
+
+      task.put(sinkRecords);
+
+      assertIterableEquals(
+          documents.stream().filter(d -> d.getInteger("_id", 0) != 4).collect(toList()),
+          collection.find().into(new ArrayList<>()));
+
+      task.stop();
+
+      cfg.remove(MongoSinkTopicConfig.ERRORS_TOLERANCE_CONFIG);
+      task.start(cfg);
+
+      DataException e = assertThrows(DataException.class, () -> task.put(sinkRecords));
+      assertTrue(e.getMessage().contains("Insert document missing `after` field"));
+    }
+  }
+
+  public AutoCloseableSinkTask createSinkTask() {
+    return new AutoCloseableSinkTask(new MongoSinkTask());
+  }
+
+  static class AutoCloseableSinkTask extends SinkTask implements AutoCloseable {
+
+    private final MongoSinkTask wrapped;
+
+    AutoCloseableSinkTask(final MongoSinkTask wrapped) {
+      this.wrapped = wrapped;
+    }
+
+    @Override
+    public void close() {
+      wrapped.stop();
+    }
+
+    @Override
+    public String version() {
+      return wrapped.version();
+    }
+
+    @Override
+    public void start(final Map<String, String> overrides) {
+      HashMap<String, String> props = new HashMap<>();
+      props.put(MongoSinkConfig.CONNECTION_URI_CONFIG, MONGODB.getConnectionString().toString());
+      overrides.forEach(props::put);
+      wrapped.start(props);
+    }
+
+    @Override
+    public void put(final Collection<SinkRecord> records) {
+      wrapped.put(records);
+    }
+
+    @Override
+    public void stop() {
+      wrapped.stop();
+    }
+  }
+}

--- a/src/integrationTest/java/com/mongodb/kafka/connect/source/schema/SchemaUtils.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/source/schema/SchemaUtils.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.source.schema;
+
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.Struct;
+
+import junit.framework.AssertionFailedError;
+
+public final class SchemaUtils {
+
+  public static void assertStructsEquals(final List<Struct> expected, final List<Struct> actual) {
+    assertEquals(
+        expected.size(),
+        actual.size(),
+        format("Different sized lists: expected %s, actual: %s", expected.size(), actual.size()));
+
+    for (int i = 0; i < expected.size(); i++) {
+      Struct expectedStruct = expected.get(i);
+      Struct actualStruct = actual.get(i);
+
+      try {
+        assertStructEquals(expectedStruct, actualStruct);
+      } catch (Throwable e) {
+        throw new AssertionFailedError(
+            format("Struct differed in position [%s] : %s", i, e.getMessage()));
+      }
+    }
+  }
+
+  static void assertStructEquals(final Struct expected, final Struct actual) {
+    assertStructSchemaEquals(expected.schema(), actual.schema());
+    for (Field field : expected.schema().fields()) {
+      assertEquals(
+          expected.get(field), actual.get(field), format("Field: '%s' differs", field.name()));
+    }
+  }
+
+  static void assertStructSchemaEquals(final Schema expected, final Schema actual) {
+    assertEquals(
+        expected.fields().size(),
+        actual.fields().size(),
+        format(
+            "Different fields length: expected %s, actual: %s",
+            expected.fields().size(), actual.fields().size()));
+    for (int i = 0; i < expected.fields().size(); i++) {
+      Field expectedField = expected.schema().fields().get(i);
+      Field actualField = actual.schema().fields().get(i);
+
+      assertEquals(expectedField.name(), actualField.name(), "Field name differs");
+      assertEquals(expectedField.index(), actualField.index(), "Field index differs");
+
+      try {
+        assertSchemaEquals(expectedField.schema(), actualField.schema());
+      } catch (Throwable e) {
+        throw new AssertionFailedError(
+            format("Field schema differed for: %s : %s", expectedField.name(), e.getMessage()));
+      }
+    }
+  }
+
+  static void assertSchemaEquals(final Schema expected, final Schema actual) {
+    assertEquals(expected.isOptional(), actual.isOptional(), "Optional value differs");
+    assertEquals(expected.version(), actual.version(), "version differs");
+    assertEquals(expected.name(), actual.name(), "name differs");
+
+    assertEquals(expected.doc(), actual.doc(), "docs differ");
+    assertEquals(expected.type(), actual.type(), "type differs");
+
+    Object expectedDefaultValue = expected.defaultValue();
+    Object actualDefaultValue = actual.defaultValue();
+    if (expectedDefaultValue instanceof Struct && actualDefaultValue instanceof Struct) {
+      assertStructEquals((Struct) expectedDefaultValue, (Struct) actualDefaultValue);
+    } else {
+      assertEquals(expectedDefaultValue, actualDefaultValue, "values differ");
+    }
+    if (expected.type() == Type.MAP) {
+      assertEquals(expected.keySchema(), actual.keySchema(), "keySchema differs");
+      assertEquals(expected.valueSchema(), actual.valueSchema(), "valueSchema differs");
+    } else if (expected.type() == Type.STRUCT) {
+      assertStructSchemaEquals(expected, actual);
+    }
+    assertEquals(expected.parameters(), actual.parameters(), "parameters differs");
+  }
+
+  private SchemaUtils() {}
+}

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbHandler.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbHandler.java
@@ -63,9 +63,17 @@ public class MongoDbHandler extends DebeziumCdcHandler {
   @Override
   public Optional<WriteModel<BsonDocument>> handle(final SinkDocument doc) {
 
-    BsonDocument keyDoc =
-        doc.getKeyDoc()
-            .orElseThrow(() -> new DataException("Key document must not be missing for CDC mode"));
+    BsonDocument keyDoc = doc.getKeyDoc().orElseGet(BsonDocument::new);
+
+    if (keyDoc.isEmpty()) {
+      if (getConfig().logErrors()) {
+        LOGGER.error("Key document must not be missing for CDC mode {}", doc);
+      }
+      if (getConfig().tolerateErrors()) {
+        return Optional.empty();
+      }
+      throw new DataException("Key document must not be missing for CDC mode");
+    }
 
     BsonDocument valueDoc = doc.getValueDoc().orElseGet(BsonDocument::new);
 
@@ -77,6 +85,6 @@ public class MongoDbHandler extends DebeziumCdcHandler {
     LOGGER.debug("key: " + keyDoc.toString());
     LOGGER.debug("value: " + valueDoc.toString());
 
-    return Optional.of(getCdcOperation(valueDoc).perform(doc));
+    return handleOperation(() -> Optional.of(getCdcOperation(valueDoc).perform(doc)));
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/rdbms/RdbmsHandler.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/rdbms/RdbmsHandler.java
@@ -65,9 +65,7 @@ public class RdbmsHandler extends DebeziumCdcHandler {
 
   @Override
   public Optional<WriteModel<BsonDocument>> handle(final SinkDocument doc) {
-
     BsonDocument keyDoc = doc.getKeyDoc().orElseGet(BsonDocument::new);
-
     BsonDocument valueDoc = doc.getValueDoc().orElseGet(BsonDocument::new);
 
     if (valueDoc.isEmpty()) {
@@ -75,7 +73,8 @@ public class RdbmsHandler extends DebeziumCdcHandler {
       return Optional.empty();
     }
 
-    return Optional.of(getCdcOperation(valueDoc).perform(new SinkDocument(keyDoc, valueDoc)));
+    return handleOperation(
+        () -> Optional.of(getCdcOperation(valueDoc).perform(new SinkDocument(keyDoc, valueDoc))));
   }
 
   static BsonDocument generateFilterDoc(

--- a/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyHelper.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.sink.writemodel.strategy;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.kafka.connect.errors.DataException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.bson.BsonDocument;
+
+import com.mongodb.client.model.WriteModel;
+
+import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
+import com.mongodb.kafka.connect.sink.converter.SinkDocument;
+
+public final class WriteModelStrategyHelper {
+  private static final Logger LOGGER = LoggerFactory.getLogger(WriteModelStrategyHelper.class);
+
+  public static List<WriteModel<BsonDocument>> createValueWriteModel(
+      final MongoSinkTopicConfig config,
+      final SinkDocument document,
+      final List<WriteModel<BsonDocument>> docsToWrite) {
+    if (document.getValueDoc().isPresent()) {
+      createValueWriteModel(config, document).map(docsToWrite::add);
+    } else if (document.getKeyDoc().isPresent()) {
+      createKeyDeleteOneModel(config, document).map(docsToWrite::add);
+    } else {
+      if (config.logErrors()) {
+        LOGGER.error(
+            "skipping sink record {} for which neither key doc nor value doc were present",
+            document);
+      }
+    }
+    return docsToWrite;
+  }
+
+  static Optional<WriteModel<BsonDocument>> createValueWriteModel(
+      final MongoSinkTopicConfig config, final SinkDocument document) {
+    try {
+      return Optional.of(config.getWriteModelStrategy().createWriteModel(document));
+    } catch (Exception e) {
+      if (config.logErrors()) {
+        LOGGER.error("Could not create write model {}", document, e);
+      }
+      if (config.tolerateErrors()) {
+        return Optional.empty();
+      }
+      if (e instanceof DataException) {
+        throw e;
+      }
+      throw new DataException("Could not build the WriteModel.", e);
+    }
+  }
+
+  static Optional<WriteModel<BsonDocument>> createKeyDeleteOneModel(
+      final MongoSinkTopicConfig config, final SinkDocument document) {
+    try {
+      return config.getDeleteOneWriteModelStrategy().map(s -> s.createWriteModel(document));
+    } catch (Exception e) {
+      if (config.logErrors()) {
+        LOGGER.error("Could not create write model {}", document, e);
+      }
+      if (config.tolerateErrors()) {
+        return Optional.empty();
+      }
+      throw new DataException("Could not create write model", e);
+    }
+  }
+
+  private WriteModelStrategyHelper() {}
+}

--- a/src/test/java/com/mongodb/kafka/connect/sink/cdc/debezium/rdbms/RdbmsHandlerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/cdc/debezium/rdbms/RdbmsHandlerTest.java
@@ -44,6 +44,8 @@ import com.mongodb.client.model.DeleteOneModel;
 import com.mongodb.client.model.ReplaceOneModel;
 import com.mongodb.client.model.WriteModel;
 
+import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
+import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.ErrorTolerance;
 import com.mongodb.kafka.connect.sink.cdc.debezium.OperationType;
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 
@@ -51,8 +53,10 @@ import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 class RdbmsHandlerTest {
   private static final RdbmsHandler RDBMS_HANDLER_DEFAULT_MAPPING =
       new RdbmsHandler(createTopicConfig());
-  private static final RdbmsHandler RDBMS_HANDLER_EMPTY_MAPPING =
-      new RdbmsHandler(createTopicConfig(), emptyMap());
+  private static final RdbmsHandler ERROR_TOLERANT_HANDLER =
+      new RdbmsHandler(
+          createTopicConfig(
+              MongoSinkTopicConfig.ERRORS_TOLERANCE_CONFIG, ErrorTolerance.ALL.value()));
 
   @Test
   @DisplayName("verify existing default config from base class")
@@ -64,7 +68,7 @@ class RdbmsHandlerTest {
                 "default config for handler must not be null"),
         () ->
             assertNotNull(
-                RDBMS_HANDLER_EMPTY_MAPPING.getConfig(),
+                new RdbmsHandler(createTopicConfig(), emptyMap()).getConfig(),
                 "default config for handler must not be null"));
   }
 
@@ -94,6 +98,7 @@ class RdbmsHandlerTest {
     SinkDocument cdcEvent =
         new SinkDocument(BsonDocument.parse("{id: 1234}"), BsonDocument.parse("{op: 'x'}"));
     assertThrows(DataException.class, () -> RDBMS_HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
+    assertEquals(Optional.empty(), ERROR_TOLERANT_HANDLER.handle(cdcEvent));
   }
 
   @Test
@@ -102,8 +107,9 @@ class RdbmsHandlerTest {
     SinkDocument cdcEvent =
         new SinkDocument(
             BsonDocument.parse("{id: 1234}"),
-            BsonDocument.parse("{op: 'c', after: {id: 1234, foo: 'bar'}}"));
-    assertThrows(DataException.class, () -> RDBMS_HANDLER_EMPTY_MAPPING.handle(cdcEvent));
+            BsonDocument.parse("{op: 'z', after: {id: 1234, foo: 'bar'}}"));
+    assertThrows(DataException.class, () -> RDBMS_HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
+    assertEquals(Optional.empty(), ERROR_TOLERANT_HANDLER.handle(cdcEvent));
   }
 
   @Test
@@ -112,6 +118,7 @@ class RdbmsHandlerTest {
     SinkDocument cdcEvent =
         new SinkDocument(BsonDocument.parse("{id: 1234}"), BsonDocument.parse("{op: 'c'}"));
     assertThrows(DataException.class, () -> RDBMS_HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
+    assertEquals(Optional.empty(), ERROR_TOLERANT_HANDLER.handle(cdcEvent));
   }
 
   @Test
@@ -120,6 +127,7 @@ class RdbmsHandlerTest {
     SinkDocument cdcEvent =
         new SinkDocument(BsonDocument.parse("{id: 1234}"), BsonDocument.parse("{op: null}"));
     assertThrows(DataException.class, () -> RDBMS_HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
+    assertEquals(Optional.empty(), ERROR_TOLERANT_HANDLER.handle(cdcEvent));
   }
 
   @Test
@@ -128,6 +136,7 @@ class RdbmsHandlerTest {
     SinkDocument cdcEvent =
         new SinkDocument(BsonDocument.parse("{id: 1234}"), BsonDocument.parse("{po: null}"));
     assertThrows(DataException.class, () -> RDBMS_HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
+    assertEquals(Optional.empty(), ERROR_TOLERANT_HANDLER.handle(cdcEvent));
   }
 
   @TestFactory


### PR DESCRIPTION
Ensure that missing or invalid Resume Tokens do not error.

KAFKA-105

Scenarios tested:

*Source*
 
 * Missing / invalid / not found Resume Tokens (Integration test with a mocked offsetStorageReader) 
 * Poison pill message - invalid schema


*Sink*

  * Poison pill messages - Invalid Key / Values types & invalid documents
  * Errors thrown by PostProcessors
  * Debezium CDC handler errors / poison pills

 Evergreen: https://spruce.mongodb.com/version/5f620eba2fbabe32998f3c09/tasks