### PR TITLE
Added `offset.partition.name` configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
   - [KAFKA-155](https://jira.mongodb.org/browse/KAFKA-155) Fix business key update strategies to use dot notation for filters
   - [KAFKA-105](https://jira.mongodb.org/browse/KAFKA-105) Improve `errors.tolerance=all` support in the sink and source connectors.
   - [KAFKA-106](https://jira.mongodb.org/browse/KAFKA-106) Changed `max.num.retries` default to 1. A safer default especially as the driver now has retryable writes.
+  - [KAFKA-158](https://jira.mongodb.org/browse/KAFKA-158) Added `offset.partition.name` configuration, which allows for custom partitioning naming strategies.
+    Note: This can be used to start a new change stream, when an existing offset contains an invalid resume token.
 
 ## 1.2.0
   - [KAFKA-92](https://jira.mongodb.org/browse/KAFKA-92) Allow the Sink connector to use multiple tasks.

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -273,6 +273,13 @@ public class MongoSourceConfig extends AbstractConfig {
           + HEARTBEAT_TOPIC_NAME_DEFAULT
           + "'.";
 
+  public static final String OFFSET_PARTITION_NAME_CONFIG = "offset.partition.name";
+  public static final String OFFSET_PARTITION_NAME_DISPLAY = "Offset partition name";
+  public static final String OFFSET_PARTITION_NAME_DEFAULT = "";
+  public static final String OFFSET_PARTITION_NAME_DOC =
+      "Use a custom offset partition name. If blank the default partition name based on the "
+          + "connection details will be used.";
+
   public static final ConfigDef CONFIG = createConfigDef();
   private static final List<Consumer<MongoSourceConfig>> INITIALIZERS =
       singletonList(MongoSourceConfig::validateCollection);
@@ -719,6 +726,20 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         HEARTBEAT_TOPIC_NAME_DISPLAY);
+
+    group = "Partition";
+    orderInGroup = 0;
+
+    configDef.define(
+        OFFSET_PARTITION_NAME_CONFIG,
+        Type.STRING,
+        OFFSET_PARTITION_NAME_DEFAULT,
+        Importance.MEDIUM,
+        OFFSET_PARTITION_NAME_DOC,
+        group,
+        ++orderInGroup,
+        Width.SHORT,
+        OFFSET_PARTITION_NAME_DISPLAY);
 
     return configDef;
   }

--- a/src/test/java/com/mongodb/kafka/connect/source/MongoSourceTaskTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/MongoSourceTaskTest.java
@@ -386,31 +386,31 @@ class MongoSourceTaskTest {
 
     assertEquals(
         format("mongodb+srv://localhost/%s.%s", TEST_DATABASE, TEST_COLLECTION),
-        task.createNamespaceString(cfg, false));
+        task.createDefaultPartitionName(cfg));
     assertEquals(
         format("mongodb+srv://user:password@localhost//%s.%s", TEST_DATABASE, TEST_COLLECTION),
-        task.createNamespaceString(cfg, true));
+        task.createLegacyPartitionName(cfg));
 
     cfgMap.put(CONNECTION_URI_CONFIG, "mongodb://localhost/");
     cfg = new MongoSourceConfig(cfgMap);
     assertEquals(
         format("mongodb://localhost/%s.%s", TEST_DATABASE, TEST_COLLECTION),
-        task.createNamespaceString(cfg, false));
+        task.createDefaultPartitionName(cfg));
     assertEquals(
         format("mongodb://localhost//%s.%s", TEST_DATABASE, TEST_COLLECTION),
-        task.createNamespaceString(cfg, true));
+        task.createLegacyPartitionName(cfg));
 
     cfgMap.remove(COLLECTION_CONFIG);
     cfg = new MongoSourceConfig(cfgMap);
     assertEquals(
-        format("mongodb://localhost/%s", TEST_DATABASE), task.createNamespaceString(cfg, false));
+        format("mongodb://localhost/%s", TEST_DATABASE), task.createDefaultPartitionName(cfg));
     assertEquals(
-        format("mongodb://localhost//%s.", TEST_DATABASE), task.createNamespaceString(cfg, true));
+        format("mongodb://localhost//%s.", TEST_DATABASE), task.createLegacyPartitionName(cfg));
 
     cfgMap.remove(DATABASE_CONFIG);
     cfg = new MongoSourceConfig(cfgMap);
-    assertEquals("mongodb://localhost/", task.createNamespaceString(cfg, false));
-    assertEquals("mongodb://localhost//.", task.createNamespaceString(cfg, true));
+    assertEquals("mongodb://localhost/", task.createDefaultPartitionName(cfg));
+    assertEquals("mongodb://localhost//.", task.createLegacyPartitionName(cfg));
   }
 
   private void resetMocks() {


### PR DESCRIPTION
Allows for custom partition naming schemes.

KAFKA-158

https://spruce.mongodb.com/version/5f6a08ded1fe0717d385c0a1/tasks