### PR TITLE
Clone only used

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/PartialKeyStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/PartialKeyStrategy.java
@@ -52,7 +52,9 @@ public class PartialKeyStrategy implements IdStrategy {
     // NOTE: this has to operate on a clone because
     // otherwise it would interfere with further projections
     // happening later in the chain e.g. for key fields
-    SinkDocument clone = doc.clone();
+    BsonDocument keyClone = doc.getKeyDoc().map(bson -> bson.clone()).orElse(null);
+    SinkDocument clone = new SinkDocument(keyClone, null);
+
     fieldProjector.process(clone, orig);
     // NOTE: If there is no key doc present the strategy
     // simply returns an empty BSON document per default.

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/PartialValueStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/PartialValueStrategy.java
@@ -52,7 +52,10 @@ public class PartialValueStrategy implements IdStrategy {
     // NOTE: this has to operate on a clone because
     // otherwise it would interfere with further projections
     // happening later in the chain e.g. for value fields
-    SinkDocument clone = doc.clone();
+    BsonDocument valueClone =
+        doc.getValueDoc().map(bsonDocument -> bsonDocument.clone()).orElse(null);
+    SinkDocument clone = new SinkDocument(null, valueClone);
+
     fieldProjector.process(clone, orig);
     // NOTE: If there is no value doc present the strategy
     // simply returns an empty BSON document per default.


### PR DESCRIPTION
Hey guys, I faced an error with PartialValueStrategy. 
After digging, I found out that's because my kafka's key type is `string` type. When I try to clone the key, the key is converted to a bson type. But it's just a string, so the conversion(bson parsing) fails.
I think it's clear and enough to clone the value of SinkDocument in PartialValueStrategy. The same goes for PartialKeyStrategy.
Any ideas?

The config and error were below.
```
key.converter=org.apache.kafka.connect.storage.StringConverter
value.converter=io.confluent.connect.avro.AvroConverter
value.converter.schema.registry.url=schema_registry_url
value.converter.schemas.enabled=true

document.id.strategy=com.mongodb.kafka.connect.sink.processor.id.strategy.PartialValueStrategy
document.id.strategy.partial.value.projection.list=eventId
document.id.strategy.partial.value.projection.type=AllowList
writemodel.strategy=com.mongodb.kafka.connect.sink.writemodel.strategy.ReplaceOneBusinessKeyStrategy
```

```
org.apache.kafka.connect.errors.DataException: Unexpected data conversion exception.
 	at com.mongodb.kafka.connect.sink.converter.LazyBsonDocument.getUnwrapped(LazyBsonDocument.java:133)
 	at com.mongodb.kafka.connect.sink.converter.LazyBsonDocument.clone(LazyBsonDocument.java:125)
 	at com.mongodb.kafka.connect.sink.converter.SinkDocument.clone(SinkDocument.java:45)
 	at com.mongodb.kafka.connect.sink.processor.id.strategy.PartialValueStrategy.generateId(PartialValueStrategy.java:55)
 	at com.mongodb.kafka.connect.sink.processor.DocumentIdAdder.lambda$process$0(DocumentIdAdder.java:49)
 	at java.util.Optional.ifPresent(Optional.java:159)
 	at com.mongodb.kafka.connect.sink.processor.DocumentIdAdder.process(DocumentIdAdder.java:46)
 	at com.mongodb.kafka.connect.sink.MongoSinkTask.lambda$buildWriteModel$5(MongoSinkTask.java:277)
 	at java.util.ArrayList.forEach(ArrayList.java:1257)
 	at java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1082)
 	at com.mongodb.kafka.connect.sink.MongoSinkTask.lambda$buildWriteModel$6(MongoSinkTask.java:277)
 	at java.util.ArrayList.forEach(ArrayList.java:1257)
 	at com.mongodb.kafka.connect.sink.MongoSinkTask.buildWriteModel(MongoSinkTask.java:274)
 	at com.mongodb.kafka.connect.sink.MongoSinkTask.processSinkRecords(MongoSinkTask.java:194)
 	at com.mongodb.kafka.connect.sink.MongoSinkTask.lambda$put$2(MongoSinkTask.java:134)
 	at java.util.ArrayList.forEach(ArrayList.java:1257)
 	at com.mongodb.kafka.connect.sink.MongoSinkTask.lambda$put$3(MongoSinkTask.java:132)
 	at java.util.HashMap.forEach(HashMap.java:1289)
 	at com.mongodb.kafka.connect.sink.MongoSinkTask.put(MongoSinkTask.java:127)
 	at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:539)
 	at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:322)
 	at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:224)
 	at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:192)
 	at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:177)
 	at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:227)
 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
 	at java.lang.Thread.run(Thread.java:748)
 Caused by: org.bson.json.JsonParseException: JSON reader was expecting a value but found 'my_kafka_key_string'.
 	at org.bson.json.JsonReader.readBsonType(JsonReader.java:270)
 	at org.bson.AbstractBsonReader.verifyBSONType(AbstractBsonReader.java:680)
 	at org.bson.AbstractBsonReader.checkPreconditions(AbstractBsonReader.java:722)
 	at org.bson.AbstractBsonReader.readStartDocument(AbstractBsonReader.java:450)
 	at org.bson.codecs.BsonDocumentCodec.decode(BsonDocumentCodec.java:81)
 	at org.bson.BsonDocument.parse(BsonDocument.java:62)
 	at com.mongodb.kafka.connect.sink.converter.JsonRawStringRecordConverter.convert(JsonRawStringRecordConverter.java:34)
 	at com.mongodb.kafka.connect.sink.converter.SinkConverter.lambda$convert$0(SinkConverter.java:48)
 	at com.mongodb.kafka.connect.sink.converter.LazyBsonDocument.getUnwrapped(LazyBsonDocument.java:131)
 	... 29 more
```