### PR TITLE
Fix LazyBsonDocument clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug Fixes
   - [KAFKA-171](https://jira.mongodb.org/browse/KAFKA-171) Fixed bug which made the top level inferred schema optional
+  - [KAFKA-180](https://jira.mongodb.org/browse/KAFKA-180) Fix LazyBsonDocument clone, no need to try and unwrap the values before cloning.
 
 ## 1.3.0
   - [KAFKA-129](https://jira.mongodb.org/browse/KAFKA-129) Added support for Bson bytes in the Sink connector.

--- a/src/main/java/com/mongodb/kafka/connect/sink/converter/LazyBsonDocument.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/converter/LazyBsonDocument.java
@@ -57,11 +57,11 @@ public class LazyBsonDocument extends BsonDocument {
       final Type dataType,
       final BiFunction<Schema, Object, BsonDocument> converter) {
     if (record == null) {
-      throw new IllegalArgumentException("SinkRecord can not be null");
+      throw new IllegalArgumentException("record can not be null");
     } else if (dataType == null) {
       throw new IllegalArgumentException("dataType can not be null");
     } else if (converter == null) {
-      throw new IllegalArgumentException("BiFunction can not be null");
+      throw new IllegalArgumentException("converter can not be null");
     }
     this.record = record;
     this.dataType = dataType;

--- a/src/main/java/com/mongodb/kafka/connect/sink/converter/LazyBsonDocument.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/converter/LazyBsonDocument.java
@@ -35,13 +35,13 @@ import org.bson.BsonValue;
 public class LazyBsonDocument extends BsonDocument {
   private static final long serialVersionUID = 1L;
 
-  private transient SinkRecord record;
-  private transient Type dataType;
-  private transient BiFunction<Schema, Object, BsonDocument> converter;
+  private final transient SinkRecord record;
+  private final transient Type dataType;
+  private final transient BiFunction<Schema, Object, BsonDocument> converter;
 
   private BsonDocument unwrapped;
 
-  enum Type {
+  public enum Type {
     KEY,
     VALUE
   }
@@ -58,6 +58,8 @@ public class LazyBsonDocument extends BsonDocument {
       final BiFunction<Schema, Object, BsonDocument> converter) {
     if (record == null) {
       throw new IllegalArgumentException("SinkRecord can not be null");
+    } else if (dataType == null) {
+      throw new IllegalArgumentException("dataType can not be null");
     } else if (converter == null) {
       throw new IllegalArgumentException("BiFunction can not be null");
     }
@@ -143,7 +145,7 @@ public class LazyBsonDocument extends BsonDocument {
 
   @Override
   public BsonDocument clone() {
-    return getUnwrapped().clone();
+    return new LazyBsonDocument(record, dataType, converter);
   }
 
   private BsonDocument getUnwrapped() {

--- a/src/test/java/com/mongodb/kafka/connect/sink/converter/LazyBsonDocumentTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/converter/LazyBsonDocumentTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.sink.converter;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.RawBsonDocument;
+
+import com.mongodb.kafka.connect.sink.converter.LazyBsonDocument.Type;
+
+@SuppressWarnings({"ResultOfMethodCallIgnored", "MismatchedQueryAndUpdateOfCollection"})
+@RunWith(JUnitPlatform.class)
+public class LazyBsonDocumentTest {
+
+  private static final String JSON = "{_id: 12345, a: 'a', b: 'b', c: 'c'}";
+  private static final String NOT_JSON = "A normal string";
+  private static final RawBsonDocument EXPECTED_BSON_DOCUMENT = RawBsonDocument.parse(JSON);
+  private static final SinkRecord SINK_RECORD =
+      new SinkRecord("topic", 0, Schema.STRING_SCHEMA, JSON, Schema.STRING_SCHEMA, NOT_JSON, 1L);
+  private static final SinkRecord SINK_RECORD_ALT_KEY =
+      new SinkRecord("topic", 0, Schema.STRING_SCHEMA, NOT_JSON, Schema.STRING_SCHEMA, JSON, 1L);
+  private static final SinkRecord SINK_RECORD_ALT_VALUE =
+      new SinkRecord("topic", 0, Schema.STRING_SCHEMA, JSON, Schema.STRING_SCHEMA, NOT_JSON, 1L);
+
+  @Test
+  @DisplayName("test invalid LazyBsonDocuments")
+  void testInvalidLazyBsonDocuments() {
+    assertAll(
+        "Ensure not nulls",
+        () ->
+            assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                    new LazyBsonDocument(
+                        null, Type.KEY, (Schema schema, Object data) -> new BsonDocument())),
+        () ->
+            assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                    new LazyBsonDocument(
+                        SINK_RECORD, null, (Schema schema, Object data) -> new BsonDocument())),
+        () ->
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> new LazyBsonDocument(SINK_RECORD, Type.KEY, null)));
+  }
+
+  @Test
+  @DisplayName("test invalid conversions")
+  void testInvalidConversions() {
+    assertAll(
+        "Ensure throws DataException when failing to convert",
+        () ->
+            assertDoesNotThrow(
+                () ->
+                    new LazyBsonDocument(
+                        SINK_RECORD_ALT_KEY,
+                        Type.KEY,
+                        (Schema schema, Object data) -> BsonDocument.parse(data.toString()))),
+        () ->
+            assertThrows(
+                DataException.class,
+                new LazyBsonDocument(
+                        SINK_RECORD_ALT_KEY,
+                        Type.KEY,
+                        (Schema schema, Object data) -> BsonDocument.parse(data.toString()))
+                    ::toString),
+        () ->
+            assertThrows(
+                DataException.class,
+                new LazyBsonDocument(
+                        SINK_RECORD_ALT_VALUE,
+                        Type.VALUE,
+                        (Schema schema, Object data) -> BsonDocument.parse(data.toString()))
+                    ::toString));
+  }
+
+  @Test
+  @DisplayName("test BsonDocument read API")
+  void testBsonDocumentReadAPI() {
+    LazyBsonDocument lazyBsonDocument =
+        new LazyBsonDocument(
+            SINK_RECORD,
+            Type.KEY,
+            (Schema schema, Object data) -> BsonDocument.parse(data.toString()));
+    assertAll(
+        "The BsonDocument API returns results as expected",
+        () -> assertEquals(EXPECTED_BSON_DOCUMENT.size(), lazyBsonDocument.size()),
+        () -> assertEquals(EXPECTED_BSON_DOCUMENT.entrySet(), lazyBsonDocument.entrySet()),
+        () -> assertEquals(EXPECTED_BSON_DOCUMENT.keySet(), lazyBsonDocument.keySet()),
+        () -> assertIterableEquals(EXPECTED_BSON_DOCUMENT.values(), lazyBsonDocument.values()),
+        () ->
+            assertEquals(
+                EXPECTED_BSON_DOCUMENT.containsValue(new BsonString("a")),
+                lazyBsonDocument.containsValue(new BsonString("a"))),
+        () ->
+            assertEquals(
+                EXPECTED_BSON_DOCUMENT.containsKey("a"), lazyBsonDocument.containsKey("a")));
+  }
+
+  @Test
+  @DisplayName("test clone")
+  void testClone() {
+    assertAll(
+        "The BsonDocument API returns results as expected",
+        () -> {
+          LazyBsonDocument lazyBsonDocument =
+              new LazyBsonDocument(
+                  SINK_RECORD,
+                  Type.KEY,
+                  (Schema schema, Object data) -> BsonDocument.parse(data.toString()));
+          assertEquals(lazyBsonDocument, lazyBsonDocument.clone());
+        },
+        () -> {
+          LazyBsonDocument lazyBsonDocument =
+              new LazyBsonDocument(
+                  SINK_RECORD_ALT_KEY,
+                  Type.KEY,
+                  (Schema schema, Object data) -> BsonDocument.parse(data.toString()));
+          assertDoesNotThrow(lazyBsonDocument::clone);
+        },
+        () -> {
+          LazyBsonDocument lazyBsonDocument =
+              new LazyBsonDocument(
+                  SINK_RECORD_ALT_VALUE,
+                  Type.VALUE,
+                  (Schema schema, Object data) -> BsonDocument.parse(data.toString()));
+          assertDoesNotThrow(lazyBsonDocument::clone);
+        });
+  }
+}

--- a/src/test/java/com/mongodb/kafka/connect/sink/processor/id/strategy/IdStrategyTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/processor/id/strategy/IdStrategyTest.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.DisplayName;
@@ -64,6 +65,8 @@ import org.bson.BsonValue;
 import org.bson.UuidRepresentation;
 
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
+import com.mongodb.kafka.connect.sink.converter.LazyBsonDocument;
+import com.mongodb.kafka.connect.sink.converter.LazyBsonDocument.Type;
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 import com.mongodb.kafka.connect.sink.processor.AllowListKeyProjector;
 import com.mongodb.kafka.connect.sink.processor.AllowListValueProjector;
@@ -75,6 +78,11 @@ class IdStrategyTest {
   private static final int UUID_STRING_LENGTH = 36;
   private static final int BSON_OID_STRING_LENGTH = 12;
   private static final int KAFKA_META_DATA_PARTS = 3;
+  private static final BsonDocument INVALID_BSON_DOCUMENT =
+      new LazyBsonDocument(
+          new SinkRecord("topic", 0, Schema.STRING_SCHEMA, "k", Schema.STRING_SCHEMA, "v", 1L),
+          Type.KEY,
+          (s, o) -> BsonDocument.parse(o.toString()));
 
   @TestFactory
   @DisplayName("test different id generation strategies")
@@ -289,7 +297,7 @@ class IdStrategyTest {
 
     IdStrategy ids = new PartialKeyStrategy();
     ids.configure(cfg);
-    SinkDocument sd = new SinkDocument(keyDoc, null);
+    SinkDocument sd = new SinkDocument(keyDoc, INVALID_BSON_DOCUMENT);
     BsonValue id = ids.generateId(sd, null);
 
     assertAll(
@@ -315,7 +323,7 @@ class IdStrategyTest {
 
     IdStrategy ids = new PartialKeyStrategy();
     ids.configure(cfg);
-    SinkDocument sd = new SinkDocument(keyDoc, null);
+    SinkDocument sd = new SinkDocument(keyDoc, INVALID_BSON_DOCUMENT);
     BsonValue id = ids.generateId(sd, null);
 
     assertAll(
@@ -342,7 +350,7 @@ class IdStrategyTest {
 
     IdStrategy ids = new PartialValueStrategy();
     ids.configure(cfg);
-    SinkDocument sd = new SinkDocument(null, valueDoc);
+    SinkDocument sd = new SinkDocument(INVALID_BSON_DOCUMENT, valueDoc);
     BsonValue id = ids.generateId(sd, null);
 
     assertAll(
@@ -369,7 +377,7 @@ class IdStrategyTest {
 
     IdStrategy ids = new PartialValueStrategy();
     ids.configure(cfg);
-    SinkDocument sd = new SinkDocument(null, valueDoc);
+    SinkDocument sd = new SinkDocument(INVALID_BSON_DOCUMENT, valueDoc);
     BsonValue id = ids.generateId(sd, null);
 
     assertAll(


### PR DESCRIPTION
Clone the LazyBsonDocument and not the unwrapped BsonDocument
As not all LazyBsonDocument instances are valid BsonDocuments
and need unwrapping.

KAFKA-180