### PR TITLE
Fixed sink validation issue including synthetic config property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Bug Fixes
   - [KAFKA-171](https://jira.mongodb.org/browse/KAFKA-171) Fixed bug which made the top level inferred schema optional
+  - [KAFKA-166](https://jira.mongodb.org/browse/KAFKA-166) Fixed sink validation issue including synthetic config property
+
 
 ## 1.3.0
   - [KAFKA-129](https://jira.mongodb.org/browse/KAFKA-129) Added support for Bson bytes in the Sink connector.

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
@@ -22,6 +22,7 @@ import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.TOPIC_OVERRIDE
 import static com.mongodb.kafka.connect.util.Validators.errorCheckingValueValidator;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 import static org.apache.kafka.common.config.ConfigDef.Width;
@@ -84,6 +85,8 @@ public class MongoSinkConfig extends AbstractConfig {
           + "' and '"
           + TOPICS_CONFIG
           + "' are overridable.";
+
+  static final List<String> IGNORED_CONFIGS = singletonList(TOPIC_OVERRIDE_CONFIG);
 
   private Map<String, String> originals;
   private final Optional<List<String>> topics;
@@ -187,6 +190,7 @@ public class MongoSinkConfig extends AbstractConfig {
           @SuppressWarnings("unchecked")
           public Map<String, ConfigValue> validateAll(final Map<String, String> props) {
             Map<String, ConfigValue> results = super.validateAll(props);
+            IGNORED_CONFIGS.forEach(c -> results.remove(c));
             // Don't validate child configs if the top level configs are broken
             if (results.values().stream().anyMatch((c) -> !c.errorMessages().isEmpty())) {
               return results;


### PR DESCRIPTION
The config definition includes two synthetic properties: The topic override template property and the topic property.  When validating these should not be included in the results. This combined with https://issues.apache.org/jira/browse/KAFKA-10600 can
cause confusion to users.

KAFKA-166