### PR TITLE
Configurable topic suffix for source connector

### DIFF
--- a/config/MongoSourceConnector.properties
+++ b/config/MongoSourceConnector.properties
@@ -8,6 +8,7 @@ database=test
 collection=source
 
 topic.prefix=
+topic.suffix=
 poll.max.batch.size=1000
 poll.await.time.ms=5000
 

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -133,6 +133,13 @@ public class MongoSourceConfig extends AbstractConfig {
   private static final String TOPIC_PREFIX_DISPLAY = "Topic Prefix";
   private static final String TOPIC_PREFIX_DEFAULT = "";
 
+  public static final String TOPIC_SUFFIX_CONFIG = "topic.suffix";
+  private static final String TOPIC_SUFFIX_DOC =
+      "Suffix to append to database & collection names to generate the name of the Kafka "
+          + "topic to publish data to.";
+  private static final String TOPIC_SUFFIX_DISPLAY = "Topic Suffix";
+  private static final String TOPIC_SUFFIX_DEFAULT = "";
+
   public static final String PIPELINE_CONFIG = "pipeline";
   private static final String PIPELINE_DISPLAY = "The pipeline to apply to the change stream";
   private static final String PIPELINE_DOC =
@@ -523,6 +530,18 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         TOPIC_PREFIX_DISPLAY);
+
+    configDef.define(
+        TOPIC_SUFFIX_CONFIG,
+        Type.STRING,
+        TOPIC_SUFFIX_DEFAULT,
+        null,
+        Importance.LOW,
+        TOPIC_SUFFIX_DOC,
+        group,
+        ++orderInGroup,
+        Width.MEDIUM,
+        TOPIC_SUFFIX_DISPLAY);
 
     configDef.define(
         POLL_MAX_BATCH_SIZE_CONFIG,

--- a/src/test/java/com/mongodb/kafka/connect/source/MongoSourceConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/MongoSourceConfigTest.java
@@ -34,6 +34,7 @@ import static com.mongodb.kafka.connect.source.MongoSourceConfig.PIPELINE_CONFIG
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_AWAIT_TIME_MS_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_MAX_BATCH_SIZE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.TOPIC_PREFIX_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.TOPIC_SUFFIX_CONFIG;
 import static com.mongodb.kafka.connect.source.SourceTestHelper.CLIENT_URI_AUTH_SETTINGS;
 import static com.mongodb.kafka.connect.source.SourceTestHelper.CLIENT_URI_DEFAULT_SETTINGS;
 import static com.mongodb.kafka.connect.source.SourceTestHelper.createConfigMap;
@@ -281,6 +282,18 @@ class MongoSourceConfigTest {
             assertEquals(
                 "prefix",
                 createSourceConfig(TOPIC_PREFIX_CONFIG, "prefix").getString(TOPIC_PREFIX_CONFIG)));
+  }
+
+  @Test
+  @DisplayName("test topic suffix")
+  void testTopicSuffix() {
+    assertAll(
+        "Topic suffix",
+        () -> assertEquals("", createSourceConfig().getString(TOPIC_SUFFIX_CONFIG)),
+        () ->
+            assertEquals(
+                "suffix",
+                createSourceConfig(TOPIC_SUFFIX_CONFIG, "suffix").getString(TOPIC_SUFFIX_CONFIG)));
   }
 
   @Test

--- a/src/test/java/com/mongodb/kafka/connect/source/MongoSourceTaskTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/MongoSourceTaskTest.java
@@ -86,20 +86,39 @@ class MongoSourceTaskTest {
         "Topic name",
         () ->
             assertEquals(
-                "db1", task.getTopicNameFromNamespace("", BsonDocument.parse("{db: 'db1'}"))),
+                "db1", task.getTopicNameFromNamespace("", "", BsonDocument.parse("{db: 'db1'}"))),
         () ->
             assertEquals(
                 "db1.coll1",
                 task.getTopicNameFromNamespace(
-                    "", BsonDocument.parse("{db: 'db1', coll: 'coll1'}"))),
+                    "", "", BsonDocument.parse("{db: 'db1', coll: 'coll1'}"))),
         () ->
             assertEquals(
-                "a.db1", task.getTopicNameFromNamespace("a", BsonDocument.parse("{db: 'db1'}"))),
+                "a.db1",
+                task.getTopicNameFromNamespace("a", "", BsonDocument.parse("{db: 'db1'}"))),
         () ->
             assertEquals(
                 "a.db1.coll1",
                 task.getTopicNameFromNamespace(
-                    "a", BsonDocument.parse("{db: 'db1', coll: 'coll1'}"))));
+                    "a", "", BsonDocument.parse("{db: 'db1', coll: 'coll1'}"))),
+        () ->
+            assertEquals(
+                "db1.b",
+                task.getTopicNameFromNamespace("", "b", BsonDocument.parse("{db: 'db1'}"))),
+        () ->
+            assertEquals(
+                "db1.coll1.b",
+                task.getTopicNameFromNamespace(
+                    "", "b", BsonDocument.parse("{db: 'db1', coll: 'coll1'}"))),
+        () ->
+            assertEquals(
+                "a.db1.b",
+                task.getTopicNameFromNamespace("a", "b", BsonDocument.parse("{db: 'db1'}"))),
+        () ->
+            assertEquals(
+                "a.db1.coll1.b",
+                task.getTopicNameFromNamespace(
+                    "a", "b", BsonDocument.parse("{db: 'db1', coll: 'coll1'}"))));
   }
 
   @Test


### PR DESCRIPTION
Added a new config option to enable setting a custom suffix for the topic in which the messages will be sent.

KAFKA-184