### PR TITLE
Fix logging of general exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - [KAFKA-171](https://jira.mongodb.org/browse/KAFKA-171) Fixed bug which made the top level inferred schema optional
   - [KAFKA-166](https://jira.mongodb.org/browse/KAFKA-166) Fixed sink validation issue including synthetic config property
   - [KAFKA-180](https://jira.mongodb.org/browse/KAFKA-180) Fix LazyBsonDocument clone, no need to try and unwrap the values before cloning.
+  - [KAFKA-188](https://jira.mongodb.org/browse/KAFKA-188) Fix logging of general exceptions.
 
 ## 1.3.0
   - [KAFKA-129](https://jira.mongodb.org/browse/KAFKA-129) Added support for Bson bytes in the Sink connector.

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTask.java
@@ -212,6 +212,9 @@ public class MongoSinkTask extends SinkTask {
           config.getNamespace().getFullName());
       handleMongoException(config, e);
     } catch (Exception e) {
+      if (config.logErrors()) {
+        LOGGER.error("Failed to write mongodb documents", e);
+      }
       if (!config.tolerateErrors()) {
         throw new DataException("Failed to write mongodb documents", e);
       }

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -379,6 +379,10 @@ public class MongoSourceConfig extends AbstractConfig {
         .getJsonWriterSettings();
   }
 
+  public boolean logErrors() {
+    return !tolerateErrors() || getBoolean(ERRORS_LOG_ENABLE_CONFIG);
+  }
+
   public boolean tolerateErrors() {
     return ErrorTolerance.valueOf(getString(ERRORS_TOLERANCE_CONFIG).toUpperCase())
         .equals(ErrorTolerance.ALL);

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -21,7 +21,6 @@ import static com.mongodb.kafka.connect.source.MongoSourceConfig.CONNECTION_URI_
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COPY_EXISTING_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.DATABASE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
-import static com.mongodb.kafka.connect.source.MongoSourceConfig.ERRORS_LOG_ENABLE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.HEARTBEAT_INTERVAL_MS_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.HEARTBEAT_TOPIC_NAME_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_AWAIT_TIME_MS_CONFIG;
@@ -302,10 +301,10 @@ public final class MongoSourceTask extends SourceTask {
               format(
                   "Exception creating Source record for: Key=%s Value=%s",
                   keyDocument.toJson(), valueDocument.toJson());
+      if (sourceConfig.logErrors()) {
+        LOGGER.error(errorMessage.get(), e);
+      }
       if (sourceConfig.tolerateErrors()) {
-        if (sourceConfig.getBoolean(ERRORS_LOG_ENABLE_CONFIG)) {
-          LOGGER.error(errorMessage.get(), e);
-        }
         if (sourceConfig.getString(ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG).isEmpty()) {
           return Optional.empty();
         }

--- a/src/test/java/com/mongodb/kafka/connect/source/MongoSourceConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/MongoSourceConfigTest.java
@@ -22,7 +22,6 @@ import static com.mongodb.kafka.connect.source.MongoSourceConfig.CONNECTION_URI_
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COPY_EXISTING_NAMESPACE_REGEX_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COPY_EXISTING_PIPELINE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
-import static com.mongodb.kafka.connect.source.MongoSourceConfig.ERRORS_LOG_ENABLE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.ERRORS_TOLERANCE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.FULL_DOCUMENT_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.HEARTBEAT_INTERVAL_MS_CONFIG;
@@ -318,7 +317,8 @@ class MongoSourceConfigTest {
         "Error configurations",
         () -> assertFalse(createSourceConfig().tolerateErrors()),
         () -> assertTrue(createSourceConfig(ERRORS_TOLERANCE_CONFIG, "all").tolerateErrors()),
-        () -> assertFalse(createSourceConfig().getBoolean(ERRORS_LOG_ENABLE_CONFIG)),
+        () -> assertTrue(createSourceConfig().logErrors()),
+        () -> assertFalse(createSourceConfig(ERRORS_TOLERANCE_CONFIG, "all").logErrors()),
         () ->
             assertTrue(
                 createSourceConfig()


### PR DESCRIPTION
We log errors if the user doesn't tolerate errors or if the user tolerates errors and sets the logging flag.

KAFKA-188