### PR TITLE
Fixed topics.regex sink validation issue for synthetic config property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Changelog
 
+## 1.5.0
+
+### Improvements
+- 
+
+### Bug Fixes
+- [KAFKA-195](https://jira.mongodb.org/browse/KAFKA-195) Fixed topics.regex sink validation issue for synthetic config property
+
+
 ## 1.4.0
 
 ### Improvements

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
@@ -566,7 +566,6 @@ public class MongoSinkTopicConfig extends AbstractConfig {
 
   static Map<String, ConfigValue> validateRegexAll(final Map<String, String> props) {
     Map<String, ConfigValue> results = new HashMap<>();
-    AtomicBoolean containsError = new AtomicBoolean();
     Map<String, String> sinkTopicOriginals = createSinkTopicOriginals(props);
 
     CONFIG
@@ -574,9 +573,6 @@ public class MongoSinkTopicConfig extends AbstractConfig {
         .forEach(
             (k, v) -> {
               if (!IGNORED_CONFIGS.contains(k)) {
-                if (!v.errorMessages().isEmpty()) {
-                  containsError.set(true);
-                }
                 results.put(
                     k, new ConfigValue(k, v.value(), v.recommendedValues(), v.errorMessages()));
               }

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
@@ -506,7 +506,6 @@ public class MongoSinkTopicConfig extends AbstractConfig {
         props.keySet().stream().filter(k -> k.startsWith(prefix)).collect(Collectors.toList());
 
     Map<String, ConfigValue> results = new HashMap<>();
-    AtomicBoolean containsError = new AtomicBoolean();
     Map<String, String> sinkTopicOriginals = createSinkTopicOriginals(topic, props);
 
     CONFIG
@@ -515,16 +514,13 @@ public class MongoSinkTopicConfig extends AbstractConfig {
             (k, v) -> {
               String name = topicOverrides.contains(prefix + k) ? prefix + k : k;
               if (props.containsKey(name) && !IGNORED_CONFIGS.contains(name)) {
-                if (!v.errorMessages().isEmpty()) {
-                  containsError.set(true);
-                }
                 results.put(
                     name,
                     new ConfigValue(name, v.value(), v.recommendedValues(), v.errorMessages()));
               }
             });
 
-    if (!containsError.get()) {
+    if (results.values().stream().allMatch(v -> v.errorMessages().isEmpty())) {
       MongoSinkTopicConfig cfg = new MongoSinkTopicConfig(topic, sinkTopicOriginals, false);
       INITIALIZERS.forEach(
           i -> {

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
@@ -513,12 +513,11 @@ public class MongoSinkTopicConfig extends AbstractConfig {
         .validateAll(sinkTopicOriginals)
         .forEach(
             (k, v) -> {
-              if (!v.errorMessages().isEmpty()) {
-                containsError.set(true);
-              }
-
               String name = topicOverrides.contains(prefix + k) ? prefix + k : k;
               if (props.containsKey(name) && !IGNORED_CONFIGS.contains(name)) {
+                if (!v.errorMessages().isEmpty()) {
+                  containsError.set(true);
+                }
                 results.put(
                     name,
                     new ConfigValue(name, v.value(), v.recommendedValues(), v.errorMessages()));
@@ -574,11 +573,13 @@ public class MongoSinkTopicConfig extends AbstractConfig {
         .validateAll(sinkTopicOriginals)
         .forEach(
             (k, v) -> {
-              if (!v.errorMessages().isEmpty()) {
-                containsError.set(true);
+              if (!IGNORED_CONFIGS.contains(k)) {
+                if (!v.errorMessages().isEmpty()) {
+                  containsError.set(true);
+                }
+                results.put(
+                    k, new ConfigValue(k, v.value(), v.recommendedValues(), v.errorMessages()));
               }
-              results.put(
-                  k, new ConfigValue(k, v.value(), v.recommendedValues(), v.errorMessages()));
             });
 
     props.keySet().stream()

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
@@ -182,6 +182,30 @@ class MongoSinkConfigTest {
   }
 
   @Test
+  @DisplayName("test validation")
+  void testValidationRegex() {
+    Map<String, String> configMap =
+        createConfigMap(format("{'%s': '^topic.*'}", TOPICS_REGEX_CONFIG));
+
+    Map<String, ConfigValue> validateAllMap = MongoSinkConfig.CONFIG.validateAll(configMap);
+
+    validateAllMap.values().forEach(v -> assertTrue(v.errorMessages().isEmpty()));
+    Set<String> configNames =
+        validateAllMap.values().stream().map(ConfigValue::name).collect(Collectors.toSet());
+
+    Set<String> expectedKeys = new HashSet<>(MongoSinkConfig.CONFIG.configKeys().keySet());
+    expectedKeys.addAll(MongoSinkTopicConfig.CONFIG.configKeys().keySet());
+    // Remove ignored configs
+    expectedKeys.removeAll(MongoSinkConfig.IGNORED_CONFIGS);
+    expectedKeys.removeAll(MongoSinkTopicConfig.IGNORED_CONFIGS);
+
+    // Added declared overrides
+    expectedKeys.addAll(configMap.keySet());
+
+    assertEquals(expectedKeys, configNames);
+  }
+
+  @Test
   @DisplayName("test topic regex")
   void testTopicRegex() {
     assertAll(


### PR DESCRIPTION
KAFKA-195

This is linked to #47 but I missed the usecase where users declare a `topics.regex`