### PR TITLE
Errant Record Reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 ## 1.5.0
 
 ### Improvements
-- [KAFKA-168](https://jira.mongodb.org/browse/KAFKA-168) Added DeleteOneBusinessKeyStrategy for topics containing records to removed from MongoDB.
+  - [KAFKA-168](https://jira.mongodb.org/browse/KAFKA-168) Added DeleteOneBusinessKeyStrategy for topics containing records to removed from MongoDB.
+  - [KAFKA-183](https://jira.mongodb.org/browse/KAFKA-183) Added support for the errant record reporter if available.
 
 ### Bug Fixes
-- [KAFKA-195](https://jira.mongodb.org/browse/KAFKA-195) Fixed topics.regex sink validation issue for synthetic config property
+  - [KAFKA-195](https://jira.mongodb.org/browse/KAFKA-195) Fixed topics.regex sink validation issue for synthetic config property
 
 
 ## 1.4.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,14 +48,14 @@ java {
 }
 
 repositories {
-    mavenCentral()
     maven("http://packages.confluent.io/maven/")
+    mavenCentral()
     maven("https://jitpack.io")
 }
 
 extra.apply {
     set("mongodbDriverVersion", "[4.1,4.1.99)")
-    set("kafkaVersion", "2.5.0")
+    set("kafkaVersion", "2.6.0")
     set("avroVersion", "1.9.2")
 
     // Testing dependencies
@@ -65,14 +65,14 @@ extra.apply {
     set("mockitoVersion", "2.27.0")
 
     // Integration test dependencies
-    set("confluentVersion", "5.5.1")
-    set("scalaVersion", "2.12")
+    set("confluentVersion", "6.0.1")
+    set("scalaVersion", "2.13")
     set("curatorVersion", "2.9.0")
     set("connectUtilsVersion", "0.4+")
 }
 
 dependencies {
-    api("org.apache.kafka:connect-api:${project.extra["kafkaVersion"]}")
+    implementation("org.apache.kafka:connect-api:${project.extra["kafkaVersion"]}")
     implementation("org.mongodb:mongodb-driver-sync:${project.extra["mongodbDriverVersion"]}")
     implementation("org.apache.avro:avro:${project.extra["avroVersion"]}")
 

--- a/src/integrationTest/java/com/mongodb/kafka/connect/FullDocumentRoundTripIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/FullDocumentRoundTripIntegrationTest.java
@@ -247,7 +247,7 @@ public class FullDocumentRoundTripIntegrationTest extends MongoKafkaTestCase {
                       e.getThrowableInformation()
                           .getThrowable()
                           .getMessage()
-                          .equals(
+                          .contains(
                               "Schema being registered is incompatible with an earlier schema")));
     }
   }

--- a/src/integrationTest/java/com/mongodb/kafka/connect/embedded/RestApp.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/embedded/RestApp.java
@@ -19,7 +19,6 @@ package com.mongodb.kafka.connect.embedded;
 
 import java.util.Properties;
 
-import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
@@ -37,47 +36,21 @@ public class RestApp {
   public Server restServer;
   public String restConnect;
 
-  public RestApp(String zkConnect, String kafkaTopic) {
-    this(zkConnect, kafkaTopic, CompatibilityLevel.NONE.name, null);
-  }
-
   public RestApp(
-      String zkConnect,
-      String kafkaTopic,
-      String compatibilityType,
-      Properties schemaRegistryProps) {
-    this(zkConnect, null, kafkaTopic, compatibilityType, true, schemaRegistryProps);
-  }
-
-  public RestApp(
-      String zkConnect,
-      String kafkaTopic,
-      String compatibilityType,
-      boolean masterEligibility,
-      Properties schemaRegistryProps) {
-    this(zkConnect, null, kafkaTopic, compatibilityType, masterEligibility, schemaRegistryProps);
-  }
-
-  public RestApp(
-      String zkConnect,
       String bootstrapBrokers,
       String kafkaTopic,
       String compatibilityType,
-      boolean masterEligibility,
+      boolean leaderEligibility,
       Properties schemaRegistryProps) {
     prop = new Properties();
     if (schemaRegistryProps != null) {
       prop.putAll(schemaRegistryProps);
     }
-    if (zkConnect != null) {
-      prop.setProperty(SchemaRegistryConfig.KAFKASTORE_CONNECTION_URL_CONFIG, zkConnect);
-    }
-    if (bootstrapBrokers != null) {
-      prop.setProperty(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, bootstrapBrokers);
-    }
+
+    prop.setProperty(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, bootstrapBrokers);
     prop.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG, kafkaTopic);
     prop.put(SchemaRegistryConfig.SCHEMA_COMPATIBILITY_CONFIG, compatibilityType);
-    prop.put(SchemaRegistryConfig.MASTER_ELIGIBILITY, masterEligibility);
+    prop.put(SchemaRegistryConfig.LEADER_ELIGIBILITY, leaderEligibility);
   }
 
   public void start() throws Exception {
@@ -107,21 +80,21 @@ public class RestApp {
     prop.putAll(props);
   }
 
-  public boolean isMaster() {
-    return restApp.schemaRegistry().isMaster();
+  public boolean isLeader() {
+    return restApp.schemaRegistry().isLeader();
   }
 
-  public void setMaster(SchemaRegistryIdentity schemaRegistryIdentity)
+  public void setLeader(SchemaRegistryIdentity schemaRegistryIdentity)
       throws SchemaRegistryException {
-    restApp.schemaRegistry().setMaster(schemaRegistryIdentity);
+    restApp.schemaRegistry().setLeader(schemaRegistryIdentity);
   }
 
   public SchemaRegistryIdentity myIdentity() {
     return restApp.schemaRegistry().myIdentity();
   }
 
-  public SchemaRegistryIdentity masterIdentity() {
-    return restApp.schemaRegistry().masterIdentity();
+  public SchemaRegistryIdentity leaderIdentity() {
+    return restApp.schemaRegistry().leaderIdentity();
   }
 
   public SchemaRegistry schemaRegistry() {

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordData.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordData.java
@@ -19,7 +19,6 @@ package com.mongodb.kafka.connect.sink;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +41,7 @@ final class MongoProcessedSinkRecordData {
   private final SinkRecord sinkRecord;
   private final SinkDocument sinkDocument;
   private final WriteModel<BsonDocument> writeModel;
+  private Exception exception;
 
   MongoProcessedSinkRecordData(final SinkRecord sinkRecord, final MongoSinkConfig sinkConfig) {
     this.sinkRecord = sinkRecord;
@@ -64,14 +64,11 @@ final class MongoProcessedSinkRecordData {
   }
 
   public WriteModel<BsonDocument> getWriteModel() {
-    if (writeModel == null) {
-      throw new DataException("Unable to create a valid WriteModel for the SinkRecord");
-    }
     return writeModel;
   }
 
-  public boolean canProcess() {
-    return namespace != null && writeModel != null;
+  public Exception getException() {
+    return exception;
   }
 
   private MongoNamespace createNamespace() {
@@ -106,6 +103,7 @@ final class MongoProcessedSinkRecordData {
     try {
       return supplier.get();
     } catch (Exception e) {
+      exception = e;
       if (config.logErrors()) {
         LOGGER.error("Unable to process record {}", sinkRecord, e);
       }

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordData.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordData.java
@@ -88,7 +88,7 @@ final class MongoProcessedSinkRecordData {
                   .getPostProcessors()
                   .getPostProcessorList()
                   .forEach(pp -> pp.process(sinkDocument, sinkRecord));
-              return WriteModelStrategyHelper.createWriteModel(config, sinkDocument);
+              return Optional.of(WriteModelStrategyHelper.createWriteModel(config, sinkDocument));
             })
         .orElse(null);
   }

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
@@ -457,7 +457,7 @@ public class MongoSinkTopicConfig extends AbstractConfig {
     return Optional.of(deleteOneWriteModelStrategy);
   }
 
-  Optional<CdcHandler> getCdcHandler() {
+  public Optional<CdcHandler> getCdcHandler() {
     String cdcHandler = getString(CHANGE_DATA_CAPTURE_HANDLER_CONFIG);
     if (cdcHandler.isEmpty()) {
       return Optional.empty();

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
@@ -457,7 +457,7 @@ public class MongoSinkTopicConfig extends AbstractConfig {
     return Optional.of(deleteOneWriteModelStrategy);
   }
 
-  public Optional<CdcHandler> getCdcHandler() {
+  Optional<CdcHandler> getCdcHandler() {
     String cdcHandler = getString(CHANGE_DATA_CAPTURE_HANDLER_CONFIG);
     if (cdcHandler.isEmpty()) {
       return Optional.empty();

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/DebeziumCdcHandler.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/DebeziumCdcHandler.java
@@ -20,23 +20,16 @@ package com.mongodb.kafka.connect.sink.cdc.debezium;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
-import java.util.function.Supplier;
 
 import org.apache.kafka.connect.errors.DataException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.bson.BsonDocument;
-
-import com.mongodb.client.model.WriteModel;
 
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
 import com.mongodb.kafka.connect.sink.cdc.CdcHandler;
 import com.mongodb.kafka.connect.sink.cdc.CdcOperation;
 
 public abstract class DebeziumCdcHandler extends CdcHandler {
-  private static final Logger LOGGER = LoggerFactory.getLogger(DebeziumCdcHandler.class);
 
   private static final String OPERATION_TYPE_FIELD_PATH = "op";
 
@@ -67,22 +60,6 @@ public abstract class DebeziumCdcHandler extends CdcHandler {
       return op;
     } catch (IllegalArgumentException exc) {
       throw new DataException("Parsing CDC operation failed", exc);
-    }
-  }
-
-  protected Optional<WriteModel<BsonDocument>> handleOperation(
-      final Supplier<Optional<WriteModel<BsonDocument>>> supplier) {
-    try {
-      return supplier.get();
-    } catch (Exception e) {
-      if (getConfig().logErrors()) {
-        LOGGER.error("Unable to process operation.", e);
-      }
-      if (getConfig().tolerateErrors()) {
-        return Optional.empty();
-      } else {
-        throw e;
-      }
     }
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/OperationType.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/OperationType.java
@@ -18,6 +18,8 @@
 
 package com.mongodb.kafka.connect.sink.cdc.debezium;
 
+import org.apache.kafka.connect.errors.DataException;
+
 public enum OperationType {
   CREATE("c"),
   READ("r"),
@@ -45,7 +47,7 @@ public enum OperationType {
       case "d":
         return DELETE;
       default:
-        throw new IllegalArgumentException("Unknown operation type " + text);
+        throw new DataException("Unknown operation type " + text);
     }
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbHandler.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbHandler.java
@@ -66,12 +66,6 @@ public class MongoDbHandler extends DebeziumCdcHandler {
     BsonDocument keyDoc = doc.getKeyDoc().orElseGet(BsonDocument::new);
 
     if (keyDoc.isEmpty()) {
-      if (getConfig().logErrors()) {
-        LOGGER.error("Key document must not be missing for CDC mode {}", doc);
-      }
-      if (getConfig().tolerateErrors()) {
-        return Optional.empty();
-      }
       throw new DataException("Key document must not be missing for CDC mode");
     }
 
@@ -85,6 +79,6 @@ public class MongoDbHandler extends DebeziumCdcHandler {
     LOGGER.debug("key: " + keyDoc.toString());
     LOGGER.debug("value: " + valueDoc.toString());
 
-    return handleOperation(() -> Optional.of(getCdcOperation(valueDoc).perform(doc)));
+    return Optional.of(getCdcOperation(valueDoc).perform(doc));
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/rdbms/RdbmsHandler.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/rdbms/RdbmsHandler.java
@@ -73,8 +73,7 @@ public class RdbmsHandler extends DebeziumCdcHandler {
       return Optional.empty();
     }
 
-    return handleOperation(
-        () -> Optional.of(getCdcOperation(valueDoc).perform(new SinkDocument(keyDoc, valueDoc))));
+    return Optional.of(getCdcOperation(valueDoc).perform(new SinkDocument(keyDoc, valueDoc)));
   }
 
   static BsonDocument generateFilterDoc(

--- a/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyHelper.java
@@ -16,8 +16,6 @@
 
 package com.mongodb.kafka.connect.sink.writemodel.strategy;
 
-import java.util.Optional;
-
 import org.apache.kafka.connect.errors.DataException;
 
 import org.bson.BsonDocument;
@@ -29,12 +27,12 @@ import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 
 public final class WriteModelStrategyHelper {
 
-  public static Optional<WriteModel<BsonDocument>> createWriteModel(
+  public static WriteModel<BsonDocument> createWriteModel(
       final MongoSinkTopicConfig config, final SinkDocument document) {
     if (document.getValueDoc().isPresent()) {
-      return Optional.of(createValueWriteModel(config, document));
+      return createValueWriteModel(config, document);
     } else if (document.getKeyDoc().isPresent()) {
-      return Optional.of(createKeyDeleteOneModel(config, document));
+      return createKeyDeleteOneModel(config, document);
     } else {
       throw new DataException("Invalid Sink Record neither key doc nor value doc were present");
     }

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordDataTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordDataTest.java
@@ -29,9 +29,9 @@ import static com.mongodb.kafka.connect.sink.SinkTestHelper.createSinkConfig;
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.DataException;
@@ -139,12 +139,12 @@ class MongoProcessedSinkRecordDataTest {
     assertAll(
         "Ensure error tolerance is supported",
         () ->
-            assertFalse(
+            assertNotNull(
                 new MongoProcessedSinkRecordData(
                         INVALID_SINK_RECORD, createSinkConfig(ERRORS_TOLERANCE_CONFIG, "all"))
-                    .canProcess()),
+                    .getException()),
         () ->
-            assertFalse(
+            assertNotNull(
                 new MongoProcessedSinkRecordData(
                         INVALID_SINK_RECORD,
                         createSinkConfig(
@@ -154,9 +154,9 @@ class MongoProcessedSinkRecordDataTest {
                                 "all",
                                 CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
                                 MongoDbHandler.class.getCanonicalName())))
-                    .canProcess()),
+                    .getException()),
         () ->
-            assertFalse(
+            assertNotNull(
                 new MongoProcessedSinkRecordData(
                         SINK_RECORD,
                         createSinkConfig(
@@ -168,7 +168,7 @@ class MongoProcessedSinkRecordDataTest {
                                 FieldPathNamespaceMapper.class.getCanonicalName(),
                                 FIELD_VALUE_COLLECTION_NAMESPACE_MAPPER_CONFIG,
                                 FIELD_NAMESPACE_MAPPER_ERROR_IF_INVALID_CONFIG)))
-                    .canProcess()),
+                    .getException()),
         () ->
             assertThrows(
                 DataException.class,
@@ -204,7 +204,7 @@ class MongoProcessedSinkRecordDataTest {
   void assertWriteModel(
       final MongoProcessedSinkRecordData processedData,
       final ReplaceOneModel<BsonDocument> expectedWriteModel) {
-    assertTrue(processedData.canProcess());
+    assertNull(processedData.getException());
     ReplaceOneModel<BsonDocument> writeModel =
         (ReplaceOneModel<BsonDocument>) processedData.getWriteModel();
     assertEquals(expectedWriteModel.getFilter(), writeModel.getFilter());

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkRecordProcessorTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkRecordProcessorTest.java
@@ -56,7 +56,7 @@ class MongoSinkRecordProcessorTest {
     sinkRecords.addAll(createSinkRecordList("default.topic", 50));
 
     List<List<MongoProcessedSinkRecordData>> processedData =
-        MongoSinkRecordProcessor.orderedGroupByTopicAndNamespace(sinkRecords, sinkConfig);
+        MongoSinkRecordProcessor.orderedGroupByTopicAndNamespace(sinkRecords, sinkConfig, p -> {});
 
     assertEquals(3, processedData.size());
     assertTopicAndNamespace("default.topic", "myDB.default.topic", processedData.get(0));
@@ -77,7 +77,7 @@ class MongoSinkRecordProcessorTest {
     sinkRecords.addAll(createSinkRecordList("alt.topic", 20));
 
     List<List<MongoProcessedSinkRecordData>> processedData =
-        MongoSinkRecordProcessor.orderedGroupByTopicAndNamespace(sinkRecords, sinkConfig);
+        MongoSinkRecordProcessor.orderedGroupByTopicAndNamespace(sinkRecords, sinkConfig, p -> {});
 
     assertEquals(4, processedData.size());
     assertTopicAndNamespace("default.topic", "db.coll.1", processedData.get(0));
@@ -102,7 +102,7 @@ class MongoSinkRecordProcessorTest {
     sinkRecords.addAll(createSinkRecordList("alt.topic", 20));
 
     List<List<MongoProcessedSinkRecordData>> processedData =
-        MongoSinkRecordProcessor.orderedGroupByTopicAndNamespace(sinkRecords, sinkConfig);
+        MongoSinkRecordProcessor.orderedGroupByTopicAndNamespace(sinkRecords, sinkConfig, p -> {});
 
     assertEquals(8, processedData.size());
     assertTopicAndNamespace("default.topic", "db.coll.1", processedData.get(0));
@@ -127,7 +127,7 @@ class MongoSinkRecordProcessorTest {
         () -> {
           List<List<MongoProcessedSinkRecordData>> processedData =
               MongoSinkRecordProcessor.orderedGroupByTopicAndNamespace(
-                  sinkRecords, createSinkConfig(ERRORS_TOLERANCE_CONFIG, "all"));
+                  sinkRecords, createSinkConfig(ERRORS_TOLERANCE_CONFIG, "all"), p -> {});
           assertEquals(1, processedData.size());
           assertEquals(50, processedData.get(0).size());
           assertTopicAndNamespace(TEST_TOPIC, format("myDB.%s", TEST_TOPIC), processedData.get(0));
@@ -137,7 +137,7 @@ class MongoSinkRecordProcessorTest {
                 DataException.class,
                 () ->
                     MongoSinkRecordProcessor.orderedGroupByTopicAndNamespace(
-                        sinkRecords, createSinkConfig())));
+                        sinkRecords, createSinkConfig(), p -> {})));
   }
 
   void assertTopicAndNamespace(

--- a/src/test/java/com/mongodb/kafka/connect/sink/cdc/debezium/OperationTypeTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/cdc/debezium/OperationTypeTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.apache.kafka.connect.errors.DataException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
@@ -73,6 +74,6 @@ class OperationTypeTest {
   @Test
   @DisplayName("when invalid op type IllegalArgumentException")
   void testOperationTypeInvalid() {
-    assertThrows(IllegalArgumentException.class, () -> OperationType.fromText("x"));
+    assertThrows(DataException.class, () -> OperationType.fromText("x"));
   }
 }

--- a/src/test/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbHandlerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbHandlerTest.java
@@ -48,8 +48,6 @@ import com.mongodb.client.model.ReplaceOneModel;
 import com.mongodb.client.model.UpdateOneModel;
 import com.mongodb.client.model.WriteModel;
 
-import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
-import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.ErrorTolerance;
 import com.mongodb.kafka.connect.sink.cdc.debezium.OperationType;
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 
@@ -58,11 +56,6 @@ class MongoDbHandlerTest {
 
   private static final MongoDbHandler HANDLER_DEFAULT_MAPPING =
       new MongoDbHandler(createTopicConfig());
-
-  private static final MongoDbHandler ERROR_TOLERANT_HANDLER =
-      new MongoDbHandler(
-          createTopicConfig(
-              MongoSinkTopicConfig.ERRORS_TOLERANCE_CONFIG, ErrorTolerance.ALL.value()));
 
   @Test
   @DisplayName("verify existing default config from base class")
@@ -102,7 +95,6 @@ class MongoDbHandlerTest {
             new BsonDocument("id", new BsonInt32(1234)),
             new BsonDocument("op", new BsonString("x")));
     assertThrows(DataException.class, () -> HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
-    assertEquals(Optional.empty(), ERROR_TOLERANT_HANDLER.handle(cdcEvent));
   }
 
   @Test
@@ -115,8 +107,6 @@ class MongoDbHandlerTest {
                 .append("after", new BsonString("{_id:1234,foo:\"blah\"}")));
 
     assertThrows(DataException.class, () -> HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
-    Optional<WriteModel<BsonDocument>> handle = ERROR_TOLERANT_HANDLER.handle(cdcEvent);
-    assertEquals(Optional.empty(), handle);
   }
 
   @Test
@@ -128,7 +118,6 @@ class MongoDbHandlerTest {
             new BsonDocument("op", new BsonInt32('c')));
 
     assertThrows(DataException.class, () -> HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
-    assertEquals(Optional.empty(), ERROR_TOLERANT_HANDLER.handle(cdcEvent));
   }
 
   @Test
@@ -139,7 +128,6 @@ class MongoDbHandlerTest {
             new BsonDocument("id", new BsonInt32(1234)), new BsonDocument("po", BsonNull.VALUE));
 
     assertThrows(DataException.class, () -> HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
-    assertEquals(Optional.empty(), ERROR_TOLERANT_HANDLER.handle(cdcEvent));
   }
 
   @TestFactory

--- a/src/test/java/com/mongodb/kafka/connect/sink/cdc/debezium/rdbms/RdbmsHandlerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/cdc/debezium/rdbms/RdbmsHandlerTest.java
@@ -44,8 +44,6 @@ import com.mongodb.client.model.DeleteOneModel;
 import com.mongodb.client.model.ReplaceOneModel;
 import com.mongodb.client.model.WriteModel;
 
-import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
-import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.ErrorTolerance;
 import com.mongodb.kafka.connect.sink.cdc.debezium.OperationType;
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 
@@ -53,10 +51,6 @@ import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 class RdbmsHandlerTest {
   private static final RdbmsHandler RDBMS_HANDLER_DEFAULT_MAPPING =
       new RdbmsHandler(createTopicConfig());
-  private static final RdbmsHandler ERROR_TOLERANT_HANDLER =
-      new RdbmsHandler(
-          createTopicConfig(
-              MongoSinkTopicConfig.ERRORS_TOLERANCE_CONFIG, ErrorTolerance.ALL.value()));
 
   @Test
   @DisplayName("verify existing default config from base class")
@@ -98,7 +92,6 @@ class RdbmsHandlerTest {
     SinkDocument cdcEvent =
         new SinkDocument(BsonDocument.parse("{id: 1234}"), BsonDocument.parse("{op: 'x'}"));
     assertThrows(DataException.class, () -> RDBMS_HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
-    assertEquals(Optional.empty(), ERROR_TOLERANT_HANDLER.handle(cdcEvent));
   }
 
   @Test
@@ -109,7 +102,6 @@ class RdbmsHandlerTest {
             BsonDocument.parse("{id: 1234}"),
             BsonDocument.parse("{op: 'z', after: {id: 1234, foo: 'bar'}}"));
     assertThrows(DataException.class, () -> RDBMS_HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
-    assertEquals(Optional.empty(), ERROR_TOLERANT_HANDLER.handle(cdcEvent));
   }
 
   @Test
@@ -118,7 +110,6 @@ class RdbmsHandlerTest {
     SinkDocument cdcEvent =
         new SinkDocument(BsonDocument.parse("{id: 1234}"), BsonDocument.parse("{op: 'c'}"));
     assertThrows(DataException.class, () -> RDBMS_HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
-    assertEquals(Optional.empty(), ERROR_TOLERANT_HANDLER.handle(cdcEvent));
   }
 
   @Test
@@ -127,7 +118,6 @@ class RdbmsHandlerTest {
     SinkDocument cdcEvent =
         new SinkDocument(BsonDocument.parse("{id: 1234}"), BsonDocument.parse("{op: null}"));
     assertThrows(DataException.class, () -> RDBMS_HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
-    assertEquals(Optional.empty(), ERROR_TOLERANT_HANDLER.handle(cdcEvent));
   }
 
   @Test
@@ -136,7 +126,6 @@ class RdbmsHandlerTest {
     SinkDocument cdcEvent =
         new SinkDocument(BsonDocument.parse("{id: 1234}"), BsonDocument.parse("{po: null}"));
     assertThrows(DataException.class, () -> RDBMS_HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
-    assertEquals(Optional.empty(), ERROR_TOLERANT_HANDLER.handle(cdcEvent));
   }
 
   @TestFactory


### PR DESCRIPTION
This PR has two commits: 

* The first updates the Kafka version to one that supports the errant record reporter and updates some of the testing framework
* The second adds errant record reporting if available. This caused some extra refactoring to centralize the error reporting. Now the MongoSinkRecordProcessor handles errors and reporting of them.
