### PR TITLE
Improved the usability of the Source connector heartbeat mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Improvements
   - [KAFKA-168](https://jira.mongodb.org/browse/KAFKA-168) Added DeleteOneBusinessKeyStrategy for topics containing records to removed from MongoDB.
   - [KAFKA-183](https://jira.mongodb.org/browse/KAFKA-183) Added support for the errant record reporter if available.
+  - [KAFKA-176](https://jira.mongodb.org/browse/KAFKA-176) Improved heartbeat usability. Added `heartbeat.bootstrap.servers` configuration to
+    automatically consume heartbeats.
 
 ### Bug Fixes
   - [KAFKA-195](https://jira.mongodb.org/browse/KAFKA-195) Fixed topics.regex sink validation issue for synthetic config property

--- a/src/integrationTest/java/com/mongodb/kafka/connect/MongoSourceConnectorIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/MongoSourceConnectorIntegrationTest.java
@@ -335,8 +335,9 @@ public class MongoSourceConnectorIntegrationTest extends MongoKafkaTestCase {
   }
 
   @Test
-  @DisplayName("Ensure Source uses heartbeats for creating offsets and can automatically")
-  void testSourceUsesHeartbeatsForOffsets() {
+  @DisplayName(
+      "Ensure Source uses heartbeats for creating offsets and can automatically process them")
+  void testSourceUsesHeartbeatsForOffsetsAutomaticProcessing() {
     assumeTrue(isGreaterThanFourDotZero());
     try (LogCapture logCapture = new LogCapture(Logger.getLogger(MongoSourceTask.class))) {
       MongoCollection<Document> coll = getAndCreateCollection();

--- a/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
@@ -590,6 +590,7 @@ public class MongoSourceTaskIntegrationTest extends MongoKafkaTestCase {
               put(MongoSourceConfig.HEARTBEAT_TOPIC_NAME_CONFIG, "heartBeatTopic");
               put(MongoSourceConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "1000");
               put(MongoSourceConfig.POLL_MAX_BATCH_SIZE_CONFIG, "10");
+              put(MongoSourceConfig.HEARTBEAT_BOOTSTRAP_SERVERS_CONFIG, KAFKA.bootstrapServers());
             }
           };
 

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -30,6 +30,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.apache.kafka.common.config.ConfigDef.Width;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -314,6 +315,12 @@ public class MongoSourceConfig extends AbstractConfig {
           + " Defaults to '"
           + HEARTBEAT_TOPIC_NAME_DEFAULT
           + "'.";
+  public static final String HEARTBEAT_BOOTSTRAP_SERVERS_CONFIG = "heartbeat.bootstrap.servers";
+  private static final String HEARTBEAT_BOOTSTRAP_SERVERS_DISPLAY =
+      "The bootstrap servers for automatically consuming heartbeat events.";
+  private static final String HEARTBEAT_BOOTSTRAP_SERVERS_DOC =
+      "For consuming heartbeat events. The list of host/port pairs required for establishing "
+          + "the initial connection to the Kafka cluster by the heartbeat event consumer.";
 
   public static final String OFFSET_PARTITION_NAME_CONFIG = "offset.partition.name";
   public static final String OFFSET_PARTITION_NAME_DISPLAY = "Offset partition name";
@@ -836,6 +843,18 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         HEARTBEAT_TOPIC_NAME_DISPLAY);
+
+    configDef.define(
+        HEARTBEAT_BOOTSTRAP_SERVERS_CONFIG,
+        Type.LIST,
+        Collections.emptyList(),
+        new ConfigDef.NonNullValidator(),
+        Importance.MEDIUM,
+        HEARTBEAT_BOOTSTRAP_SERVERS_DOC,
+        group,
+        ++orderInGroup,
+        Width.MEDIUM,
+        HEARTBEAT_BOOTSTRAP_SERVERS_DISPLAY);
 
     group = "Partition";
     orderInGroup = 0;

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -21,6 +21,7 @@ import static com.mongodb.kafka.connect.source.MongoSourceConfig.CONNECTION_URI_
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COPY_EXISTING_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.DATABASE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.HEARTBEAT_BOOTSTRAP_SERVERS_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.HEARTBEAT_INTERVAL_MS_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.HEARTBEAT_TOPIC_NAME_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_AWAIT_TIME_MS_CONFIG;
@@ -348,6 +349,7 @@ public final class MongoSourceTask extends SourceTask {
             cursor,
             sourceConfig.getLong(HEARTBEAT_INTERVAL_MS_CONFIG),
             sourceConfig.getString(HEARTBEAT_TOPIC_NAME_CONFIG),
+            sourceConfig.getList(HEARTBEAT_BOOTSTRAP_SERVERS_CONFIG),
             partitionMap);
   }
 

--- a/src/main/java/com/mongodb/kafka/connect/source/heartbeat/HeartbeatConsumer.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/heartbeat/HeartbeatConsumer.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.source.heartbeat;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.kafka.clients.consumer.CommitFailedException;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.utils.Bytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class HeartbeatConsumer implements Runnable {
+  private static final Logger LOGGER = LoggerFactory.getLogger(HeartbeatConsumer.class);
+  private static final String CONSUMER_GROUP_ID = "MONGODB_SOURCE_HEARTBEAT";
+  private static final String CONSUMER_DESERIALIZER =
+      "org.apache.kafka.common.serialization.BytesDeserializer";
+
+  private final AtomicBoolean running;
+  private final KafkaConsumer<Bytes, Bytes> consumer;
+  private final String heartbeatTopicName;
+  private final long heartbeatIntervalMS;
+
+  HeartbeatConsumer(
+      final List<String> bootStrapServers,
+      final long heartbeatIntervalMS,
+      final String heartbeatTopicName) {
+    this.consumer = tryCreateConsumer(String.join(",", bootStrapServers)).orElse(null);
+    this.heartbeatIntervalMS = heartbeatIntervalMS;
+    this.heartbeatTopicName = heartbeatTopicName;
+    this.running = new AtomicBoolean(false);
+    if (consumer != null) {
+      new Thread(this).start();
+      LOGGER.info("Start heartbeat offset consumer");
+    }
+  }
+
+  public void run() {
+    running.set(true);
+    consumer.subscribe(Collections.singleton(heartbeatTopicName));
+    Duration pollDuration = Duration.ofMillis(heartbeatIntervalMS);
+    try {
+      while (running.get()) {
+        if (!consumer.poll(pollDuration).isEmpty()) {
+          try {
+            LOGGER.info("Syncing heartbeat offsets");
+            consumer.commitSync();
+          } catch (CommitFailedException e) {
+            // ignore any superseded commits by the connector
+          }
+        }
+      }
+    } catch (WakeupException e) {
+      // Ignore exception if closing
+      if (!running.get()) {
+        throw e;
+      }
+    } catch (Exception e) {
+      LOGGER.error("Heartbeat consumer exception", e);
+    } finally {
+      consumer.close();
+    }
+  }
+
+  public void shutdown() {
+    running.set(false);
+    if (consumer != null) {
+      consumer.wakeup();
+    }
+  }
+
+  private static Optional<KafkaConsumer<Bytes, Bytes>> tryCreateConsumer(
+      final String bootStrapServers) {
+    Properties props = new Properties();
+    props.setProperty("bootstrap.servers", bootStrapServers);
+    props.setProperty("group.id", CONSUMER_GROUP_ID);
+    props.setProperty("enable.auto.commit", "true");
+    props.setProperty("key.deserializer", CONSUMER_DESERIALIZER);
+    props.setProperty("value.deserializer", CONSUMER_DESERIALIZER);
+
+    try {
+      return Optional.of(new KafkaConsumer<>(props));
+    } catch (Exception e) {
+      LOGGER.error("Unable to create Heartbeat consumer", e);
+      return Optional.empty();
+    }
+  }
+}

--- a/src/main/java/com/mongodb/kafka/connect/source/heartbeat/HeartbeatManager.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/heartbeat/HeartbeatManager.java
@@ -104,7 +104,7 @@ public class HeartbeatManager implements AutoCloseable {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     if (!isClosed.getAndSet(true) && heartbeatConsumer != null) {
       heartbeatConsumer.shutdown();
     }

--- a/src/main/java/com/mongodb/kafka/connect/source/heartbeat/HeartbeatManager.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/heartbeat/HeartbeatManager.java
@@ -18,19 +18,12 @@ package com.mongodb.kafka.connect.source.heartbeat;
 
 import static com.mongodb.kafka.connect.source.MongoSourceTask.ID_FIELD;
 
-import java.time.Duration;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.kafka.clients.consumer.CommitFailedException;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.common.errors.WakeupException;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -43,10 +36,6 @@ import com.mongodb.client.MongoChangeStreamCursor;
 
 public class HeartbeatManager implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(HeartbeatManager.class);
-  private static final String CONSUMER_GROUP_ID = "MONGODB_SOURCE_HEARTBEAT";
-  private static final String CONSUMER_DESERIALIZER =
-      "org.apache.kafka.common.serialization.BytesDeserializer";
-
   public static final String HEARTBEAT_KEY = "HEARTBEAT";
   private final Time time;
   private final MongoChangeStreamCursor<? extends BsonDocument> cursor;
@@ -75,7 +64,7 @@ public class HeartbeatManager implements AutoCloseable {
     this.canCreateHeartbeat = cursor != null && heartbeatIntervalMS > 0;
     this.heartbeatConsumer =
         canCreateHeartbeat && !bootstrapServers.isEmpty()
-            ? new HeartbeatConsumer(bootstrapServers)
+            ? new HeartbeatConsumer(bootstrapServers, heartbeatIntervalMS, heartbeatTopicName)
             : null;
   }
 
@@ -118,70 +107,6 @@ public class HeartbeatManager implements AutoCloseable {
   public void close() throws Exception {
     if (!isClosed.getAndSet(true) && heartbeatConsumer != null) {
       heartbeatConsumer.shutdown();
-    }
-  }
-
-  public class HeartbeatConsumer implements Runnable {
-    private final AtomicBoolean running;
-    private final KafkaConsumer<Bytes, Bytes> consumer;
-
-    public HeartbeatConsumer(final List<String> bootStrapServers) {
-      this.consumer = tryCreateConsumer(String.join(",", bootStrapServers)).orElse(null);
-      this.running = new AtomicBoolean(false);
-      if (consumer != null) {
-        new Thread(this).start();
-        LOGGER.info("Start heartbeat offset consumer");
-      }
-    }
-
-    public void run() {
-      running.set(true);
-      consumer.subscribe(Collections.singleton(heartbeatTopicName));
-      Duration pollDuration = Duration.ofMillis(heartbeatIntervalMS);
-      try {
-        while (running.get()) {
-          if (!consumer.poll(pollDuration).isEmpty()) {
-            try {
-              LOGGER.info("Syncing heartbeat offsets");
-              consumer.commitSync();
-            } catch (CommitFailedException e) {
-              // ignore any superseded commits by the connector
-            }
-          }
-        }
-      } catch (WakeupException e) {
-        // Ignore exception if closing
-        if (!running.get()) {
-          throw e;
-        }
-      } catch (Exception e) {
-        LOGGER.error("Heartbeat consumer exception", e);
-      } finally {
-        consumer.close();
-      }
-    }
-
-    public void shutdown() {
-      running.set(false);
-      if (consumer != null) {
-        consumer.wakeup();
-      }
-    }
-  }
-
-  private Optional<KafkaConsumer<Bytes, Bytes>> tryCreateConsumer(final String bootStrapServers) {
-    Properties props = new Properties();
-    props.setProperty("bootstrap.servers", bootStrapServers);
-    props.setProperty("group.id", CONSUMER_GROUP_ID);
-    props.setProperty("enable.auto.commit", "true");
-    props.setProperty("key.deserializer", CONSUMER_DESERIALIZER);
-    props.setProperty("value.deserializer", CONSUMER_DESERIALIZER);
-
-    try {
-      return Optional.of(new KafkaConsumer<>(props));
-    } catch (Exception e) {
-      LOGGER.error("Unable to create Heartbeat consumer", e);
-      return Optional.empty();
     }
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/source/heartbeat/HeartbeatManager.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/heartbeat/HeartbeatManager.java
@@ -18,10 +18,19 @@ package com.mongodb.kafka.connect.source.heartbeat;
 
 import static com.mongodb.kafka.connect.source.MongoSourceTask.ID_FIELD;
 
+import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.kafka.clients.consumer.CommitFailedException;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -32,31 +41,42 @@ import org.bson.BsonDocument;
 
 import com.mongodb.client.MongoChangeStreamCursor;
 
-public class HeartbeatManager {
+public class HeartbeatManager implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(HeartbeatManager.class);
+  private static final String CONSUMER_GROUP_ID = "MONGODB_SOURCE_HEARTBEAT";
+  private static final String CONSUMER_DESERIALIZER =
+      "org.apache.kafka.common.serialization.BytesDeserializer";
+
   public static final String HEARTBEAT_KEY = "HEARTBEAT";
   private final Time time;
-  private final String heartbeatTopicName;
   private final MongoChangeStreamCursor<? extends BsonDocument> cursor;
+  private final String heartbeatTopicName;
   private final long heartbeatIntervalMS;
   private final Map<String, Object> partitionMap;
   private final boolean canCreateHeartbeat;
+  private final AtomicBoolean isClosed = new AtomicBoolean(false);
+  private final HeartbeatConsumer heartbeatConsumer;
 
-  private volatile long lastHeartbeatMS = 0;
-  private volatile String lastResumeToken = "";
+  private long lastHeartbeatMS = 0;
+  private String lastResumeToken = "";
 
   public HeartbeatManager(
       final Time time,
       final MongoChangeStreamCursor<? extends BsonDocument> cursor,
       final long heartbeatIntervalMS,
       final String heartbeatTopicName,
+      final List<String> bootstrapServers,
       final Map<String, Object> partitionMap) {
     this.time = time;
-    this.heartbeatTopicName = heartbeatTopicName;
     this.cursor = cursor;
     this.heartbeatIntervalMS = heartbeatIntervalMS;
+    this.heartbeatTopicName = heartbeatTopicName;
     this.partitionMap = partitionMap;
     this.canCreateHeartbeat = cursor != null && heartbeatIntervalMS > 0;
+    this.heartbeatConsumer =
+        canCreateHeartbeat && !bootstrapServers.isEmpty()
+            ? new HeartbeatConsumer(bootstrapServers)
+            : null;
   }
 
   public Optional<SourceRecord> heartbeat() {
@@ -92,5 +112,76 @@ public class HeartbeatManager {
               });
     }
     return Optional.empty();
+  }
+
+  @Override
+  public void close() throws Exception {
+    if (!isClosed.getAndSet(true) && heartbeatConsumer != null) {
+      heartbeatConsumer.shutdown();
+    }
+  }
+
+  public class HeartbeatConsumer implements Runnable {
+    private final AtomicBoolean running;
+    private final KafkaConsumer<Bytes, Bytes> consumer;
+
+    public HeartbeatConsumer(final List<String> bootStrapServers) {
+      this.consumer = tryCreateConsumer(String.join(",", bootStrapServers)).orElse(null);
+      this.running = new AtomicBoolean(false);
+      if (consumer != null) {
+        new Thread(this).start();
+        LOGGER.info("Start heartbeat offset consumer");
+      }
+    }
+
+    public void run() {
+      running.set(true);
+      consumer.subscribe(Collections.singleton(heartbeatTopicName));
+      Duration pollDuration = Duration.ofMillis(heartbeatIntervalMS);
+      try {
+        while (running.get()) {
+          if (!consumer.poll(pollDuration).isEmpty()) {
+            try {
+              LOGGER.info("Syncing heartbeat offsets");
+              consumer.commitSync();
+            } catch (CommitFailedException e) {
+              // ignore any superseded commits by the connector
+            }
+          }
+        }
+      } catch (WakeupException e) {
+        // Ignore exception if closing
+        if (!running.get()) {
+          throw e;
+        }
+      } catch (Exception e) {
+        LOGGER.error("Heartbeat consumer exception", e);
+      } finally {
+        consumer.close();
+      }
+    }
+
+    public void shutdown() {
+      running.set(false);
+      if (consumer != null) {
+        consumer.wakeup();
+      }
+    }
+  }
+
+  private Optional<KafkaConsumer<Bytes, Bytes>> tryCreateConsumer(final String bootStrapServers) {
+    Properties props = new Properties();
+    props.setProperty("bootstrap.servers", bootStrapServers);
+    props.setProperty("group.id", CONSUMER_GROUP_ID);
+    props.setProperty("enable.auto.commit", "true");
+    props.setProperty("key.deserializer", CONSUMER_DESERIALIZER);
+    props.setProperty("value.deserializer", CONSUMER_DESERIALIZER);
+
+    try {
+      return Optional.of(new KafkaConsumer<>(props));
+    } catch (Exception e) {
+      LOGGER.error("Unable to create Heartbeat consumer", e);
+      return Optional.empty();
+    }
   }
 }


### PR DESCRIPTION
Added the `heartbeat.bootstrap.servers` configuration so that
the HeartbeatManager can also consume heartbeat messages and
automatically update the offset.

Allowing the change stream postBatchResumeToken to be automatically
generated and consumed. On restart the latest seen offset (resumeToken)
will be used as the starting point for the new change stream cursor.

KAFKA-1767