### PR TITLE
K210

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Bug Fixes
   - [KAFKA-195](https://jira.mongodb.org/browse/KAFKA-195) Fixed topics.regex sink validation issue for synthetic config property
   - [KAFKA-203](https://jira.mongodb.org/browse/KAFKA-203) Fixed sink NPE issue when using with confluent connect 6.1.0
+  - [KAFKA-210](https://jira.mongodb.org/browse/KAFKA-210) Fix inferred schema naming convention and ensure schemas will be backwards compatible.
 
 ## 1.4.0
 

--- a/src/main/java/com/mongodb/kafka/connect/source/producer/InferSchemaAndValueProducer.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/producer/InferSchemaAndValueProducer.java
@@ -35,6 +35,6 @@ final class InferSchemaAndValueProducer implements SchemaAndValueProducer {
   @Override
   public SchemaAndValue get(final BsonDocument changeStreamDocument) {
     return bsonValueToSchemaAndValue.toSchemaAndValue(
-        inferDocumentSchema(changeStreamDocument, false, "default"), changeStreamDocument);
+        inferDocumentSchema(changeStreamDocument), changeStreamDocument);
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/source/producer/InferSchemaAndValueProducer.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/producer/InferSchemaAndValueProducer.java
@@ -35,6 +35,6 @@ final class InferSchemaAndValueProducer implements SchemaAndValueProducer {
   @Override
   public SchemaAndValue get(final BsonDocument changeStreamDocument) {
     return bsonValueToSchemaAndValue.toSchemaAndValue(
-        inferDocumentSchema(changeStreamDocument, false), changeStreamDocument);
+        inferDocumentSchema(changeStreamDocument, false, "default"), changeStreamDocument);
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
@@ -36,23 +36,24 @@ public final class BsonDocumentToSchema {
   private static final Schema DEFAULT_INFER_SCHEMA_TYPE = Schema.OPTIONAL_STRING_SCHEMA;
   public static final String SCHEMA_NAME_TEMPLATE = "inferred_name_%s";
 
-  public static Schema inferDocumentSchema(final BsonDocument document, final boolean optional) {
+  public static Schema inferDocumentSchema(
+      final BsonDocument document, final boolean optional, final String fieldName) {
     SchemaBuilder builder = SchemaBuilder.struct();
     if (document.containsKey(ID_FIELD)) {
-      builder.field(ID_FIELD, inferSchema(document.get(ID_FIELD)));
+      builder.field(ID_FIELD, inferSchema(document.get(ID_FIELD), ID_FIELD));
     }
     document.entrySet().stream()
         .filter(kv -> !kv.getKey().equals(ID_FIELD))
         .sorted(Map.Entry.comparingByKey())
-        .forEach(kv -> builder.field(kv.getKey(), inferSchema(kv.getValue())));
-    builder.name(generateName(builder));
+        .forEach(kv -> builder.field(kv.getKey(), inferSchema(kv.getValue(), kv.getKey())));
+    builder.name(generateName(builder, fieldName));
     if (optional) {
       builder.optional();
     }
     return builder.build();
   }
 
-  public static Schema inferSchema(final BsonValue bsonValue) {
+  public static Schema inferSchema(final BsonValue bsonValue, final String fieldName) {
     switch (bsonValue.getBsonType()) {
       case BOOLEAN:
         return Schema.OPTIONAL_BOOLEAN_SCHEMA;
@@ -70,16 +71,17 @@ public final class BsonDocumentToSchema {
       case TIMESTAMP:
         return Timestamp.builder().optional().build();
       case DOCUMENT:
-        return inferDocumentSchema(bsonValue.asDocument(), true);
+        return inferDocumentSchema(bsonValue.asDocument(), true, fieldName);
       case ARRAY:
         List<BsonValue> values = bsonValue.asArray().getValues();
         Schema firstItemSchema =
-            values.isEmpty() ? DEFAULT_INFER_SCHEMA_TYPE : inferSchema(values.get(0));
+            values.isEmpty() ? DEFAULT_INFER_SCHEMA_TYPE : inferSchema(values.get(0), fieldName);
         if (values.isEmpty()
-            || values.stream().anyMatch(bv -> !Objects.equals(inferSchema(bv), firstItemSchema))) {
+            || values.stream()
+                .anyMatch(bv -> !Objects.equals(inferSchema(bv, fieldName), firstItemSchema))) {
           return SchemaBuilder.array(DEFAULT_INFER_SCHEMA_TYPE).optional().build();
         }
-        return SchemaBuilder.array(inferSchema(bsonValue.asArray().getValues().get(0)))
+        return SchemaBuilder.array(inferSchema(bsonValue.asArray().getValues().get(0), fieldName))
             .optional()
             .build();
       case BINARY:
@@ -101,8 +103,9 @@ public final class BsonDocumentToSchema {
     }
   }
 
-  public static String generateName(final SchemaBuilder builder) {
-    return format(SCHEMA_NAME_TEMPLATE, Objects.hashCode(builder.build())).replace("-", "_");
+  public static String generateName(final SchemaBuilder builder, final String fieldName) {
+    builder.build();
+    return format(SCHEMA_NAME_TEMPLATE, fieldName);
   }
 
   private BsonDocumentToSchema() {}

--- a/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
@@ -156,6 +156,7 @@ public class SchemaAndValueProducerTest {
   @DisplayName("test infer schema and value producer")
   void testInferSchemaAndValueProducer() {
 
+    String fieldName = "default";
     Schema expectedSchema =
         nameAndBuildSchema(
             SchemaBuilder.struct()
@@ -163,7 +164,8 @@ public class SchemaAndValueProducerTest {
                     "arrayComplex",
                     SchemaBuilder.array(
                             nameAndBuildOptionalSchema(
-                                SchemaBuilder.struct().field("a", Schema.OPTIONAL_INT32_SCHEMA)))
+                                SchemaBuilder.struct().field("a", Schema.OPTIONAL_INT32_SCHEMA),
+                                "a"))
                         .optional()
                         .build())
                 .field(
@@ -187,7 +189,8 @@ public class SchemaAndValueProducerTest {
                 .field(
                     "document",
                     nameAndBuildOptionalSchema(
-                        SchemaBuilder.struct().field("a", Schema.OPTIONAL_INT32_SCHEMA)))
+                        SchemaBuilder.struct().field("a", Schema.OPTIONAL_INT32_SCHEMA),
+                        "document"))
                 .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
                 .field("int32", Schema.OPTIONAL_INT32_SCHEMA)
                 .field("int64", Schema.OPTIONAL_INT64_SCHEMA)
@@ -199,7 +202,8 @@ public class SchemaAndValueProducerTest {
                 .field("string", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("symbol", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("timestamp", Timestamp.builder().optional().build())
-                .field("undefined", Schema.OPTIONAL_STRING_SCHEMA));
+                .field("undefined", Schema.OPTIONAL_STRING_SCHEMA),
+            fieldName);
 
     Schema arrayComplexValueSchema = expectedSchema.field("arrayComplex").schema().valueSchema();
     Schema documentSchema = expectedSchema.field("document").schema();
@@ -336,12 +340,12 @@ public class SchemaAndValueProducerTest {
     };
   }
 
-  static Schema nameAndBuildSchema(final SchemaBuilder builder) {
-    return builder.name(generateName(builder)).build();
+  static Schema nameAndBuildSchema(final SchemaBuilder builder, final String fieldName) {
+    return builder.name(generateName(builder, fieldName)).build();
   }
 
-  static Schema nameAndBuildOptionalSchema(final SchemaBuilder builder) {
-    return builder.name(generateName(builder)).optional().build();
+  static Schema nameAndBuildOptionalSchema(final SchemaBuilder builder, final String fieldName) {
+    return builder.name(generateName(builder, fieldName)).optional().build();
   }
 
   static String getFullDocument(final boolean simplified) {

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/SchemaUtils.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/SchemaUtils.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -57,6 +58,11 @@ public final class SchemaUtils {
       // Doing equals on Struct just tests instance equals and not the actual values
       return getStructData((Struct) value);
     }
+
+    if (value instanceof List<?>) {
+      // List values can contain Structs which need converting
+      return getListData((List<?>) value);
+    }
     return value;
   }
 
@@ -72,6 +78,10 @@ public final class SchemaUtils {
     List<Object> structValues = new ArrayList<>();
     value.schema().fields().forEach(f -> structValues.add(convertData(value.get(f))));
     return structValues;
+  }
+
+  private static List<?> getListData(final List<?> value) {
+    return value.stream().map(SchemaUtils::convertData).collect(Collectors.toList());
   }
 
   public static void assertSchemaEquals(final Schema expected, final Schema actual) {


### PR DESCRIPTION

This includes #65 and ensures that the naming convention uses the field name of the parent object.

So the following object with produce the following names:

```
{a: {b: {c: [123]}}}
```

* "default": `{a: {b: {c: [123]}}}`
* "a": `{b: {c: [123]}}`
* "a_b": `{c: [123]}`
* "a_b_c": `[123]`
