### PR TITLE
KAFKA-215: Add override options for error handling properties

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -280,12 +280,20 @@ public class MongoSourceConfig extends AbstractConfig {
           + "and signals that any error will result in an immediate connector task failure; 'all' "
           + "changes the behavior to skip over problematic records.";
 
+  public static final String OVERRIDE_ERRORS_TOLERANCE_CONFIG = "mongo.errors.tolerance";
+  public static final String OVERRIDE_ERRORS_TOLERANCE_DOC =
+      "Use this property if you would like to configure the connector's error handling behavior differently from the Connect framework's.";
+
   public static final String ERRORS_LOG_ENABLE_CONFIG = "errors.log.enable";
   public static final String ERRORS_LOG_ENABLE_DISPLAY = "Log Errors";
   public static final boolean ERRORS_LOG_ENABLE_DEFAULT = false;
   public static final String ERRORS_LOG_ENABLE_DOC =
       "If true, write each error and the details of the failed operation and problematic record "
           + "to the Connect application log. This is 'false' by default, so that only errors that are not tolerated are reported.";
+
+  public static final String OVERRIDE_ERRORS_LOG_ENABLE_CONFIG = "mongo.errors.log.enable";
+  public static final String OVERRIDE_ERRORS_LOG_ENABLE_DOC =
+      "Use this property if you would like to configure the connector's error handling behavior differently from the Connect framework's.";
 
   public static final String ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG =
       "errors.deadletterqueue.topic.name";
@@ -297,6 +305,11 @@ public class MongoSourceConfig extends AbstractConfig {
           + "Stops poison messages when using schemas, any message will be outputted as extended json on the specified topic. "
           + "By default messages are not outputted to the dead letter queue. "
           + "Also requires `errors.tolerance=all`.";
+
+  public static final String OVERRIDE_ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG =
+      "mongo.errors.deadletterqueue.topic.name";
+  public static final String LEGACY_ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_DOC =
+      "Use this property if you would like to configure the connector's error handling behavior differently from the Connect framework's.";
 
   public static final String HEARTBEAT_INTERVAL_MS_CONFIG = "heartbeat.interval.ms";
   private static final String HEARTBEAT_INTERVAL_MS_DISPLAY = "Heartbeat interval";
@@ -424,13 +437,23 @@ public class MongoSourceConfig extends AbstractConfig {
         .getJsonWriterSettings();
   }
 
-  public boolean logErrors() {
-    return !tolerateErrors() || getBoolean(ERRORS_LOG_ENABLE_CONFIG);
+  @SuppressWarnings("deprecated")
+  public boolean tolerateErrors() {
+    String errorsTolerance = ConfigHelper.getOverrideOrFallback(
+            this, AbstractConfig::getString, OVERRIDE_ERRORS_TOLERANCE_CONFIG, ERRORS_TOLERANCE_CONFIG);
+    return ErrorTolerance.valueOf(errorsTolerance.toUpperCase()).equals(ErrorTolerance.ALL);
   }
 
-  public boolean tolerateErrors() {
-    return ErrorTolerance.valueOf(getString(ERRORS_TOLERANCE_CONFIG).toUpperCase())
-        .equals(ErrorTolerance.ALL);
+  public boolean logErrors() {
+    return !tolerateErrors()
+        || ConfigHelper.getOverrideOrFallback(
+            this, AbstractConfig::getBoolean, OVERRIDE_ERRORS_LOG_ENABLE_CONFIG, ERRORS_LOG_ENABLE_CONFIG);
+  }
+
+  public String getDlqTopic() {
+    return ConfigHelper.getOverrideOrFallback(
+        this, AbstractConfig::getString,
+        OVERRIDE_ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG, ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG);
   }
 
   private <T extends Configurable> T configureInstance(final T instance) {
@@ -792,6 +815,17 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.SHORT,
         ERRORS_TOLERANCE_DISPLAY);
+    configDef.define(
+        OVERRIDE_ERRORS_TOLERANCE_CONFIG,
+        Type.STRING,
+        ERRORS_TOLERANCE_DEFAULT.value(),
+        Validators.EnumValidatorAndRecommender.in(ErrorTolerance.values()),
+        Importance.MEDIUM,
+        OVERRIDE_ERRORS_TOLERANCE_DOC,
+        group,
+        ++orderInGroup,
+        Width.SHORT,
+        ERRORS_TOLERANCE_DISPLAY);
 
     configDef.define(
         ERRORS_LOG_ENABLE_CONFIG,
@@ -803,6 +837,16 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.SHORT,
         ERRORS_LOG_ENABLE_DISPLAY);
+    configDef.define(
+        OVERRIDE_ERRORS_LOG_ENABLE_CONFIG,
+        Type.BOOLEAN,
+        ERRORS_LOG_ENABLE_DEFAULT,
+        Importance.MEDIUM,
+        OVERRIDE_ERRORS_LOG_ENABLE_DOC,
+        group,
+        ++orderInGroup,
+        Width.SHORT,
+        ERRORS_LOG_ENABLE_DISPLAY);
 
     configDef.define(
         ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG,
@@ -810,6 +854,16 @@ public class MongoSourceConfig extends AbstractConfig {
         ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_DEFAULT,
         Importance.MEDIUM,
         ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_DOC,
+        group,
+        ++orderInGroup,
+        Width.SHORT,
+        ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_DISPLAY);
+    configDef.define(
+        OVERRIDE_ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG,
+        Type.STRING,
+        ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_DEFAULT,
+        Importance.MEDIUM,
+        LEGACY_ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_DOC,
         group,
         ++orderInGroup,
         Width.SHORT,

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -20,7 +20,6 @@ import static com.mongodb.kafka.connect.source.MongoSourceConfig.COLLECTION_CONF
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.CONNECTION_URI_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COPY_EXISTING_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.DATABASE_CONFIG;
-import static com.mongodb.kafka.connect.source.MongoSourceConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.HEARTBEAT_INTERVAL_MS_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.HEARTBEAT_TOPIC_NAME_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_AWAIT_TIME_MS_CONFIG;
@@ -303,14 +302,14 @@ public final class MongoSourceTask extends SourceTask {
         LOGGER.error(errorMessage.get(), e);
       }
       if (sourceConfig.tolerateErrors()) {
-        if (sourceConfig.getString(ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG).isEmpty()) {
+        if (sourceConfig.getDlqTopic().isEmpty()) {
           return Optional.empty();
         }
         return Optional.of(
             new SourceRecord(
                 partition,
                 sourceOffset,
-                sourceConfig.getString(ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG),
+                sourceConfig.getDlqTopic(),
                 Schema.STRING_SCHEMA,
                 keyDocument.toJson(),
                 Schema.STRING_SCHEMA,

--- a/src/main/java/com/mongodb/kafka/connect/util/ConfigHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/ConfigHelper.java
@@ -19,6 +19,7 @@ import static java.lang.String.format;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BiFunction;
 
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigException;
@@ -152,5 +153,13 @@ public final class ConfigHelper {
       stringConfig = config.getString(defaultConfig);
     }
     return stringConfig;
+  }
+
+  public static <T> T getOverrideOrFallback(
+      final AbstractConfig config, final BiFunction<AbstractConfig, String, T> getter,
+      final String overrideProperty, final String defaultProperty) {
+    String propertyToRead =
+        config.originals().containsKey(overrideProperty) ? overrideProperty : defaultProperty;
+    return getter.apply(config, propertyToRead);
   }
 }

--- a/src/test/java/com/mongodb/kafka/connect/source/MongoSourceConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/MongoSourceConfigTest.java
@@ -22,6 +22,7 @@ import static com.mongodb.kafka.connect.source.MongoSourceConfig.CONNECTION_URI_
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COPY_EXISTING_NAMESPACE_REGEX_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COPY_EXISTING_PIPELINE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.ERRORS_LOG_ENABLE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.ERRORS_TOLERANCE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.FULL_DOCUMENT_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.HEARTBEAT_INTERVAL_MS_CONFIG;
@@ -29,6 +30,9 @@ import static com.mongodb.kafka.connect.source.MongoSourceConfig.HEARTBEAT_TOPIC
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.OUTPUT_FORMAT_KEY_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.OUTPUT_FORMAT_VALUE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.OUTPUT_SCHEMA_INFER_VALUE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.OVERRIDE_ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.OVERRIDE_ERRORS_LOG_ENABLE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.OVERRIDE_ERRORS_TOLERANCE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.PIPELINE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_AWAIT_TIME_MS_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_MAX_BATCH_SIZE_CONFIG;
@@ -364,6 +368,70 @@ class MongoSourceConfigTest {
                     .getString(ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG)
                     .isEmpty()),
         () -> assertInvalid(ERRORS_TOLERANCE_CONFIG, "Some"));
+  }
+
+  @Test
+  @DisplayName("Test error configuration overrides")
+  void testErrorConfigurationOverrides() {
+    assertAll(
+        "Error configuration overrides",
+        () -> assertTrue(createSourceConfig(OVERRIDE_ERRORS_TOLERANCE_CONFIG, "all").tolerateErrors()),
+        () -> assertFalse(createSourceConfig(OVERRIDE_ERRORS_TOLERANCE_CONFIG, "none").tolerateErrors()),
+        () ->
+            assertFalse(
+                createSourceConfig(
+                    format(
+                        "{'%s': '%s', '%s': '%s'}",
+                        ERRORS_TOLERANCE_CONFIG,
+                        "all",
+                        OVERRIDE_ERRORS_TOLERANCE_CONFIG,
+                        "none"))
+                .tolerateErrors()),
+        () ->
+            assertTrue(
+                createSourceConfig(
+                    format(
+                        "{'%s': '%s', '%s': '%s'}",
+                        ERRORS_TOLERANCE_CONFIG,
+                        "none",
+                        OVERRIDE_ERRORS_TOLERANCE_CONFIG,
+                        "all"))
+                    .tolerateErrors()),
+        () -> assertTrue(createSourceConfig(OVERRIDE_ERRORS_LOG_ENABLE_CONFIG, "true").logErrors()),
+        () -> assertTrue(
+                createSourceConfig(
+                    format(
+                        "{'%s': '%s', '%s': '%s'}",
+                        ERRORS_LOG_ENABLE_CONFIG,
+                        "false",
+                        OVERRIDE_ERRORS_LOG_ENABLE_CONFIG,
+                        "true"))
+                    .logErrors()),
+        () -> assertEquals("", createSourceConfig().getDlqTopic()),
+        () -> assertEquals("dlq", createSourceConfig(OVERRIDE_ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG, "dlq").getDlqTopic()),
+        () ->
+            assertEquals(
+                "dlq",
+                createSourceConfig(
+                    format(
+                        "{'%s': '%s', '%s': '%s'}",
+                        ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG,
+                        "qld",
+                        OVERRIDE_ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG,
+                        "dlq"))
+                    .getDlqTopic()),
+        () ->
+            assertEquals(
+                "",
+                createSourceConfig(
+                    format(
+                        "{'%s': '%s', '%s': '%s'}",
+                        ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG,
+                        "qld",
+                        OVERRIDE_ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG,
+                        ""))
+                    .getDlqTopic())
+    );
   }
 
   @Test


### PR DESCRIPTION
Addresses https://jira.mongodb.org/browse/KAFKA-215 by adding new `mongo.`-prefixed variants for error handling configuration properties that either conflict now or may conflict at some point in the future with Connect framework properties, including `errors.tolerance` and `errors.log.enable`. These variants take precedence over their non-prefixed counterparts, but if not specified, the non-prefixed counterpart will be used, preserving backwards compatibility for existing users.