### PR TITLE
KAFKA-216: throw when failing to resume change stream for any reason

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -437,6 +437,8 @@ public final class MongoSourceTask extends SourceTask {
         if (resumeTokenNotFound(e)) {
           throw new ConnectException(
               "ResumeToken not found. Cannot create a change stream cursor", e);
+        } else {
+          throw new ConnectException("Failed to resume change stream", e);
         }
       }
       return null;


### PR DESCRIPTION
When the connector is not able to create the cursor to resume the change stream for any reason other than resume token not found, rather than continue silently and not process any data, it should instead fail and allow the user to troubleshoot the issue. The user can decide to resolve the issue in any of the methods that is documented in the log message. Without failing the connector though, it is not obvious to the user that anything has gone wrong with the connector without looking in logs. This is especially problematic with low volume topics that have sporadic traffic patterns in the first place.