### PR TITLE
Support user defined topic separator

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -139,6 +139,11 @@ public class MongoSourceConfig extends AbstractConfig {
   private static final String TOPIC_MAPPER_DEFAULT =
       "com.mongodb.kafka.connect.source.topic.mapping.DefaultTopicMapper";
 
+  public static final String TOPIC_SEPARATOR_CONFIG = "topic.separator";
+  private static final String TOPIC_SEPARATOR_DEFAULT = ".";
+  private static final String TOPIC_SEPARATOR_DISPLAY = "The topic separator";
+  private static final String TOPIC_SEPARATOR_DOC = "Separator to build topic with";
+
   public static final String TOPIC_PREFIX_CONFIG = "topic.prefix";
   private static final String TOPIC_PREFIX_DOC =
       "Prefix to prepend to database & collection names to generate the name of the Kafka "
@@ -642,6 +647,18 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         ConfigDef.Width.LONG,
         TOPIC_MAPPER_DISPLAY);
+
+    configDef.define(
+        TOPIC_SEPARATOR_CONFIG,
+        Type.STRING,
+        TOPIC_SEPARATOR_DEFAULT,
+        null,
+        Importance.LOW,
+        TOPIC_SEPARATOR_DOC,
+        group,
+        ++orderInGroup,
+        Width.MEDIUM,
+        TOPIC_SEPARATOR_DISPLAY);
 
     configDef.define(
         TOPIC_PREFIX_CONFIG,

--- a/src/main/java/com/mongodb/kafka/connect/source/topic/mapping/DefaultTopicMapper.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/topic/mapping/DefaultTopicMapper.java
@@ -18,6 +18,7 @@ package com.mongodb.kafka.connect.source.topic.mapping;
 
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.TOPIC_NAMESPACE_MAP_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.TOPIC_PREFIX_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.TOPIC_SEPARATOR_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.TOPIC_SUFFIX_CONFIG;
 import static com.mongodb.kafka.connect.util.BsonDocumentFieldLookup.fieldLookup;
 import static com.mongodb.kafka.connect.util.ConfigHelper.documentFromString;
@@ -37,8 +38,8 @@ public class DefaultTopicMapper implements TopicMapper {
   private static final String DB_FIELD_PATH = "ns.db";
   private static final String COLL_FIELD_PATH = "ns.coll";
   private static final String ALL = "*";
-  private static final String SEPARATOR = ".";
 
+  private String separator;
   private String prefix;
   private String suffix;
   private Document topicNamespaceMap;
@@ -49,8 +50,9 @@ public class DefaultTopicMapper implements TopicMapper {
     String prefix = config.getString(TOPIC_PREFIX_CONFIG);
     String suffix = config.getString(TOPIC_SUFFIX_CONFIG);
 
-    this.prefix = prefix.isEmpty() ? prefix : prefix + SEPARATOR;
-    this.suffix = suffix.isEmpty() ? suffix : SEPARATOR + suffix;
+    this.separator = config.getString(TOPIC_SEPARATOR_CONFIG);
+    this.prefix = prefix.isEmpty() ? prefix : prefix + separator;
+    this.suffix = suffix.isEmpty() ? suffix : separator + suffix;
     this.topicNamespaceMap =
         documentFromString(config.getString(TOPIC_NAMESPACE_MAP_CONFIG)).orElse(new Document());
 
@@ -72,7 +74,7 @@ public class DefaultTopicMapper implements TopicMapper {
       return dbName;
     }
     String collName = getStringFromPath(COLL_FIELD_PATH, changeStreamDocument);
-    String namespace = collName.isEmpty() ? dbName : dbName + SEPARATOR + collName;
+    String namespace = collName.isEmpty() ? dbName : dbName + separator + collName;
 
     String cachedTopic = namespaceTopicCache.get(namespace);
     if (cachedTopic == null) {
@@ -105,7 +107,7 @@ public class DefaultTopicMapper implements TopicMapper {
 
     String databaseMatch = topicNamespaceMap.get(dbName, "");
     if (!databaseMatch.isEmpty()) {
-      return databaseMatch + SEPARATOR + collName;
+      return databaseMatch + separator + collName;
     }
 
     return topicNamespaceMap.get(ALL, namespace);

--- a/src/test/java/com/mongodb/kafka/connect/source/SourceTestHelper.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/SourceTestHelper.java
@@ -51,12 +51,22 @@ public final class SourceTestHelper {
     return map;
   }
 
+  public static Map<String, String> createConfigMap(final Map<String, String> kvs) {
+    Map<String, String> map = createConfigMap();
+    map.putAll(kvs);
+    return map;
+  }
+
   public static MongoSourceConfig createSourceConfig() {
     return new MongoSourceConfig(createConfigMap());
   }
 
   public static MongoSourceConfig createSourceConfig(final String json) {
     return new MongoSourceConfig(createConfigMap(json));
+  }
+
+  public static MongoSourceConfig createSourceConfig(final Map<String, String> kvs) {
+    return new MongoSourceConfig(createConfigMap(kvs));
   }
 
   public static MongoSourceConfig createSourceConfig(final String k, final String v) {


### PR DESCRIPTION
Hi
I wrote this PR to make mongo-kafka support user defined topic separator.
currently, mong-kafka use "." to build topics, which might not be allowed in some companies. So it is better to make it configurable.

I introduced `topic.separator` param in `MongoSourceConfig` it is "." by default. if the user want use other separator to build topics, just config this param. (E.g “topic.separator”：“-”)

This pr is tested by `com.mongodb.kafka.connect.source.topic.mapping.DefaultTopicMapperTest` and it runs ok in my local