### PR TITLE
Remove the retry mechanism in MongoSinkTask

### DIFF
--- a/config/MongoSinkConnector.properties
+++ b/config/MongoSinkConnector.properties
@@ -13,8 +13,6 @@ value.converter.schema.registry.url=http://localhost:8081
 connection.uri=mongodb://mongo1:27017,mongo2:27017,mongo3:27017
 database=test
 collection=sink
-max.num.retries=1
-retries.defer.timeout=5000
 
 
 ## Document manipulation settings

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -47,7 +47,8 @@ function test_systems_available {
         MSG="\nWARNING: Could not reach configured kafka system on http://localhost:$1 \nNote: This script requires curl.\n"
 
           if [[ "$OSTYPE" == "darwin"* ]]; then
-            MSG+="\nIf using OSX please try reconfiguring Docker and increasing RAM and CPU. Then restart and try again.\n\n"
+            MSG+="\nIf using OSX please try reconfiguring Docker and increasing RAM and CPU.\
+                In Docker Desktop this can be done via the \"Resources\" tab in \"Preferences\". Then try again.\n\n"
           fi
 
         echo -e $MSG

--- a/src/integrationTest/java/com/mongodb/kafka/connect/ConnectorValidationIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/ConnectorValidationIntegrationTest.java
@@ -475,13 +475,13 @@ public final class ConnectorValidationIntegrationTest {
     Optional<ConfigValue> configValue =
         getSourceErrors(properties).stream().filter(cv -> cv.name().equals(configName)).findFirst();
     assertTrue(
-            configValue.isPresent(),
-            format(
-                    "No error for '%s': %s\nErrors: %s\nProperties: %s",
-                    configName,
-                    properties.getOrDefault(configName, ""),
-                    getSourceErrors(properties),
-                    properties));
+        configValue.isPresent(),
+        format(
+            "No error for '%s': %s\nErrors: %s\nProperties: %s",
+            configName,
+            properties.getOrDefault(configName, ""),
+            getSourceErrors(properties),
+            properties));
     assertFalse(
         configValue.get().errorMessages().isEmpty(), format("No error for '%s'", configName));
   }

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
@@ -335,7 +335,7 @@ public class MongoSinkConfig extends AbstractConfig {
         .forEach(
             obsoletePropertyName ->
                 LOGGER.warn(
-                    "The configuration property {} is obsolete. Remove it as it has no effect.",
+                    "The configuration property {} is obsolete. Remove it as it has no effect, no other action is required.",
                     obsoletePropertyName));
   }
 

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
@@ -335,8 +335,15 @@ public class MongoSinkConfig extends AbstractConfig {
         .forEach(
             obsoletePropertyName ->
                 LOGGER.warn(
-                    "The configuration property {} is obsolete. Remove it as it has no effect, no other action is required.",
-                    obsoletePropertyName));
+                    "The configuration property '{}' is obsolete"
+                        + " because the sink connector started to rely on retries in the MongoDB Java driver."
+                        + " Remove it as it has no effect."
+                        + " If you have 'retryWrites=false' specified in the '{}' configuration property,"
+                        + " then retries are disabled for the sink connector;"
+                        + " remove 'retryWrites=false' from '{}' if you want to enable retries.",
+                    obsoletePropertyName,
+                    CONNECTION_URI_CONFIG,
+                    CONNECTION_URI_CONFIG));
   }
 
   /** @param propertyName See {@link #logObsoleteProperties(Collection)}. */

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
@@ -20,6 +20,7 @@ package com.mongodb.kafka.connect.sink;
 
 import static com.mongodb.kafka.connect.sink.MongoSinkConfig.CONNECTION_URI_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkConfig.TOPICS_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkConfig.logObsoleteProperties;
 import static com.mongodb.kafka.connect.util.ClassHelper.createInstance;
 import static com.mongodb.kafka.connect.util.FlexibleDateTimeParser.DEFAULT_DATE_TIME_FORMATTER_PATTERN;
 import static com.mongodb.kafka.connect.util.Validators.emptyString;
@@ -159,18 +160,6 @@ public class MongoSinkTopicConfig extends AbstractConfig {
   private static final boolean FIELD_NAMESPACE_MAPPER_ERROR_IF_INVALID_DEFAULT = false;
 
   // Writes
-  public static final String MAX_NUM_RETRIES_CONFIG = "max.num.retries";
-  private static final String MAX_NUM_RETRIES_DISPLAY = "Max number of retries";
-  private static final String MAX_NUM_RETRIES_DOC =
-      "How often a retry should be done on write errors";
-  private static final int MAX_NUM_RETRIES_DEFAULT = 1;
-
-  public static final String RETRIES_DEFER_TIMEOUT_CONFIG = "retries.defer.timeout";
-  private static final String RETRIES_DEFER_TIMEOUT_DISPLAY = "Retry defer timeout";
-  private static final String RETRIES_DEFER_TIMEOUT_DOC =
-      "How long in ms a retry should get deferred";
-  private static final int RETRIES_DEFER_TIMEOUT_DEFAULT = 5000;
-
   public static final String DELETE_ON_NULL_VALUES_CONFIG = "delete.on.null.values";
   private static final String DELETE_ON_NULL_VALUES_DISPLAY = "Delete on null values";
   private static final String DELETE_ON_NULL_VALUES_DOC =
@@ -602,7 +591,7 @@ public class MongoSinkTopicConfig extends AbstractConfig {
     String prefix = format("%s%s.", TOPIC_OVERRIDE_PREFIX, topic);
     List<String> topicOverrides =
         props.keySet().stream().filter(k -> k.startsWith(prefix)).collect(Collectors.toList());
-
+    logObsoleteProperties(topicOverrides);
     Map<String, ConfigValue> results = new HashMap<>();
     Map<String, String> sinkTopicOriginals = createSinkTopicOriginals(topic, props);
 
@@ -791,28 +780,6 @@ public class MongoSinkTopicConfig extends AbstractConfig {
 
     group = "Writes";
     orderInGroup = 0;
-    configDef.define(
-        MAX_NUM_RETRIES_CONFIG,
-        ConfigDef.Type.INT,
-        MAX_NUM_RETRIES_DEFAULT,
-        ConfigDef.Range.atLeast(0),
-        ConfigDef.Importance.MEDIUM,
-        MAX_NUM_RETRIES_DOC,
-        group,
-        ++orderInGroup,
-        ConfigDef.Width.MEDIUM,
-        MAX_NUM_RETRIES_DISPLAY);
-    configDef.define(
-        RETRIES_DEFER_TIMEOUT_CONFIG,
-        ConfigDef.Type.INT,
-        RETRIES_DEFER_TIMEOUT_DEFAULT,
-        ConfigDef.Range.atLeast(0),
-        ConfigDef.Importance.MEDIUM,
-        RETRIES_DEFER_TIMEOUT_DOC,
-        group,
-        ++orderInGroup,
-        ConfigDef.Width.MEDIUM,
-        RETRIES_DEFER_TIMEOUT_DISPLAY);
     configDef.define(
         DELETE_ON_NULL_VALUES_CONFIG,
         ConfigDef.Type.BOOLEAN,

--- a/src/main/java/com/mongodb/kafka/connect/util/ConnectionValidator.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/ConnectionValidator.java
@@ -125,8 +125,7 @@ public final class ConnectionValidator {
   /**
    * Validates that the user has the required action permissions
    *
-   * <p>Uses the connection status privileges information to check the required action permissions</p>
-   *
+   * <p>Uses the connection status privileges information to check the required action permissions
    * See: https://docs.mongodb.com/manual/reference/command/connectionStatus
    */
   public static void validateUserHasActions(
@@ -185,9 +184,7 @@ public final class ConnectionValidator {
     }
   }
 
-  /**
-   * Checks the users privileges list and removes any that are supported
-   */
+  /** Checks the users privileges list and removes any that are supported */
   private static List<String> removeUserActions(
       final List<Document> privileges,
       final String authSource,
@@ -233,15 +230,15 @@ public final class ConnectionValidator {
   /**
    * Checks the roles info document for matching actions and removes them from the provided list
    *
-   * See: https://docs.mongodb.com/manual/reference/command/rolesInfo
+   * <p>See: https://docs.mongodb.com/manual/reference/command/rolesInfo
    */
   private static List<String> removeRoleActions(
-          final MongoClient mongoClient,
-          final MongoCredential credential,
-          final String databaseName,
-          final String collectionName,
-          final Document authInfo,
-          final List<String> actions) {
+      final MongoClient mongoClient,
+      final MongoCredential credential,
+      final String databaseName,
+      final String collectionName,
+      final Document authInfo,
+      final List<String> actions) {
 
     if (actions.isEmpty()) {
       return actions;
@@ -250,17 +247,17 @@ public final class ConnectionValidator {
     List<String> unsupportedActions = new ArrayList<>(actions);
     for (final Document userRole : authInfo.getList(AUTH_USER_ROLES, Document.class, emptyList())) {
       Document rolesInfo =
-              mongoClient
-                      .getDatabase(userRole.getString("db"))
-                      .runCommand(Document.parse(format(ROLES_INFO, userRole.getString("role"))));
+          mongoClient
+              .getDatabase(userRole.getString("db"))
+              .runCommand(Document.parse(format(ROLES_INFO, userRole.getString("role"))));
       for (final Document roleInfo : rolesInfo.getList("roles", Document.class, emptyList())) {
         unsupportedActions =
-                removeUserActions(
-                        roleInfo.getList(INHERITED_PRIVILEGES, Document.class, emptyList()),
-                        credential.getSource(),
-                        databaseName,
-                        collectionName,
-                        unsupportedActions);
+            removeUserActions(
+                roleInfo.getList(INHERITED_PRIVILEGES, Document.class, emptyList()),
+                credential.getSource(),
+                databaseName,
+                collectionName,
+                unsupportedActions);
         if (unsupportedActions.isEmpty()) {
           return unsupportedActions;
         }

--- a/src/main/java/com/mongodb/kafka/connect/util/VisibleForTesting.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/VisibleForTesting.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.kafka.connect.util;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Denotes that the annotated program element is made more accessible than otherwise necessary for
+ * the purpose of testing. The annotated program element must be used as if it had the {@linkplain
+ * #otherwise() intended} access modifier for any purpose other than testing.
+ */
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.FIELD})
+public @interface VisibleForTesting {
+  /** The intended {@link AccessModifier}. */
+  AccessModifier otherwise();
+
+  /**
+   * A subset of <a
+   * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-6.html#jls-6.6.1">access
+   * modifiers</a> that includes only values relevant to be used as the {@linkplain #otherwise()
+   * intended} access modifier.
+   */
+  enum AccessModifier {
+    PRIVATE,
+    PACKAGE,
+    PROTECTED
+  }
+}

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
@@ -19,6 +19,7 @@
 package com.mongodb.kafka.connect.sink;
 
 import static com.mongodb.kafka.connect.sink.MongoSinkConfig.CONNECTION_URI_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkConfig.OBSOLETE_CONFIGS;
 import static com.mongodb.kafka.connect.sink.MongoSinkConfig.TOPICS_REGEX_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkConfig.TOPIC_OVERRIDE_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkConfig.createOverrideKey;
@@ -38,6 +39,7 @@ import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.TIMESERIES_MET
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.TIMESERIES_TIMEFIELD_AUTO_CONVERSION_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.TIMESERIES_TIMEFIELD_AUTO_CONVERSION_DATE_FORMAT_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.TIMESERIES_TIMEFIELD_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.TOPIC_OVERRIDE_PREFIX;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_LIST_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_TYPE_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.WRITEMODEL_STRATEGY_CONFIG;
@@ -797,6 +799,23 @@ class MongoSinkConfigTest {
         () -> assertEquals("", createSinkConfig().getString(TIMESERIES_GRANULARITY_CONFIG)),
         () -> assertInvalid(TIMESERIES_GRANULARITY_CONFIG, "invalid granularity"),
         () -> assertInvalid(TIMESERIES_TIMEFIELD_AUTO_CONVERSION_DATE_FORMAT_CONFIG, "J"));
+  }
+
+  @Test
+  void testObsoleteProperties() {
+    Map<String, String> properties = createConfigMap();
+    OBSOLETE_CONFIGS.forEach(
+        obsoletePropertyName -> {
+          properties.put(obsoletePropertyName, "arbitraryValue");
+          properties.put(
+              TOPIC_OVERRIDE_PREFIX + "arbitraryTopicName." + obsoletePropertyName,
+              "arbitraryValue");
+        });
+    List<String> acceptedObsoletePropertyNames =
+        MongoSinkConfig.CONFIG.validateAll(properties).keySet().stream()
+            .filter(OBSOLETE_CONFIGS::contains)
+            .collect(Collectors.toList());
+    assertTrue(acceptedObsoletePropertyNames.isEmpty(), acceptedObsoletePropertyNames::toString);
   }
 
   private Exception assertInvalid(final String key, final String value) {


### PR DESCRIPTION
This is a subtask of KAFKA-257 created to produce smaller PRs. `CHANGELOG.md` will be updated once KAFKA-257 is complete, I left a reminder in this [comment](https://jira.mongodb.org/browse/KAFKA-257?focusedCommentId=4208200&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-4208200).

**TODO** for @stIncMale: When this is merged, delete the [branch `KAFKA-267`](https://github.com/mongodb/mongo-kafka/tree/KAFKA-267) and change the "into" branch for https://github.com/mongodb/mongo-kafka/pull/91 to `master`.

KAFKA-267