### PR TITLE
Throw ConnectException if resume of change stream is not possible

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -648,6 +648,10 @@ public final class MongoSourceTask extends SourceTask {
             LOGGER.info(
                 "An exception occurred when trying to get the next item from the Change Stream", e);
           }
+          if (e instanceof MongoCommandException &&
+              ((MongoCommandException) e).getErrorCode() == 286) {
+            throw new ConnectException("Failed to resume change stream", e);
+          }
         }
         return Optional.empty();
       } catch (Exception e) {

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -646,7 +646,7 @@ public final class MongoSourceTask extends SourceTask {
           if (sourceConfig.tolerateErrors() && changeStreamNotValid(e)) {
             cursor = tryRecreateCursor(e);
           } else {
-            LOGGER.info(
+            LOGGER.error(
                 "An exception occurred when trying to get the next item from the Change Stream", e);
           }
           if (e instanceof MongoQueryException &&

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -67,6 +67,7 @@ import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoException;
+import com.mongodb.MongoQueryException;
 import com.mongodb.client.ChangeStreamIterable;
 import com.mongodb.client.MongoChangeStreamCursor;
 import com.mongodb.client.MongoClient;
@@ -648,8 +649,8 @@ public final class MongoSourceTask extends SourceTask {
             LOGGER.info(
                 "An exception occurred when trying to get the next item from the Change Stream", e);
           }
-          if (e instanceof MongoCommandException &&
-              ((MongoCommandException) e).getErrorCode() == 286) {
+          if (e instanceof MongoQueryException &&
+              ((MongoQueryException) e).getErrorCode() == 286) {
             throw new ConnectException("Failed to resume change stream", e);
           }
         }


### PR DESCRIPTION
Issue:
One of the MongoDbAtlasSource Connector on Confluent Cloud is seeing the exception `com.mongodb.MongoQueryException: Query failed with error code 286 and error message 'Error on remote shard SOMENAME.mongodb.net:27017 :: caused by :: Resume of change stream was not possible, as the resume point may no longer be in the oplog.'` within the mongo client code but not surfacing it up; causing the connector to run indefinitely without producing any new records.

The exception is thrown here: https://github.com/mongodb/mongo-kafka/blob/28603b3fd78415c616f3363bc79ec947b0b702f0/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java#L635
The corresponding catch block just logs the exception and the connector continues to run.

Mitigating action:
Throw the ConnectException in the catch block when client gets this Exception (error code 286); as the exception says that resume of change stream itself is not possible (this is not a transient error).
Maybe this is something similar to this: https://github.com/mongodb/mongo-kafka/blob/28603b3fd78415c616f3363bc79ec947b0b702f0/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java#L486
The connector should fail in such case instead of just running without producing any records.


Testing:
Haven't tested the changes as I don't have clear path to reproduce the issue. Also, the actual fix may differ.