### PR TITLE
Fix log level from INFO to ERROR when Change Stream failed

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -645,7 +645,7 @@ public final class MongoSourceTask extends SourceTask {
           if (sourceConfig.tolerateErrors() && changeStreamNotValid(e)) {
             cursor = tryRecreateCursor(e);
           } else {
-            LOGGER.info(
+            LOGGER.error(
                 "An exception occurred when trying to get the next item from the Change Stream", e);
           }
         }


### PR DESCRIPTION
Hi, Team!

I believe, failure of Change Stream is a fatal event to MongoSource Connector users. Therefore, not the info level, but the error level log is required.

In my experience, I realized too late that my Mongo Source Connector had lost its functionality because this important log was at info level.

The log was:

`INFO An exception occurred when trying to get the next item from the Change Stream: Query failed with error code 286 and error message 'Error on remote shard **.***.**.**:***** :: caused by :: Resume of change stream was not possible, as the resume point may no longer be in the oplog.' on server **.***.**.**:***** (com.mongodb.kafka.connect.source.MongoSourceTask:597)`