### PR TITLE
Added `copy.existing.allow.disk.use` configuration

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/source/MongoCopyDataManager.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoCopyDataManager.java
@@ -16,6 +16,7 @@
 package com.mongodb.kafka.connect.source;
 
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COLLECTION_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.COPY_EXISTING_ALLOW_DISK_USE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COPY_EXISTING_MAX_THREADS_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COPY_EXISTING_NAMESPACE_REGEX_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COPY_EXISTING_PIPELINE_CONFIG;
@@ -147,6 +148,7 @@ class MongoCopyDataManager implements AutoCloseable {
           .getDatabase(namespace.getDatabaseName())
           .getCollection(namespace.getCollectionName(), RawBsonDocument.class)
           .aggregate(createPipeline(sourceConfig, namespace))
+          .allowDiskUse(sourceConfig.getBoolean(COPY_EXISTING_ALLOW_DISK_USE_CONFIG))
           .forEach(this::putToQueue);
       namespacesToCopy.decrementAndGet();
     } catch (Exception e) {

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -274,6 +274,14 @@ public class MongoSourceConfig extends AbstractConfig {
           + "in the `demo` database: `demo\\.a.*`";
   private static final String COPY_EXISTING_NAMESPACE_REGEX_DEFAULT = EMPTY_STRING;
 
+  public static final String COPY_EXISTING_ALLOW_DISK_USE_CONFIG = "copy.existing.allow.disk.use";
+  private static final String COPY_EXISTING_ALLOW_DISK_USE_DISPLAY =
+      "Copy existing allow disk use with the copying aggregation";
+  private static final String COPY_EXISTING_ALLOW_DISK_USE_DOC =
+      "Copy existing data uses an aggregation pipeline that mimics change stream events. In certain contexts this can require"
+          + "writing to disk if the aggregation process runs out of memory.";
+  private static final boolean COPY_EXISTING_ALLOW_DISK_USE_DEFAULT = true;
+
   public static final String ERRORS_TOLERANCE_CONFIG = "errors.tolerance";
   public static final String ERRORS_TOLERANCE_DISPLAY = "Error Tolerance";
   public static final ErrorTolerance ERRORS_TOLERANCE_DEFAULT = ErrorTolerance.NONE;
@@ -816,6 +824,17 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         COPY_EXISTING_NAMESPACE_REGEX_DISPLAY);
+
+    configDef.define(
+        COPY_EXISTING_ALLOW_DISK_USE_CONFIG,
+        Type.BOOLEAN,
+        COPY_EXISTING_ALLOW_DISK_USE_DEFAULT,
+        Importance.MEDIUM,
+        COPY_EXISTING_ALLOW_DISK_USE_DOC,
+        group,
+        ++orderInGroup,
+        Width.MEDIUM,
+        COPY_EXISTING_ALLOW_DISK_USE_DISPLAY);
 
     group = "Errors";
     orderInGroup = 0;


### PR DESCRIPTION
Allows the copy existing aggregation to use temporary
disk storage if required. Defaults to true but can be
disabled if the user doesn't have the permissions
for disk access.

KAFKA-265