### PR TITLE
fixed source setup in docker example

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -125,6 +125,8 @@ curl -X POST -H "Content-Type: application/json" --data '
      "tasks.max":"1",
      "connector.class":"com.mongodb.kafka.connect.MongoSourceConnector",
      "connection.uri":"mongodb://mongo1:27017,mongo2:27017,mongo3:27017",
+     "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+     "value.converter": "org.apache.kafka.connect.json.JsonConverter",
      "topic.prefix":"mongo",
      "database":"test",
      "collection":"pageviews"


### PR DESCRIPTION
Added json key and value converter to the MongoDB Kafka
Source Connector, the default Avro converter does not
handle mongo jsons properly adding binary values in front
of each key and value. The behaviour could be verified
by running ./run.sh from the docker folder

KAFKA-285
https://jira.mongodb.org/browse/KAFKA-285