### PR TITLE
Mongo sink connector must tolerate the `ErrantRecordReporter` being not available

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkRecordProcessor.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkRecordProcessor.java
@@ -22,10 +22,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.mongodb.kafka.connect.sink.dlq.ErrorReporter;
 
 final class MongoSinkRecordProcessor {
   private static final Logger LOGGER = LoggerFactory.getLogger(MongoSinkRecordProcessor.class);
@@ -33,7 +34,7 @@ final class MongoSinkRecordProcessor {
   static List<List<MongoProcessedSinkRecordData>> orderedGroupByTopicAndNamespace(
       final Collection<SinkRecord> records,
       final MongoSinkConfig sinkConfig,
-      final ErrantRecordReporter errorReporter) {
+      final ErrorReporter errorReporter) {
     LOGGER.debug("Number of sink records to process: {}", records.size());
 
     List<List<MongoProcessedSinkRecordData>> orderedProcessedSinkRecordData = new ArrayList<>();

--- a/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.errors.DataException;
-import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,19 +41,20 @@ import com.mongodb.client.model.BulkWriteOptions;
 import com.mongodb.client.model.WriteModel;
 
 import com.mongodb.kafka.connect.sink.dlq.AnalyzedBatchFailedWithBulkWriteException;
+import com.mongodb.kafka.connect.sink.dlq.ErrorReporter;
 
 public final class StartedMongoSinkTask {
   private static final Logger LOGGER = LoggerFactory.getLogger(MongoSinkTask.class);
 
   private final MongoSinkConfig sinkConfig;
   private final MongoClient mongoClient;
-  private final ErrantRecordReporter errorReporter;
+  private final ErrorReporter errorReporter;
   private final Set<MongoNamespace> checkedTimeseriesNamespaces;
 
   StartedMongoSinkTask(
       final MongoSinkConfig sinkConfig,
       final MongoClient mongoClient,
-      final ErrantRecordReporter errorReporter) {
+      final ErrorReporter errorReporter) {
     this.sinkConfig = sinkConfig;
     this.mongoClient = mongoClient;
     this.errorReporter = errorReporter;

--- a/src/main/java/com/mongodb/kafka/connect/sink/dlq/AnalyzedBatchFailedWithBulkWriteException.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/dlq/AnalyzedBatchFailedWithBulkWriteException.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 
-import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import com.mongodb.MongoBulkWriteException;
@@ -44,7 +43,7 @@ import com.mongodb.lang.Nullable;
 public final class AnalyzedBatchFailedWithBulkWriteException {
   private final List<SinkRecord> batch;
   private final MongoBulkWriteException e;
-  private final ErrantRecordReporter errorReporter;
+  private final ErrorReporter errorReporter;
   private final Logger logger;
   private final Map<Integer, Map.Entry<SinkRecord, WriteException>> recordsFailedWithWriteError =
       new HashMap<>();
@@ -57,7 +56,7 @@ public final class AnalyzedBatchFailedWithBulkWriteException {
       final List<SinkRecord> batch,
       final boolean ordered,
       final MongoBulkWriteException e,
-      final ErrantRecordReporter errorReporter,
+      final ErrorReporter errorReporter,
       final Logger logger) {
     this.batch = batch;
     this.e = e;

--- a/src/main/java/com/mongodb/kafka/connect/sink/dlq/ErrorReporter.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/dlq/ErrorReporter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.kafka.connect.sink.dlq;
+
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+/**
+ * This interface exists to avoid exposing our code to {@link ErrantRecordReporter}. This allows
+ * tolerating situations when the class {@link ErrantRecordReporter} is not available.
+ */
+public interface ErrorReporter {
+  void report(SinkRecord record, Exception e);
+}

--- a/src/test/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTaskTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTaskTest.java
@@ -48,8 +48,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -57,7 +55,6 @@ import java.util.stream.IntStream;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.DataException;
-import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -81,6 +78,7 @@ import com.mongodb.client.model.ReplaceOneModel;
 import com.mongodb.client.model.WriteModel;
 
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.ErrorTolerance;
+import com.mongodb.kafka.connect.sink.dlq.ErrorReporter;
 import com.mongodb.kafka.connect.sink.dlq.WriteConcernException;
 import com.mongodb.kafka.connect.sink.dlq.WriteException;
 import com.mongodb.kafka.connect.sink.dlq.WriteSkippedException;
@@ -357,13 +355,12 @@ final class StartedMongoSinkTaskTest {
     }
   }
 
-  private static final class InMemoryErrorReporter implements ErrantRecordReporter {
+  private static final class InMemoryErrorReporter implements ErrorReporter {
     private final List<ReportedData> reported = new ArrayList<>();
 
     @Override
-    public Future<Void> report(final SinkRecord record, final Throwable e) {
+    public void report(final SinkRecord record, final Exception e) {
       reported.add(new ReportedData(record, e));
-      return CompletableFuture.completedFuture(null);
     }
 
     List<ReportedData> reported() {


### PR DESCRIPTION
KAFKA-286