### PR TITLE
Log incompatible configuration properties

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
@@ -18,7 +18,31 @@
 
 package com.mongodb.kafka.connect.sink;
 
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.CHANGE_DATA_CAPTURE_HANDLER_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.CHANGE_DATA_CAPTURE_HANDLER_DEFAULT;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DELETE_ON_NULL_VALUES_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DELETE_ON_NULL_VALUES_DEFAULT;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_DEFAULT;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_UUID_FORMAT_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FIELD_RENAMER_MAPPING_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FIELD_RENAMER_MAPPING_DEFAULT;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FIELD_RENAMER_REGEXP_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FIELD_RENAMER_REGEXP_DEFAULT;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.KEY_PROJECTION_LIST_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.KEY_PROJECTION_LIST_DEFAULT;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.KEY_PROJECTION_TYPE_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.KEY_PROJECTION_TYPE_DEFAULT;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.POST_PROCESSOR_CHAIN_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.TOPIC_OVERRIDE_PREFIX;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_LIST_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_LIST_DEFAULT;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_TYPE_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_TYPE_DEFAULT;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.WRITEMODEL_STRATEGY_CONFIG;
+import static com.mongodb.kafka.connect.util.Assertions.assertNotNull;
+import static com.mongodb.kafka.connect.util.Assertions.assertTrue;
 import static com.mongodb.kafka.connect.util.ServerApiConfig.addServerApiConfig;
 import static com.mongodb.kafka.connect.util.Validators.errorCheckingValueValidator;
 import static com.mongodb.kafka.connect.util.VisibleForTesting.AccessModifier.PRIVATE;
@@ -29,15 +53,20 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 import static org.apache.kafka.common.config.ConfigDef.Width;
 
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -51,6 +80,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.mongodb.ConnectionString;
+import com.mongodb.annotations.Immutable;
+import com.mongodb.lang.Nullable;
 
 import com.mongodb.kafka.connect.MongoSinkConnector;
 import com.mongodb.kafka.connect.util.Validators;
@@ -111,6 +142,71 @@ public class MongoSinkConfig extends AbstractConfig {
   static final Set<String> OBSOLETE_CONFIGS =
       Collections.unmodifiableSet(
           new HashSet<>(Arrays.asList("max.num.retries", "retries.defer.timeout")));
+  /** @see #logIncompatibleProperties(Map) */
+  static final Set<IncompatiblePropertiesPair> INCOMPATIBLE_CONFIGS =
+      Collections.unmodifiableSet(
+          new HashSet<>(
+              Arrays.asList(
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      POST_PROCESSOR_CHAIN_CONFIG,
+                      null),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      FIELD_RENAMER_MAPPING_CONFIG,
+                      FIELD_RENAMER_MAPPING_DEFAULT),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      FIELD_RENAMER_REGEXP_CONFIG,
+                      FIELD_RENAMER_REGEXP_DEFAULT),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      KEY_PROJECTION_LIST_CONFIG,
+                      KEY_PROJECTION_LIST_DEFAULT),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      KEY_PROJECTION_TYPE_CONFIG,
+                      KEY_PROJECTION_TYPE_DEFAULT),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      VALUE_PROJECTION_LIST_CONFIG,
+                      VALUE_PROJECTION_LIST_DEFAULT),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      VALUE_PROJECTION_TYPE_CONFIG,
+                      VALUE_PROJECTION_TYPE_DEFAULT),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      WRITEMODEL_STRATEGY_CONFIG,
+                      null),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      DOCUMENT_ID_STRATEGY_CONFIG,
+                      null),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_CONFIG,
+                      String.valueOf(DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_DEFAULT)),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      DOCUMENT_ID_STRATEGY_UUID_FORMAT_CONFIG,
+                      null),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      DELETE_ON_NULL_VALUES_CONFIG,
+                      String.valueOf(DELETE_ON_NULL_VALUES_DEFAULT)))));
 
   private Map<String, String> originals;
   private final Optional<List<String>> topics;
@@ -221,6 +317,7 @@ public class MongoSinkConfig extends AbstractConfig {
           @SuppressWarnings("unchecked")
           public Map<String, ConfigValue> validateAll(final Map<String, String> props) {
             logObsoleteProperties(props.keySet());
+            logIncompatibleProperties(props);
             Map<String, ConfigValue> results = super.validateAll(props);
             INVISIBLE_CONFIGS.forEach(
                 c -> {
@@ -324,14 +421,12 @@ public class MongoSinkConfig extends AbstractConfig {
    * This method is used in our implementation of the {@link ConfigDef#validateAll(Map)} method
    * because the original implementation silently disregards any undefined configuration properties.
    *
-   * @param propertyNames Either normal configuration property names or property names prefixed with
-   *     {@link MongoSinkTopicConfig#TOPIC_OVERRIDE_PREFIX} and a topic name, as specified <a
-   *     href="https://docs.mongodb.com/kafka-connector/master/sink-connector/configuration-properties/topic-override/">here</a>.
+   * @param propertyNames See {@link #strippedPropertyName(String)}.
    * @see #OBSOLETE_CONFIGS
    */
   static void logObsoleteProperties(final Collection<String> propertyNames) {
     propertyNames.stream()
-        .filter(MongoSinkConfig::isObsolete)
+        .filter(propertyName -> OBSOLETE_CONFIGS.contains(strippedPropertyName(propertyName)))
         .forEach(
             obsoletePropertyName ->
                 LOGGER.warn(
@@ -346,13 +441,216 @@ public class MongoSinkConfig extends AbstractConfig {
                     CONNECTION_URI_CONFIG));
   }
 
-  /** @param propertyName See {@link #logObsoleteProperties(Collection)}. */
-  private static boolean isObsolete(final String propertyName) {
-    String strippedPropertyName =
-        propertyName.startsWith(TOPIC_OVERRIDE_PREFIX)
-            ? propertyName.substring(
-                propertyName.indexOf(".", TOPIC_OVERRIDE_PREFIX.length() + 1) + 1)
-            : propertyName;
-    return OBSOLETE_CONFIGS.contains(strippedPropertyName);
+  /**
+   * @param props Properties as they are passed to {@link ConfigDef#validateAll(Map)}.
+   * @see #INCOMPATIBLE_CONFIGS
+   */
+  static void logIncompatibleProperties(final Map<String, String> props) {
+    logIncompatibleProperties(props, LOGGER::warn);
+  }
+
+  @VisibleForTesting(otherwise = PRIVATE)
+  static void logIncompatibleProperties(
+      final Map<String, String> props, final Consumer<String> logger) {
+    // global props are considered as belonging to a topic named "" for simplicity
+    String global = "";
+    Map<String, Map<String, String>> topicNameToItsStrippedProps =
+        props.entrySet().stream()
+            .collect(
+                Collectors.groupingBy(
+                    propNameAndValue -> topicNameFromPropertyName(propNameAndValue.getKey()),
+                    Collectors.mapping(
+                        Function.identity(),
+                        Collectors.toMap(
+                            propNameAndValue -> strippedPropertyName(propNameAndValue.getKey()),
+                            Entry::getValue))));
+    Map<String, String> globalProps =
+        topicNameToItsStrippedProps.getOrDefault(global, Collections.emptyMap());
+    topicNameToItsStrippedProps.remove(global);
+    Map<String, Map<String, Entry<String, Boolean>>> topicNameToCombinedStrippedProps =
+        topicNameToItsStrippedProps.entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Entry::getKey,
+                    topicNameAndItsStrippedProps ->
+                        combineProperties(
+                            globalProps,
+                            topicNameAndItsStrippedProps.getKey(),
+                            topicNameAndItsStrippedProps.getValue())));
+    Map<String, Entry<String, Boolean>> globalPropsWithFalseFlags =
+        combineProperties(globalProps, null, null);
+    INCOMPATIBLE_CONFIGS.forEach(
+        incompatiblePair -> {
+          incompatiblePair.logIfPresent(null, globalPropsWithFalseFlags, logger);
+          topicNameToCombinedStrippedProps.forEach(
+              (topicName, combinedStrippedProps) ->
+                  incompatiblePair.logIfPresent(
+                      topicName.equals(global) ? null : topicName, combinedStrippedProps, logger));
+        });
+  }
+
+  /**
+   * @param globalProps Properties that are not topic-specific.
+   * @param topicName If {@code null}, then just converts {@code globalProps} to the result {@link
+   *     Map}.
+   * @param topicStrippedProps {@code null} iff {@code topicName} is {@code null}.
+   * @return A {@link Map} where keys are property names (stripped, because {@code
+   *     topicStrippedProps} must contain only stripped property names), and values are pairs of the
+   *     property value and a flag telling whether the property value came from {@code
+   *     topicStrippedProps}, i.e., was overridden, or from {@code globalProps}.
+   */
+  private static Map<String, Entry<String, Boolean>> combineProperties(
+      final Map<String, String> globalProps,
+      @Nullable final String topicName,
+      @Nullable final Map<String, String> topicStrippedProps) {
+    assertTrue((topicName == null) ^ (topicStrippedProps != null));
+    Map<String, Entry<String, Boolean>> combinedStrippedProps = new HashMap<>();
+    globalProps.forEach(
+        (propertyName, propertyValue) ->
+            combinedStrippedProps.put(
+                propertyName, new SimpleImmutableEntry<>(propertyValue, false)));
+    if (topicStrippedProps != null) {
+      topicStrippedProps.forEach(
+          (propertyName, propertyValue) ->
+              combinedStrippedProps.put(
+                  propertyName, new SimpleImmutableEntry<>(propertyValue, true)));
+    }
+    return combinedStrippedProps;
+  }
+
+  /**
+   * @param propertyName Either a normal configuration property name, or property name prefixed with
+   *     {@link MongoSinkTopicConfig#TOPIC_OVERRIDE_PREFIX} and a topic name, as specified <a
+   *     href="https://docs.mongodb.com/kafka-connector/master/sink-connector/configuration-properties/topic-override/">here</a>.
+   */
+  private static String strippedPropertyName(final String propertyName) {
+    return propertyName.startsWith(TOPIC_OVERRIDE_PREFIX)
+        ? propertyName.substring(propertyName.indexOf(".", TOPIC_OVERRIDE_PREFIX.length() + 1) + 1)
+        : propertyName;
+  }
+
+  /** @param strippedPropertyName See {@link #strippedPropertyName(String)}. */
+  private static String overriddenPropertyName(
+      final String topicName, final String strippedPropertyName) {
+    return TOPIC_OVERRIDE_PREFIX + topicName + "." + strippedPropertyName;
+  }
+
+  /**
+   * @return {@code ""} if {@code propertyName} is not prefixed with {@link
+   *     MongoSinkTopicConfig#TOPIC_OVERRIDE_PREFIX}, otherwise returns the topic name from {@code
+   *     propertyName}.
+   */
+  private static String topicNameFromPropertyName(final String propertyName) {
+    if (propertyName.startsWith(TOPIC_OVERRIDE_PREFIX)) {
+      int topicNameStartIdx = TOPIC_OVERRIDE_PREFIX.length();
+      return propertyName.substring(
+          topicNameStartIdx, propertyName.indexOf(".", topicNameStartIdx));
+    } else {
+      return "";
+    }
+  }
+
+  /**
+   * A description of a pair of incompatible <a
+   * href="https://docs.mongodb.com/kafka-connector/master/sink-connector/configuration-properties/">
+   * configuration properties</a>.
+   */
+  @Immutable
+  private static final class IncompatiblePropertiesPair {
+    private final String propertyName1;
+    private final String defaultPropertyValue1;
+    private final String propertyName2;
+    private final String defaultPropertyValue2;
+    private final String msg;
+
+    /**
+     * @param defaultPropertyValue1 Must be {@code null} if the actual default value is not a
+     *     special value that can be used to disable a global property per topic by explicitly
+     *     setting it to the default value.
+     * @param defaultPropertyValue2 See {@code defaultPropertyValue2}.
+     */
+    private IncompatiblePropertiesPair(
+        final String propertyName1,
+        @Nullable final String defaultPropertyValue1,
+        final String propertyName2,
+        @Nullable final String defaultPropertyValue2,
+        @Nullable final String msg) {
+      this.propertyName1 = propertyName1;
+      this.defaultPropertyValue1 = defaultPropertyValue1;
+      this.propertyName2 = propertyName2;
+      this.defaultPropertyValue2 = defaultPropertyValue2;
+      this.msg = msg == null ? "" : " " + msg;
+    }
+
+    static IncompatiblePropertiesPair latterIgnored(
+        final String propertyName1,
+        @Nullable final String defaultPropertyValue1,
+        final String propertyName2,
+        @Nullable final String defaultPropertyValue2) {
+      return new IncompatiblePropertiesPair(
+          propertyName1,
+          defaultPropertyValue1,
+          propertyName2,
+          defaultPropertyValue2,
+          "The latter is ignored.");
+    }
+
+    /**
+     * @param topicName {@code null} if {@code combinedStrippedProps} represent global properties.
+     */
+    void logIfPresent(
+        @Nullable final String topicName,
+        final Map<String, Entry<String, Boolean>> combinedStrippedProps,
+        final Consumer<String> logger) {
+      Entry<String, Boolean> property1ValueAndOverridden = combinedStrippedProps.get(propertyName1);
+      if (property1ValueAndOverridden == null
+          || property1ValueAndOverridden.getKey().equals(defaultPropertyValue1)) {
+        return;
+      }
+      Entry<String, Boolean> property2ValueAndOverridden = combinedStrippedProps.get(propertyName2);
+      if (property2ValueAndOverridden == null
+          || property2ValueAndOverridden.getKey().equals(defaultPropertyValue2)) {
+        return;
+      }
+      logger.accept(
+          String.format(
+              "Configuration property %s is incompatible with %s.%s",
+              property1ValueAndOverridden.getValue()
+                  ? overriddenPropertyName(assertNotNull(topicName), propertyName1)
+                  : propertyName1,
+              property2ValueAndOverridden.getValue()
+                  ? overriddenPropertyName(assertNotNull(topicName), propertyName2)
+                  : propertyName2,
+              msg));
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final IncompatiblePropertiesPair that = (IncompatiblePropertiesPair) o;
+      return propertyName1.equals(that.propertyName1) && propertyName2.equals(that.propertyName2);
+    }
+
+    @Override
+    public int hashCode() {
+      return propertyName1.hashCode() + propertyName2.hashCode();
+    }
+
+    @Override
+    public String toString() {
+      return "IncompatiblePropertiesPair{"
+          + "name1="
+          + propertyName1
+          + ", name2="
+          + propertyName2
+          + ", msg="
+          + msg
+          + '}';
+    }
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
@@ -18,34 +18,11 @@
 
 package com.mongodb.kafka.connect.sink;
 
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.CHANGE_DATA_CAPTURE_HANDLER_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.CHANGE_DATA_CAPTURE_HANDLER_DEFAULT;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DELETE_ON_NULL_VALUES_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DELETE_ON_NULL_VALUES_DEFAULT;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_DEFAULT;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_UUID_FORMAT_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FIELD_RENAMER_MAPPING_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FIELD_RENAMER_MAPPING_DEFAULT;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FIELD_RENAMER_REGEXP_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FIELD_RENAMER_REGEXP_DEFAULT;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.KEY_PROJECTION_LIST_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.KEY_PROJECTION_LIST_DEFAULT;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.KEY_PROJECTION_TYPE_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.KEY_PROJECTION_TYPE_DEFAULT;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.POST_PROCESSOR_CHAIN_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.TOPIC_OVERRIDE_PREFIX;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_LIST_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_LIST_DEFAULT;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_TYPE_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_TYPE_DEFAULT;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.WRITEMODEL_STRATEGY_CONFIG;
-import static com.mongodb.kafka.connect.util.Assertions.assertNotNull;
-import static com.mongodb.kafka.connect.util.Assertions.assertTrue;
+import static com.mongodb.kafka.connect.sink.SinkConfigSoftValidator.logIncompatibleProperties;
+import static com.mongodb.kafka.connect.sink.SinkConfigSoftValidator.logObsoleteProperties;
 import static com.mongodb.kafka.connect.util.ServerApiConfig.addServerApiConfig;
 import static com.mongodb.kafka.connect.util.Validators.errorCheckingValueValidator;
-import static com.mongodb.kafka.connect.util.VisibleForTesting.AccessModifier.PRIVATE;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -53,20 +30,10 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 import static org.apache.kafka.common.config.ConfigDef.Width;
 
-import java.util.AbstractMap.SimpleImmutableEntry;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -76,19 +43,13 @@ import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigValue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.mongodb.ConnectionString;
-import com.mongodb.annotations.Immutable;
-import com.mongodb.lang.Nullable;
 
 import com.mongodb.kafka.connect.MongoSinkConnector;
 import com.mongodb.kafka.connect.util.Validators;
-import com.mongodb.kafka.connect.util.VisibleForTesting;
 
 public class MongoSinkConfig extends AbstractConfig {
-  private static final Logger LOGGER = LoggerFactory.getLogger(MongoSinkConfig.class);
   private static final String EMPTY_STRING = "";
   public static final String TOPICS_CONFIG = MongoSinkConnector.TOPICS_CONFIG;
   private static final String TOPICS_DOC =
@@ -131,82 +92,6 @@ public class MongoSinkConfig extends AbstractConfig {
   static final String PROVIDER_CONFIG = "provider";
 
   static final List<String> INVISIBLE_CONFIGS = singletonList(TOPIC_OVERRIDE_CONFIG);
-  /**
-   * Names of the <a
-   * href="https://docs.mongodb.com/kafka-connector/master/sink-connector/configuration-properties/">configuration
-   * properties</a> that were supported previously, but are currently ignored.
-   *
-   * @see #logObsoleteProperties(Collection)
-   */
-  @VisibleForTesting(otherwise = PRIVATE)
-  static final Set<String> OBSOLETE_CONFIGS =
-      Collections.unmodifiableSet(
-          new HashSet<>(Arrays.asList("max.num.retries", "retries.defer.timeout")));
-  /** @see #logIncompatibleProperties(Map) */
-  static final Set<IncompatiblePropertiesPair> INCOMPATIBLE_CONFIGS =
-      Collections.unmodifiableSet(
-          new HashSet<>(
-              Arrays.asList(
-                  IncompatiblePropertiesPair.latterIgnored(
-                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
-                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
-                      POST_PROCESSOR_CHAIN_CONFIG,
-                      null),
-                  IncompatiblePropertiesPair.latterIgnored(
-                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
-                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
-                      FIELD_RENAMER_MAPPING_CONFIG,
-                      FIELD_RENAMER_MAPPING_DEFAULT),
-                  IncompatiblePropertiesPair.latterIgnored(
-                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
-                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
-                      FIELD_RENAMER_REGEXP_CONFIG,
-                      FIELD_RENAMER_REGEXP_DEFAULT),
-                  IncompatiblePropertiesPair.latterIgnored(
-                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
-                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
-                      KEY_PROJECTION_LIST_CONFIG,
-                      KEY_PROJECTION_LIST_DEFAULT),
-                  IncompatiblePropertiesPair.latterIgnored(
-                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
-                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
-                      KEY_PROJECTION_TYPE_CONFIG,
-                      KEY_PROJECTION_TYPE_DEFAULT),
-                  IncompatiblePropertiesPair.latterIgnored(
-                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
-                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
-                      VALUE_PROJECTION_LIST_CONFIG,
-                      VALUE_PROJECTION_LIST_DEFAULT),
-                  IncompatiblePropertiesPair.latterIgnored(
-                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
-                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
-                      VALUE_PROJECTION_TYPE_CONFIG,
-                      VALUE_PROJECTION_TYPE_DEFAULT),
-                  IncompatiblePropertiesPair.latterIgnored(
-                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
-                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
-                      WRITEMODEL_STRATEGY_CONFIG,
-                      null),
-                  IncompatiblePropertiesPair.latterIgnored(
-                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
-                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
-                      DOCUMENT_ID_STRATEGY_CONFIG,
-                      null),
-                  IncompatiblePropertiesPair.latterIgnored(
-                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
-                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
-                      DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_CONFIG,
-                      String.valueOf(DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_DEFAULT)),
-                  IncompatiblePropertiesPair.latterIgnored(
-                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
-                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
-                      DOCUMENT_ID_STRATEGY_UUID_FORMAT_CONFIG,
-                      null),
-                  IncompatiblePropertiesPair.latterIgnored(
-                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
-                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
-                      DELETE_ON_NULL_VALUES_CONFIG,
-                      String.valueOf(DELETE_ON_NULL_VALUES_DEFAULT)))));
 
   private Map<String, String> originals;
   private final Optional<List<String>> topics;
@@ -415,242 +300,5 @@ public class MongoSinkConfig extends AbstractConfig {
 
     MongoSinkTopicConfig.BASE_CONFIG.configKeys().values().forEach(configDef::define);
     return configDef;
-  }
-
-  /**
-   * This method is used in our implementation of the {@link ConfigDef#validateAll(Map)} method
-   * because the original implementation silently disregards any undefined configuration properties.
-   *
-   * @param propertyNames See {@link #strippedPropertyName(String)}.
-   * @see #OBSOLETE_CONFIGS
-   */
-  static void logObsoleteProperties(final Collection<String> propertyNames) {
-    propertyNames.stream()
-        .filter(propertyName -> OBSOLETE_CONFIGS.contains(strippedPropertyName(propertyName)))
-        .forEach(
-            obsoletePropertyName ->
-                LOGGER.warn(
-                    "The configuration property '{}' is obsolete"
-                        + " because the sink connector started to rely on retries in the MongoDB Java driver."
-                        + " Remove it as it has no effect."
-                        + " If you have 'retryWrites=false' specified in the '{}' configuration property,"
-                        + " then retries are disabled for the sink connector;"
-                        + " remove 'retryWrites=false' from '{}' if you want to enable retries.",
-                    obsoletePropertyName,
-                    CONNECTION_URI_CONFIG,
-                    CONNECTION_URI_CONFIG));
-  }
-
-  /**
-   * @param props Properties as they are passed to {@link ConfigDef#validateAll(Map)}.
-   * @see #INCOMPATIBLE_CONFIGS
-   */
-  static void logIncompatibleProperties(final Map<String, String> props) {
-    logIncompatibleProperties(props, LOGGER::warn);
-  }
-
-  @VisibleForTesting(otherwise = PRIVATE)
-  static void logIncompatibleProperties(
-      final Map<String, String> props, final Consumer<String> logger) {
-    // global props are considered as belonging to a topic named "" for simplicity
-    String global = "";
-    Map<String, Map<String, String>> topicNameToItsStrippedProps =
-        props.entrySet().stream()
-            .collect(
-                Collectors.groupingBy(
-                    propNameAndValue -> topicNameFromPropertyName(propNameAndValue.getKey()),
-                    Collectors.mapping(
-                        Function.identity(),
-                        Collectors.toMap(
-                            propNameAndValue -> strippedPropertyName(propNameAndValue.getKey()),
-                            Entry::getValue))));
-    Map<String, String> globalProps =
-        topicNameToItsStrippedProps.getOrDefault(global, Collections.emptyMap());
-    topicNameToItsStrippedProps.remove(global);
-    Map<String, Map<String, Entry<String, Boolean>>> topicNameToCombinedStrippedProps =
-        topicNameToItsStrippedProps.entrySet().stream()
-            .collect(
-                Collectors.toMap(
-                    Entry::getKey,
-                    topicNameAndItsStrippedProps ->
-                        combineProperties(
-                            globalProps,
-                            topicNameAndItsStrippedProps.getKey(),
-                            topicNameAndItsStrippedProps.getValue())));
-    Map<String, Entry<String, Boolean>> globalPropsWithFalseFlags =
-        combineProperties(globalProps, null, null);
-    INCOMPATIBLE_CONFIGS.forEach(
-        incompatiblePair -> {
-          incompatiblePair.logIfPresent(null, globalPropsWithFalseFlags, logger);
-          topicNameToCombinedStrippedProps.forEach(
-              (topicName, combinedStrippedProps) ->
-                  incompatiblePair.logIfPresent(
-                      topicName.equals(global) ? null : topicName, combinedStrippedProps, logger));
-        });
-  }
-
-  /**
-   * @param globalProps Properties that are not topic-specific.
-   * @param topicName If {@code null}, then just converts {@code globalProps} to the result {@link
-   *     Map}.
-   * @param topicStrippedProps {@code null} iff {@code topicName} is {@code null}.
-   * @return A {@link Map} where keys are property names (stripped, because {@code
-   *     topicStrippedProps} must contain only stripped property names), and values are pairs of the
-   *     property value and a flag telling whether the property value came from {@code
-   *     topicStrippedProps}, i.e., was overridden, or from {@code globalProps}.
-   */
-  private static Map<String, Entry<String, Boolean>> combineProperties(
-      final Map<String, String> globalProps,
-      @Nullable final String topicName,
-      @Nullable final Map<String, String> topicStrippedProps) {
-    assertTrue((topicName == null) ^ (topicStrippedProps != null));
-    Map<String, Entry<String, Boolean>> combinedStrippedProps = new HashMap<>();
-    globalProps.forEach(
-        (propertyName, propertyValue) ->
-            combinedStrippedProps.put(
-                propertyName, new SimpleImmutableEntry<>(propertyValue, false)));
-    if (topicStrippedProps != null) {
-      topicStrippedProps.forEach(
-          (propertyName, propertyValue) ->
-              combinedStrippedProps.put(
-                  propertyName, new SimpleImmutableEntry<>(propertyValue, true)));
-    }
-    return combinedStrippedProps;
-  }
-
-  /**
-   * @param propertyName Either a normal configuration property name, or property name prefixed with
-   *     {@link MongoSinkTopicConfig#TOPIC_OVERRIDE_PREFIX} and a topic name, as specified <a
-   *     href="https://docs.mongodb.com/kafka-connector/master/sink-connector/configuration-properties/topic-override/">here</a>.
-   */
-  private static String strippedPropertyName(final String propertyName) {
-    return propertyName.startsWith(TOPIC_OVERRIDE_PREFIX)
-        ? propertyName.substring(propertyName.indexOf(".", TOPIC_OVERRIDE_PREFIX.length() + 1) + 1)
-        : propertyName;
-  }
-
-  /** @param strippedPropertyName See {@link #strippedPropertyName(String)}. */
-  private static String overriddenPropertyName(
-      final String topicName, final String strippedPropertyName) {
-    return TOPIC_OVERRIDE_PREFIX + topicName + "." + strippedPropertyName;
-  }
-
-  /**
-   * @return {@code ""} if {@code propertyName} is not prefixed with {@link
-   *     MongoSinkTopicConfig#TOPIC_OVERRIDE_PREFIX}, otherwise returns the topic name from {@code
-   *     propertyName}.
-   */
-  private static String topicNameFromPropertyName(final String propertyName) {
-    if (propertyName.startsWith(TOPIC_OVERRIDE_PREFIX)) {
-      int topicNameStartIdx = TOPIC_OVERRIDE_PREFIX.length();
-      return propertyName.substring(
-          topicNameStartIdx, propertyName.indexOf(".", topicNameStartIdx));
-    } else {
-      return "";
-    }
-  }
-
-  /**
-   * A description of a pair of incompatible <a
-   * href="https://docs.mongodb.com/kafka-connector/master/sink-connector/configuration-properties/">
-   * configuration properties</a>.
-   */
-  @Immutable
-  private static final class IncompatiblePropertiesPair {
-    private final String propertyName1;
-    private final String defaultPropertyValue1;
-    private final String propertyName2;
-    private final String defaultPropertyValue2;
-    private final String msg;
-
-    /**
-     * @param defaultPropertyValue1 Must be {@code null} if the actual default value is not a
-     *     special value that can be used to disable a global property per topic by explicitly
-     *     setting it to the default value.
-     * @param defaultPropertyValue2 See {@code defaultPropertyValue2}.
-     */
-    private IncompatiblePropertiesPair(
-        final String propertyName1,
-        @Nullable final String defaultPropertyValue1,
-        final String propertyName2,
-        @Nullable final String defaultPropertyValue2,
-        @Nullable final String msg) {
-      this.propertyName1 = propertyName1;
-      this.defaultPropertyValue1 = defaultPropertyValue1;
-      this.propertyName2 = propertyName2;
-      this.defaultPropertyValue2 = defaultPropertyValue2;
-      this.msg = msg == null ? "" : " " + msg;
-    }
-
-    static IncompatiblePropertiesPair latterIgnored(
-        final String propertyName1,
-        @Nullable final String defaultPropertyValue1,
-        final String propertyName2,
-        @Nullable final String defaultPropertyValue2) {
-      return new IncompatiblePropertiesPair(
-          propertyName1,
-          defaultPropertyValue1,
-          propertyName2,
-          defaultPropertyValue2,
-          "The latter is ignored.");
-    }
-
-    /**
-     * @param topicName {@code null} if {@code combinedStrippedProps} represent global properties.
-     */
-    void logIfPresent(
-        @Nullable final String topicName,
-        final Map<String, Entry<String, Boolean>> combinedStrippedProps,
-        final Consumer<String> logger) {
-      Entry<String, Boolean> property1ValueAndOverridden = combinedStrippedProps.get(propertyName1);
-      if (property1ValueAndOverridden == null
-          || property1ValueAndOverridden.getKey().equals(defaultPropertyValue1)) {
-        return;
-      }
-      Entry<String, Boolean> property2ValueAndOverridden = combinedStrippedProps.get(propertyName2);
-      if (property2ValueAndOverridden == null
-          || property2ValueAndOverridden.getKey().equals(defaultPropertyValue2)) {
-        return;
-      }
-      logger.accept(
-          String.format(
-              "Configuration property %s is incompatible with %s.%s",
-              property1ValueAndOverridden.getValue()
-                  ? overriddenPropertyName(assertNotNull(topicName), propertyName1)
-                  : propertyName1,
-              property2ValueAndOverridden.getValue()
-                  ? overriddenPropertyName(assertNotNull(topicName), propertyName2)
-                  : propertyName2,
-              msg));
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      final IncompatiblePropertiesPair that = (IncompatiblePropertiesPair) o;
-      return propertyName1.equals(that.propertyName1) && propertyName2.equals(that.propertyName2);
-    }
-
-    @Override
-    public int hashCode() {
-      return propertyName1.hashCode() + propertyName2.hashCode();
-    }
-
-    @Override
-    public String toString() {
-      return "IncompatiblePropertiesPair{"
-          + "name1="
-          + propertyName1
-          + ", name2="
-          + propertyName2
-          + ", msg="
-          + msg
-          + '}';
-    }
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
@@ -20,7 +20,6 @@ package com.mongodb.kafka.connect.sink;
 
 import static com.mongodb.kafka.connect.sink.MongoSinkConfig.CONNECTION_URI_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkConfig.TOPICS_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkConfig.logObsoleteProperties;
 import static com.mongodb.kafka.connect.util.ClassHelper.createInstance;
 import static com.mongodb.kafka.connect.util.FlexibleDateTimeParser.DEFAULT_DATE_TIME_FORMATTER_PATTERN;
 import static com.mongodb.kafka.connect.util.Validators.emptyString;
@@ -164,13 +163,13 @@ public class MongoSinkTopicConfig extends AbstractConfig {
   private static final String DELETE_ON_NULL_VALUES_DISPLAY = "Delete on null values";
   private static final String DELETE_ON_NULL_VALUES_DOC =
       "Whether or not the connector tries to delete documents based on key when " + "value is null";
-  private static final boolean DELETE_ON_NULL_VALUES_DEFAULT = false;
+  static final boolean DELETE_ON_NULL_VALUES_DEFAULT = false;
 
   public static final String WRITEMODEL_STRATEGY_CONFIG = "writemodel.strategy";
   private static final String WRITEMODEL_STRATEGY_DISPLAY = "The writeModel strategy";
   private static final String WRITEMODEL_STRATEGY_DOC =
       "The class the handles how build the write models for the sink documents";
-  private static final String WRITEMODEL_STRATEGY_DEFAULT =
+  static final String WRITEMODEL_STRATEGY_DEFAULT =
       "com.mongodb.kafka.connect.sink.writemodel.strategy.DefaultWriteModelStrategy";
 
   public static final String MAX_BATCH_SIZE_CONFIG = "max.batch.size";
@@ -211,32 +210,32 @@ public class MongoSinkTopicConfig extends AbstractConfig {
   private static final String KEY_PROJECTION_TYPE_DISPLAY = "The key projection type";
   private static final String KEY_PROJECTION_TYPE_DOC =
       "The type of key projection to use " + "Use either `AllowList` or `BlockList`.";
-  private static final String KEY_PROJECTION_TYPE_DEFAULT = "none";
+  static final String KEY_PROJECTION_TYPE_DEFAULT = "none";
 
   public static final String KEY_PROJECTION_LIST_CONFIG = "key.projection.list";
   private static final String KEY_PROJECTION_LIST_DISPLAY = "The key projection list";
   private static final String KEY_PROJECTION_LIST_DOC =
       "A comma separated list of field names for key projection";
-  private static final String KEY_PROJECTION_LIST_DEFAULT = EMPTY_STRING;
+  static final String KEY_PROJECTION_LIST_DEFAULT = EMPTY_STRING;
 
   public static final String VALUE_PROJECTION_TYPE_CONFIG = "value.projection.type";
   private static final String VALUE_PROJECTION_TYPE_DISPLAY =
       "The type of value projection to use " + "Use either `AllowList` or `BlockList`.";
   private static final String VALUE_PROJECTION_TYPE_DOC = "The type of value projection to use";
-  private static final String VALUE_PROJECTION_TYPE_DEFAULT = "none";
+  static final String VALUE_PROJECTION_TYPE_DEFAULT = "none";
 
   public static final String VALUE_PROJECTION_LIST_CONFIG = "value.projection.list";
   private static final String VALUE_PROJECTION_LIST_DISPLAY = "The value projection list";
   private static final String VALUE_PROJECTION_LIST_DOC =
       "A comma separated list of field names for value projection";
-  private static final String VALUE_PROJECTION_LIST_DEFAULT = EMPTY_STRING;
+  static final String VALUE_PROJECTION_LIST_DEFAULT = EMPTY_STRING;
 
   public static final String FIELD_RENAMER_MAPPING_CONFIG = "field.renamer.mapping";
   private static final String FIELD_RENAMER_MAPPING_DISPLAY = "The field renamer mapping";
   private static final String FIELD_RENAMER_MAPPING_DOC =
       "An inline JSON array with objects describing field name mappings.\n"
           + "Example: `[{\"oldName\":\"key.fieldA\",\"newName\":\"field1\"},{\"oldName\":\"value.xyz\",\"newName\":\"abc\"}]`";
-  private static final String FIELD_RENAMER_MAPPING_DEFAULT = "[]";
+  static final String FIELD_RENAMER_MAPPING_DEFAULT = "[]";
 
   public static final String FIELD_RENAMER_REGEXP_CONFIG = "field.renamer.regexp";
   public static final String FIELD_RENAMER_REGEXP_DISPLAY = "The field renamer regex";
@@ -244,14 +243,14 @@ public class MongoSinkTopicConfig extends AbstractConfig {
       "An inline JSON array with objects describing regexp settings.\n"
           + "Example: `[{\"regexp\":\"^key\\\\\\\\..*my.*$\",\"pattern\":\"my\",\"replace\":\"\"},"
           + "{\"regexp\":\"^value\\\\\\\\..*$\",\"pattern\":\"\\\\\\\\.\",\"replace\":\"_\"}]`";
-  private static final String FIELD_RENAMER_REGEXP_DEFAULT = "[]";
+  static final String FIELD_RENAMER_REGEXP_DEFAULT = "[]";
 
   // Id strategies
   public static final String DOCUMENT_ID_STRATEGY_CONFIG = "document.id.strategy";
   private static final String DOCUMENT_ID_STRATEGY_DISPLAY = "The document id strategy";
   private static final String DOCUMENT_ID_STRATEGY_DOC =
       "The IdStrategy class name to use for generating a unique document id (_id)";
-  private static final String DOCUMENT_ID_STRATEGY_DEFAULT =
+  static final String DOCUMENT_ID_STRATEGY_DEFAULT =
       "com.mongodb.kafka.connect.sink.processor.id.strategy.BsonOidStrategy";
 
   public static final String DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_CONFIG =
@@ -260,7 +259,7 @@ public class MongoSinkTopicConfig extends AbstractConfig {
       "The document id strategy overwrite existing setting";
   private static final String DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_DOC =
       "Allows the document id strategy will overwrite existing `_id` values";
-  private static final boolean DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_DEFAULT = false;
+  static final boolean DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_DEFAULT = false;
 
   public static final String DOCUMENT_ID_STRATEGY_UUID_FORMAT_CONFIG =
       "document.id.strategy.uuid.format";
@@ -339,7 +338,7 @@ public class MongoSinkTopicConfig extends AbstractConfig {
   private static final String CHANGE_DATA_CAPTURE_HANDLER_DISPLAY = "The CDC handler";
   private static final String CHANGE_DATA_CAPTURE_HANDLER_DOC =
       "The class name of the CDC handler to use for processing";
-  private static final String CHANGE_DATA_CAPTURE_HANDLER_DEFAULT = EMPTY_STRING;
+  static final String CHANGE_DATA_CAPTURE_HANDLER_DEFAULT = EMPTY_STRING;
 
   // Timeseries
   public static final String TIMESERIES_TIMEFIELD_CONFIG = "timeseries.timefield";
@@ -597,7 +596,6 @@ public class MongoSinkTopicConfig extends AbstractConfig {
     String prefix = format("%s%s.", TOPIC_OVERRIDE_PREFIX, topic);
     List<String> topicOverrides =
         props.keySet().stream().filter(k -> k.startsWith(prefix)).collect(Collectors.toList());
-    logObsoleteProperties(topicOverrides);
     Map<String, ConfigValue> results = new HashMap<>();
     Map<String, String> sinkTopicOriginals = createSinkTopicOriginals(topic, props);
 

--- a/src/main/java/com/mongodb/kafka/connect/sink/SinkConfigSoftValidator.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/SinkConfigSoftValidator.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.kafka.connect.sink;
+
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.CHANGE_DATA_CAPTURE_HANDLER_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.CHANGE_DATA_CAPTURE_HANDLER_DEFAULT;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DELETE_ON_NULL_VALUES_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DELETE_ON_NULL_VALUES_DEFAULT;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_DEFAULT;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_UUID_FORMAT_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FIELD_RENAMER_MAPPING_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FIELD_RENAMER_MAPPING_DEFAULT;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FIELD_RENAMER_REGEXP_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FIELD_RENAMER_REGEXP_DEFAULT;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.KEY_PROJECTION_LIST_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.KEY_PROJECTION_LIST_DEFAULT;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.KEY_PROJECTION_TYPE_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.KEY_PROJECTION_TYPE_DEFAULT;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.POST_PROCESSOR_CHAIN_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.TOPIC_OVERRIDE_PREFIX;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_LIST_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_LIST_DEFAULT;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_TYPE_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_TYPE_DEFAULT;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.WRITEMODEL_STRATEGY_CONFIG;
+import static com.mongodb.kafka.connect.util.Assertions.assertNotNull;
+import static com.mongodb.kafka.connect.util.Assertions.assertTrue;
+import static com.mongodb.kafka.connect.util.VisibleForTesting.AccessModifier.PRIVATE;
+
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mongodb.annotations.Immutable;
+import com.mongodb.lang.Nullable;
+
+import com.mongodb.kafka.connect.util.VisibleForTesting;
+
+/** Logs information about potential configuration issues. */
+public final class SinkConfigSoftValidator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MongoSinkConfig.class);
+
+  /**
+   * Names of the <a
+   * href="https://docs.mongodb.com/kafka-connector/master/sink-connector/configuration-properties/">configuration
+   * properties</a> that were supported previously, but are currently ignored.
+   *
+   * @see #logObsoleteProperties(Collection)
+   */
+  @VisibleForTesting(otherwise = PRIVATE)
+  static final Set<String> OBSOLETE_CONFIGS =
+      Collections.unmodifiableSet(
+          new HashSet<>(Arrays.asList("max.num.retries", "retries.defer.timeout")));
+  /** @see #logIncompatibleProperties(Map) */
+  private static final Set<IncompatiblePropertiesPair> INCOMPATIBLE_CONFIGS =
+      Collections.unmodifiableSet(
+          new HashSet<>(
+              Arrays.asList(
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      POST_PROCESSOR_CHAIN_CONFIG,
+                      null),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      FIELD_RENAMER_MAPPING_CONFIG,
+                      FIELD_RENAMER_MAPPING_DEFAULT),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      FIELD_RENAMER_REGEXP_CONFIG,
+                      FIELD_RENAMER_REGEXP_DEFAULT),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      KEY_PROJECTION_LIST_CONFIG,
+                      KEY_PROJECTION_LIST_DEFAULT),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      KEY_PROJECTION_TYPE_CONFIG,
+                      KEY_PROJECTION_TYPE_DEFAULT),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      VALUE_PROJECTION_LIST_CONFIG,
+                      VALUE_PROJECTION_LIST_DEFAULT),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      VALUE_PROJECTION_TYPE_CONFIG,
+                      VALUE_PROJECTION_TYPE_DEFAULT),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      WRITEMODEL_STRATEGY_CONFIG,
+                      null),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      DOCUMENT_ID_STRATEGY_CONFIG,
+                      null),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_CONFIG,
+                      String.valueOf(DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_DEFAULT)),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      DOCUMENT_ID_STRATEGY_UUID_FORMAT_CONFIG,
+                      null),
+                  IncompatiblePropertiesPair.latterIgnored(
+                      CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+                      CHANGE_DATA_CAPTURE_HANDLER_DEFAULT,
+                      DELETE_ON_NULL_VALUES_CONFIG,
+                      String.valueOf(DELETE_ON_NULL_VALUES_DEFAULT)))));
+
+  /**
+   * This method is used in our implementation of the {@link ConfigDef#validateAll(Map)} method
+   * because the original implementation silently disregards any undefined configuration properties.
+   *
+   * @param propertyNames See {@link #strippedPropertyName(String)}.
+   * @see #OBSOLETE_CONFIGS
+   */
+  static void logObsoleteProperties(final Collection<String> propertyNames) {
+    propertyNames.stream()
+        .filter(propertyName -> OBSOLETE_CONFIGS.contains(strippedPropertyName(propertyName)))
+        .forEach(
+            obsoletePropertyName ->
+                LOGGER.warn(
+                    "The configuration property '{}' is obsolete"
+                        + " because the sink connector started to rely on retries in the MongoDB Java driver."
+                        + " Remove it as it has no effect."
+                        + " If you have 'retryWrites=false' specified in the '{}' configuration property,"
+                        + " then retries are disabled for the sink connector;"
+                        + " remove 'retryWrites=false' from '{}' if you want to enable retries.",
+                    obsoletePropertyName,
+                    MongoSinkConfig.CONNECTION_URI_CONFIG,
+                    MongoSinkConfig.CONNECTION_URI_CONFIG));
+  }
+
+  /**
+   * @param props Properties as they are passed to {@link ConfigDef#validateAll(Map)}.
+   * @see #INCOMPATIBLE_CONFIGS
+   */
+  static void logIncompatibleProperties(final Map<String, String> props) {
+    logIncompatibleProperties(props, LOGGER::warn);
+  }
+
+  @VisibleForTesting(otherwise = PRIVATE)
+  static void logIncompatibleProperties(
+      final Map<String, String> props, final Consumer<String> logger) {
+    // global props are considered as belonging to a topic named "" for simplicity
+    String global = "";
+    Map<String, Map<String, String>> topicNameToItsStrippedProps =
+        props.entrySet().stream()
+            .collect(
+                Collectors.groupingBy(
+                    propNameAndValue -> topicNameFromPropertyName(propNameAndValue.getKey()),
+                    Collectors.mapping(
+                        Function.identity(),
+                        Collectors.toMap(
+                            propNameAndValue -> strippedPropertyName(propNameAndValue.getKey()),
+                            Entry::getValue))));
+    Map<String, String> globalProps =
+        topicNameToItsStrippedProps.getOrDefault(global, Collections.emptyMap());
+    topicNameToItsStrippedProps.remove(global);
+    Map<String, Map<String, Entry<String, Boolean>>> topicNameToCombinedStrippedProps =
+        topicNameToItsStrippedProps.entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Entry::getKey,
+                    topicNameAndItsStrippedProps ->
+                        combineProperties(
+                            globalProps,
+                            topicNameAndItsStrippedProps.getKey(),
+                            topicNameAndItsStrippedProps.getValue())));
+    Map<String, Entry<String, Boolean>> globalPropsWithFalseFlags =
+        combineProperties(globalProps, null, null);
+    INCOMPATIBLE_CONFIGS.forEach(
+        incompatiblePair -> {
+          incompatiblePair.logIfPresent(null, globalPropsWithFalseFlags, logger);
+          topicNameToCombinedStrippedProps.forEach(
+              (topicName, combinedStrippedProps) ->
+                  incompatiblePair.logIfPresent(
+                      topicName.equals(global) ? null : topicName, combinedStrippedProps, logger));
+        });
+  }
+
+  /**
+   * @param globalProps Properties that are not topic-specific.
+   * @param topicName If {@code null}, then just converts {@code globalProps} to the result {@link
+   *     Map}.
+   * @param topicStrippedProps {@code null} iff {@code topicName} is {@code null}.
+   * @return A {@link Map} where keys are property names (stripped, because {@code
+   *     topicStrippedProps} must contain only stripped property names), and values are pairs of the
+   *     property value and a flag telling whether the property value came from {@code
+   *     topicStrippedProps}, i.e., was overridden, or from {@code globalProps}.
+   */
+  private static Map<String, Entry<String, Boolean>> combineProperties(
+      final Map<String, String> globalProps,
+      @Nullable final String topicName,
+      @Nullable final Map<String, String> topicStrippedProps) {
+    assertTrue((topicName == null) ^ (topicStrippedProps != null));
+    Map<String, Entry<String, Boolean>> combinedStrippedProps = new HashMap<>();
+    globalProps.forEach(
+        (propertyName, propertyValue) ->
+            combinedStrippedProps.put(
+                propertyName, new AbstractMap.SimpleImmutableEntry<>(propertyValue, false)));
+    if (topicStrippedProps != null) {
+      topicStrippedProps.forEach(
+          (propertyName, propertyValue) ->
+              combinedStrippedProps.put(
+                  propertyName, new AbstractMap.SimpleImmutableEntry<>(propertyValue, true)));
+    }
+    return combinedStrippedProps;
+  }
+
+  /**
+   * @param propertyName Either a normal configuration property name, or property name prefixed with
+   *     {@link MongoSinkTopicConfig#TOPIC_OVERRIDE_PREFIX} and a topic name, as specified <a
+   *     href="https://docs.mongodb.com/kafka-connector/master/sink-connector/configuration-properties/topic-override/">here</a>.
+   */
+  private static String strippedPropertyName(final String propertyName) {
+    return propertyName.startsWith(TOPIC_OVERRIDE_PREFIX)
+        ? propertyName.substring(propertyName.indexOf(".", TOPIC_OVERRIDE_PREFIX.length() + 1) + 1)
+        : propertyName;
+  }
+
+  /** @param strippedPropertyName See {@link #strippedPropertyName(String)}. */
+  private static String overriddenPropertyName(
+      final String topicName, final String strippedPropertyName) {
+    return TOPIC_OVERRIDE_PREFIX + topicName + "." + strippedPropertyName;
+  }
+
+  /**
+   * @return {@code ""} if {@code propertyName} is not prefixed with {@link
+   *     MongoSinkTopicConfig#TOPIC_OVERRIDE_PREFIX}, otherwise returns the topic name from {@code
+   *     propertyName}.
+   */
+  private static String topicNameFromPropertyName(final String propertyName) {
+    if (propertyName.startsWith(TOPIC_OVERRIDE_PREFIX)) {
+      int topicNameStartIdx = TOPIC_OVERRIDE_PREFIX.length();
+      return propertyName.substring(
+          topicNameStartIdx, propertyName.indexOf(".", topicNameStartIdx));
+    } else {
+      return "";
+    }
+  }
+
+  /**
+   * A description of a pair of incompatible <a
+   * href="https://docs.mongodb.com/kafka-connector/master/sink-connector/configuration-properties/">
+   * configuration properties</a>.
+   */
+  @Immutable
+  private static final class IncompatiblePropertiesPair {
+    private final String propertyName1;
+    private final String defaultPropertyValue1;
+    private final String propertyName2;
+    private final String defaultPropertyValue2;
+    private final String msg;
+
+    /**
+     * @param defaultPropertyValue1 Must be {@code null} if the actual default value is not a
+     *     special value that can be used to disable a global property per topic by explicitly
+     *     setting it to the default value.
+     * @param defaultPropertyValue2 See {@code defaultPropertyValue2}.
+     */
+    private IncompatiblePropertiesPair(
+        final String propertyName1,
+        @Nullable final String defaultPropertyValue1,
+        final String propertyName2,
+        @Nullable final String defaultPropertyValue2,
+        @Nullable final String msg) {
+      this.propertyName1 = propertyName1;
+      this.defaultPropertyValue1 = defaultPropertyValue1;
+      this.propertyName2 = propertyName2;
+      this.defaultPropertyValue2 = defaultPropertyValue2;
+      this.msg = msg == null ? "" : " " + msg;
+    }
+
+    static IncompatiblePropertiesPair latterIgnored(
+        final String propertyName1,
+        @Nullable final String defaultPropertyValue1,
+        final String propertyName2,
+        @Nullable final String defaultPropertyValue2) {
+      return new IncompatiblePropertiesPair(
+          propertyName1,
+          defaultPropertyValue1,
+          propertyName2,
+          defaultPropertyValue2,
+          "The latter is ignored.");
+    }
+
+    /**
+     * @param topicName {@code null} if {@code combinedStrippedProps} represent global properties.
+     */
+    void logIfPresent(
+        @Nullable final String topicName,
+        final Map<String, Entry<String, Boolean>> combinedStrippedProps,
+        final Consumer<String> logger) {
+      Entry<String, Boolean> property1ValueAndOverridden =
+          combinedStrippedProps.get(propertyName1);
+      if (property1ValueAndOverridden == null
+          || property1ValueAndOverridden.getKey().equals(defaultPropertyValue1)) {
+        return;
+      }
+      Entry<String, Boolean> property2ValueAndOverridden =
+          combinedStrippedProps.get(propertyName2);
+      if (property2ValueAndOverridden == null
+          || property2ValueAndOverridden.getKey().equals(defaultPropertyValue2)) {
+        return;
+      }
+      logger.accept(
+          String.format(
+              "Configuration property %s is incompatible with %s.%s",
+              property1ValueAndOverridden.getValue()
+                  ? overriddenPropertyName(assertNotNull(topicName), propertyName1)
+                  : propertyName1,
+              property2ValueAndOverridden.getValue()
+                  ? overriddenPropertyName(assertNotNull(topicName), propertyName2)
+                  : propertyName2,
+              msg));
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final IncompatiblePropertiesPair that = (IncompatiblePropertiesPair) o;
+      return propertyName1.equals(that.propertyName1) && propertyName2.equals(that.propertyName2);
+    }
+
+    @Override
+    public int hashCode() {
+      return propertyName1.hashCode() + propertyName2.hashCode();
+    }
+
+    @Override
+    public String toString() {
+      return "IncompatiblePropertiesPair{"
+          + "name1="
+          + propertyName1
+          + ", name2="
+          + propertyName2
+          + ", msg="
+          + msg
+          + '}';
+    }
+  }
+
+  private SinkConfigSoftValidator() {}
+}

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
@@ -19,18 +19,13 @@
 package com.mongodb.kafka.connect.sink;
 
 import static com.mongodb.kafka.connect.sink.MongoSinkConfig.CONNECTION_URI_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkConfig.OBSOLETE_CONFIGS;
 import static com.mongodb.kafka.connect.sink.MongoSinkConfig.TOPICS_REGEX_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkConfig.TOPIC_OVERRIDE_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkConfig.createOverrideKey;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.CHANGE_DATA_CAPTURE_HANDLER_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.COLLECTION_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DATABASE_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DELETE_ON_NULL_VALUES_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DELETE_ON_NULL_VALUES_DEFAULT;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_DEFAULT;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FIELD_RENAMER_MAPPING_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FIELD_RENAMER_REGEXP_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.KEY_PROJECTION_LIST_CONFIG;
@@ -47,12 +42,12 @@ import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.TOPIC_OVERRIDE
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_LIST_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_TYPE_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.WRITEMODEL_STRATEGY_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.WRITEMODEL_STRATEGY_DEFAULT;
 import static com.mongodb.kafka.connect.sink.SinkTestHelper.CLIENT_URI_AUTH_SETTINGS;
 import static com.mongodb.kafka.connect.sink.SinkTestHelper.CLIENT_URI_DEFAULT_SETTINGS;
 import static com.mongodb.kafka.connect.sink.SinkTestHelper.TEST_TOPIC;
 import static com.mongodb.kafka.connect.sink.SinkTestHelper.createConfigMap;
 import static com.mongodb.kafka.connect.sink.SinkTestHelper.createSinkConfig;
+import static com.mongodb.kafka.connect.sink.SinkConfigSoftValidator.OBSOLETE_CONFIGS;
 import static com.mongodb.kafka.connect.util.FlexibleDateTimeParser.DEFAULT_DATE_TIME_FORMATTER_PATTERN;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -801,68 +796,6 @@ class MongoSinkConfigTest {
         () -> assertEquals("", createSinkConfig().getString(TIMESERIES_GRANULARITY_CONFIG)),
         () -> assertInvalid(TIMESERIES_GRANULARITY_CONFIG, "invalid granularity"),
         () -> assertInvalid(TIMESERIES_TIMEFIELD_AUTO_CONVERSION_DATE_FORMAT_CONFIG, "J"));
-  }
-
-  @Test
-  @DisplayName("Incompatible configuration properties must be logged")
-  void logIncompatibleProperties() {
-    // prepare properties
-    Map<String, String> props = new HashMap<>();
-    props.put(
-        CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
-        "com.mongodb.kafka.connect.sink.cdc.mongodb.ChangeStreamHandler");
-    props.put(DELETE_ON_NULL_VALUES_CONFIG, "true");
-    props.put(
-        WRITEMODEL_STRATEGY_CONFIG,
-        "com.mongodb.kafka.connect.sink.writemodel.strategy.DefaultWriteModelStrategy");
-    props.put(
-        createOverrideKey("topic1", CHANGE_DATA_CAPTURE_HANDLER_CONFIG),
-        "com.mongodb.kafka.connect.sink.cdc.mongodb.ChangeStreamHandler");
-    props.put(
-        createOverrideKey("topic1", DELETE_ON_NULL_VALUES_CONFIG),
-        String.valueOf(DELETE_ON_NULL_VALUES_DEFAULT));
-    props.put(
-        createOverrideKey("topic1", DOCUMENT_ID_STRATEGY_CONFIG), DOCUMENT_ID_STRATEGY_DEFAULT);
-    props.put(createOverrideKey("topic2", DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_CONFIG), "true");
-    props.put(createOverrideKey("topic2", WRITEMODEL_STRATEGY_CONFIG), WRITEMODEL_STRATEGY_DEFAULT);
-    // configure expectations
-    String latterIgnoredMsgFormat =
-        "Configuration property %s is incompatible with %s. The latter is ignored.";
-    Set<String> expectedMessages = new HashSet<>();
-    expectedMessages.add(
-        String.format(
-            latterIgnoredMsgFormat,
-            CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
-            DELETE_ON_NULL_VALUES_CONFIG));
-    expectedMessages.add(
-        String.format(
-            latterIgnoredMsgFormat,
-            CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
-            WRITEMODEL_STRATEGY_CONFIG));
-    expectedMessages.add(
-        String.format(
-            latterIgnoredMsgFormat,
-            createOverrideKey("topic1", CHANGE_DATA_CAPTURE_HANDLER_CONFIG),
-            createOverrideKey("topic1", DOCUMENT_ID_STRATEGY_CONFIG)));
-    expectedMessages.add(
-        String.format(
-            latterIgnoredMsgFormat,
-            createOverrideKey("topic1", CHANGE_DATA_CAPTURE_HANDLER_CONFIG),
-            WRITEMODEL_STRATEGY_CONFIG));
-    expectedMessages.add(
-        String.format(
-            latterIgnoredMsgFormat,
-            CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
-            createOverrideKey("topic2", DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_CONFIG)));
-    expectedMessages.add(
-        String.format(
-            latterIgnoredMsgFormat,
-            CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
-            createOverrideKey("topic2", WRITEMODEL_STRATEGY_CONFIG)));
-    // run and assert
-    Set<String> actualMessages = new HashSet<>();
-    MongoSinkConfig.logIncompatibleProperties(props, actualMessages::add);
-    assertEquals(expectedMessages, actualMessages);
   }
 
   @Test

--- a/src/test/java/com/mongodb/kafka/connect/sink/SinkConfigSoftValidatorTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/SinkConfigSoftValidatorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.kafka.connect.sink;
+
+import static com.mongodb.kafka.connect.sink.MongoSinkConfig.createOverrideKey;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.CHANGE_DATA_CAPTURE_HANDLER_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DELETE_ON_NULL_VALUES_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DELETE_ON_NULL_VALUES_DEFAULT;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_DEFAULT;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.WRITEMODEL_STRATEGY_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.WRITEMODEL_STRATEGY_DEFAULT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class SinkConfigSoftValidatorTest {
+  @Test
+  @DisplayName("Incompatible configuration properties must be logged")
+  void logIncompatibleProperties() {
+    // prepare properties
+    Map<String, String> props = new HashMap<>();
+    props.put(
+        CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+        "com.mongodb.kafka.connect.sink.cdc.mongodb.ChangeStreamHandler");
+    props.put(DELETE_ON_NULL_VALUES_CONFIG, "true");
+    props.put(
+        WRITEMODEL_STRATEGY_CONFIG,
+        "com.mongodb.kafka.connect.sink.writemodel.strategy.DefaultWriteModelStrategy");
+    props.put(
+        createOverrideKey("topic1", CHANGE_DATA_CAPTURE_HANDLER_CONFIG),
+        "com.mongodb.kafka.connect.sink.cdc.mongodb.ChangeStreamHandler");
+    props.put(
+        createOverrideKey("topic1", DELETE_ON_NULL_VALUES_CONFIG),
+        String.valueOf(DELETE_ON_NULL_VALUES_DEFAULT));
+    props.put(
+        createOverrideKey("topic1", DOCUMENT_ID_STRATEGY_CONFIG), DOCUMENT_ID_STRATEGY_DEFAULT);
+    props.put(createOverrideKey("topic2", DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_CONFIG), "true");
+    props.put(createOverrideKey("topic2", WRITEMODEL_STRATEGY_CONFIG), WRITEMODEL_STRATEGY_DEFAULT);
+    // configure expectations
+    String latterIgnoredMsgFormat =
+        "Configuration property %s is incompatible with %s. The latter is ignored.";
+    Set<String> expectedMessages = new HashSet<>();
+    expectedMessages.add(
+        String.format(
+            latterIgnoredMsgFormat,
+            CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+            DELETE_ON_NULL_VALUES_CONFIG));
+    expectedMessages.add(
+        String.format(
+            latterIgnoredMsgFormat,
+            CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+            WRITEMODEL_STRATEGY_CONFIG));
+    expectedMessages.add(
+        String.format(
+            latterIgnoredMsgFormat,
+            createOverrideKey("topic1", CHANGE_DATA_CAPTURE_HANDLER_CONFIG),
+            createOverrideKey("topic1", DOCUMENT_ID_STRATEGY_CONFIG)));
+    expectedMessages.add(
+        String.format(
+            latterIgnoredMsgFormat,
+            createOverrideKey("topic1", CHANGE_DATA_CAPTURE_HANDLER_CONFIG),
+            WRITEMODEL_STRATEGY_CONFIG));
+    expectedMessages.add(
+        String.format(
+            latterIgnoredMsgFormat,
+            CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+            createOverrideKey("topic2", DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_CONFIG)));
+    expectedMessages.add(
+        String.format(
+            latterIgnoredMsgFormat,
+            CHANGE_DATA_CAPTURE_HANDLER_CONFIG,
+            createOverrideKey("topic2", WRITEMODEL_STRATEGY_CONFIG)));
+    // run and assert
+    Set<String> actualMessages = new HashSet<>();
+    SinkConfigSoftValidator.logIncompatibleProperties(props, actualMessages::add);
+    assertEquals(expectedMessages, actualMessages);
+  }
+}


### PR DESCRIPTION
Specifically, when the CDC handler is configured
(https://docs.mongodb.com/kafka-connector/current/sink-connector/configuration-properties/cdc/)
configuration properties for post processors
https://docs.mongodb.com/kafka-connector/current/sink-connector/configuration-properties/post-processors/
and configuration properties for the ID strategy
are ignored.

KAFKA-277