### PR TITLE
Correctly process namespaces when converting `org.apache.avro.Schema` to `org.apache.kafka.connect.data.Schema`

### DIFF
--- a/src/integrationTest/java/com/mongodb/kafka/connect/avro/SchemaNameIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/avro/SchemaNameIntegrationTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.kafka.connect.avro;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+
+import io.confluent.connect.avro.AvroData;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.mongodb.kafka.connect.mongodb.MongoKafkaTestCase;
+
+final class SchemaNameIntegrationTest extends MongoKafkaTestCase {
+  @Test
+  @DisplayName(
+      "Ensure Avro schema namespaces are correctly reflected in Kafka Connect schema names and can be stored in Schema Registry")
+  void schemaName() throws RestClientException, IOException {
+    SchemaRegistryClient src = new CachedSchemaRegistryClient(KAFKA.schemaRegistryUrl(), 1);
+    org.apache.kafka.connect.data.Schema kafkaConnectRecordSchema =
+        com.mongodb.kafka.connect.source.schema.AvroSchema.fromJson(
+            "{\n"
+                + "  \"name\": \"recordSchemaName\",\n"
+                + "  \"namespace\": \"recordSchemaNamespace\",\n"
+                + "  \"type\": \"record\",\n"
+                + "  \"fields\": [\n"
+                + "    {\n"
+                + "      \"name\": \"nestedRecordFieldName\",\n"
+                + "      \"type\": {\n"
+                + "        \"name\": \"nested.Record.Schema.Namespace.nestedRecordSchemaName\",\n"
+                + "        \"namespace\": \"nestedRecordSchemaNamespace\",\n"
+                + "        \"type\": \"record\",\n"
+                + "        \"fields\": [\n"
+                + "          {\n"
+                + "            \"name\": \"fieldName\",\n"
+                + "            \"type\": \"int\"\n"
+                + "          }\n"
+                + "        ]\n"
+                + "      }\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}");
+    org.apache.kafka.connect.data.Schema kafkaConnectNestedRecordFieldSchema =
+        kafkaConnectRecordSchema.field("nestedRecordFieldName").schema();
+    assertAll(
+        () ->
+            assertEquals("recordSchemaNamespace.recordSchemaName", kafkaConnectRecordSchema.name()),
+        () ->
+            assertEquals(
+                "nested.Record.Schema.Namespace.nestedRecordSchemaName",
+                kafkaConnectNestedRecordFieldSchema.name()));
+    org.apache.avro.Schema avroRecordSchema =
+        new AvroData(1).fromConnectSchema(kafkaConnectRecordSchema);
+    int registeredSchemaId = src.register("subject", new AvroSchema(avroRecordSchema));
+    ParsedSchema retrievedSchema = src.getSchemaById(registeredSchemaId);
+    org.apache.avro.Schema retrievedAvroRecordSchema =
+        (org.apache.avro.Schema) retrievedSchema.rawSchema();
+    org.apache.avro.Schema retrievedAvroNestedRecordSchema =
+        retrievedAvroRecordSchema.getField("nestedRecordFieldName").schema();
+    assertAll(
+        () -> assertEquals("recordSchemaName", retrievedAvroRecordSchema.getName()),
+        () -> assertEquals("recordSchemaNamespace", retrievedAvroRecordSchema.getNamespace()),
+        () -> assertEquals("nestedRecordSchemaName", retrievedAvroNestedRecordSchema.getName()),
+        () ->
+            assertEquals(
+                "nested.Record.Schema.Namespace", retrievedAvroNestedRecordSchema.getNamespace()));
+  }
+}

--- a/src/main/java/com/mongodb/kafka/connect/sink/SinkConfigSoftValidator.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/SinkConfigSoftValidator.java
@@ -330,14 +330,12 @@ public final class SinkConfigSoftValidator {
         @Nullable final String topicName,
         final Map<String, Entry<String, Boolean>> combinedStrippedProps,
         final Consumer<String> logger) {
-      Entry<String, Boolean> property1ValueAndOverridden =
-          combinedStrippedProps.get(propertyName1);
+      Entry<String, Boolean> property1ValueAndOverridden = combinedStrippedProps.get(propertyName1);
       if (property1ValueAndOverridden == null
           || property1ValueAndOverridden.getKey().equals(defaultPropertyValue1)) {
         return;
       }
-      Entry<String, Boolean> property2ValueAndOverridden =
-          combinedStrippedProps.get(propertyName2);
+      Entry<String, Boolean> property2ValueAndOverridden = combinedStrippedProps.get(propertyName2);
       if (property2ValueAndOverridden == null
           || property2ValueAndOverridden.getKey().equals(defaultPropertyValue2)) {
         return;

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/AvroSchema.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/AvroSchema.java
@@ -164,7 +164,7 @@ public final class AvroSchema {
       case RECORD:
         SchemaBuilder structBuilder = SchemaBuilder.struct();
         context.schemaCache.put(avroSchema, structBuilder);
-        structBuilder.name(avroSchema.getName());
+        structBuilder.name(avroSchema.getFullName());
         avroSchema
             .getFields()
             .forEach(
@@ -194,7 +194,6 @@ public final class AvroSchema {
         builder = SchemaBuilder.string();
         break;
       case BYTES:
-      case FIXED:
         builder = SchemaBuilder.bytes();
         break;
       case INT:
@@ -223,6 +222,7 @@ public final class AvroSchema {
         throw new IllegalStateException();
       case NULL:
       case ENUM:
+      case FIXED:
       default:
         throw new IllegalStateException();
     }

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
@@ -42,12 +42,12 @@ import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.TOPIC_OVERRIDE
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_LIST_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_TYPE_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.WRITEMODEL_STRATEGY_CONFIG;
+import static com.mongodb.kafka.connect.sink.SinkConfigSoftValidator.OBSOLETE_CONFIGS;
 import static com.mongodb.kafka.connect.sink.SinkTestHelper.CLIENT_URI_AUTH_SETTINGS;
 import static com.mongodb.kafka.connect.sink.SinkTestHelper.CLIENT_URI_DEFAULT_SETTINGS;
 import static com.mongodb.kafka.connect.sink.SinkTestHelper.TEST_TOPIC;
 import static com.mongodb.kafka.connect.sink.SinkTestHelper.createConfigMap;
 import static com.mongodb.kafka.connect.sink.SinkTestHelper.createSinkConfig;
-import static com.mongodb.kafka.connect.sink.SinkConfigSoftValidator.OBSOLETE_CONFIGS;
 import static com.mongodb.kafka.connect.util.FlexibleDateTimeParser.DEFAULT_DATE_TIME_FORMATTER_PATTERN;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/AvroSchemaTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/AvroSchemaTest.java
@@ -67,13 +67,13 @@ public class AvroSchemaTest {
     Schema actual = AvroSchema.fromJson(schema);
 
     SchemaBuilder nodeBuilder =
-        SchemaBuilder.struct().name("Node").field("label", Schema.STRING_SCHEMA);
+        SchemaBuilder.struct().name("org.apache.avro.Node").field("label", Schema.STRING_SCHEMA);
     nodeBuilder.field("children", SchemaBuilder.array(nodeBuilder).build());
     nodeBuilder.defaultValue(
         new Struct(nodeBuilder).put("label", "default").put("children", new ArrayList<>()));
     Schema expected =
         SchemaBuilder.struct()
-            .name("Interop")
+            .name("org.apache.avro.Interop")
             .field("intField", Schema.INT32_SCHEMA)
             .field("longField", Schema.INT64_SCHEMA)
             .field("stringField", SchemaBuilder.string().defaultValue("MISSING").build())
@@ -87,7 +87,7 @@ public class AvroSchemaTest {
                 SchemaBuilder.map(
                     Schema.STRING_SCHEMA,
                     SchemaBuilder.struct()
-                        .name("Foo")
+                        .name("org.apache.avro.Foo")
                         .field("label", Schema.STRING_SCHEMA)
                         .build()))
             .field(
@@ -96,7 +96,7 @@ public class AvroSchemaTest {
             .field(
                 "nodeRecordField",
                 SchemaBuilder.struct()
-                    .name("Parent")
+                    .name("org.apache.avro.Parent")
                     .field("label", Schema.STRING_SCHEMA)
                     .field("parent", nodeBuilder))
             .build();


### PR DESCRIPTION
See the commit message for the details regarding this change.

KAFKA-246