### PR TITLE
Allow Source Connector to send tombstones on delete events when publishing only fullDocument

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -186,6 +186,14 @@ public class MongoSourceConfig extends AbstractConfig {
   private static final String BATCH_SIZE_DOC = "The cursor batch size.";
   private static final int BATCH_SIZE_DEFAULT = 0;
 
+  public static final String TOMBSTONE_ON_DELETE_CONFIG = "tombstone.on.delete";
+  private static final String TOMBSTONE_ON_DELETE_DISPLAY =
+      "Send null value on delete event when sending only fullDocument";
+  private static final String TOMBSTONE_ON_DELETE_DOC =
+      "Send null value on delete event when sending only fullDocument.\n"
+          + "Has no effect when publish.full.document.only is false";
+  private static final boolean TOMBSTONE_ON_DELETE_DEFAULT = false;
+
   public static final String PUBLISH_FULL_DOCUMENT_ONLY_CONFIG = "publish.full.document.only";
   private static final String PUBLISH_FULL_DOCUMENT_ONLY_DISPLAY =
       "Publish only the `fullDocument` field";
@@ -590,6 +598,17 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         PUBLISH_FULL_DOCUMENT_ONLY_DISPLAY);
+
+    configDef.define(
+        TOMBSTONE_ON_DELETE_CONFIG,
+        Type.BOOLEAN,
+        TOMBSTONE_ON_DELETE_DEFAULT,
+        Importance.MEDIUM,
+        TOMBSTONE_ON_DELETE_DOC,
+        group,
+        ++orderInGroup,
+        Width.MEDIUM,
+        TOMBSTONE_ON_DELETE_DISPLAY);
 
     configDef.define(
         FULL_DOCUMENT_CONFIG,


### PR DESCRIPTION
Hi,
we had the need to send tombstones on delete events to allow consumers to delete data when origin data in deleted.
Currently the Source connector filters out every null fullDocument.
I added a configuration `tombstone.on.delete` to opt-in the feature.
When both `tombstone.on.delete`  and `publish.full.document.only` are true, the delete event with null fullDocument will be sent as tombstone (null value and null schema) to Kafka.
An integrationTest has been created to check for null values.