### PR TITLE
Null values should not be converted to the "null" string if the field is not Optional

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValue.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValue.java
@@ -71,8 +71,12 @@ public class BsonValueToSchemaAndValue {
 
   public SchemaAndValue toSchemaAndValue(final Schema schema, final BsonValue bsonValue) {
     SchemaAndValue schemaAndValue;
-    if (schema.isOptional() && bsonValue.isNull()) {
-      return new SchemaAndValue(schema, null);
+    if (bsonValue.isNull()) {
+      if (schema.isOptional()) {
+        return new SchemaAndValue(schema, null);
+      } else {
+        throw unexpectedBsonValueType(schema.type(), bsonValue);
+      }
     }
 
     switch (schema.type()) {

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValueTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValueTest.java
@@ -51,6 +51,7 @@ import org.bson.BsonDocument;
 import org.bson.BsonDouble;
 import org.bson.BsonInt32;
 import org.bson.BsonInt64;
+import org.bson.BsonNull;
 import org.bson.BsonTimestamp;
 import org.bson.RawBsonDocument;
 import org.bson.types.Decimal128;
@@ -105,6 +106,23 @@ public class BsonValueToSchemaAndValueTest {
               new SchemaAndValue(Schema.STRING_SCHEMA, expected.get(k)),
               CONVERTER.toSchemaAndValue(Schema.STRING_SCHEMA, v));
         });
+  }
+
+  @Test
+  @DisplayName("test null with optional string")
+  void testNullWithOptionalString() {
+    assertSchemaAndValueEquals(
+        new SchemaAndValue(Schema.OPTIONAL_STRING_SCHEMA, null),
+        CONVERTER.toSchemaAndValue(Schema.OPTIONAL_STRING_SCHEMA, new BsonNull()));
+  }
+
+  @Test
+  @DisplayName("test null with mandatory string")
+  void testNullWithMandatoryString() {
+    assertThrows(
+        DataException.class,
+        () -> CONVERTER.toSchemaAndValue(Schema.STRING_SCHEMA, new BsonNull()),
+        "Expected null to fail");
   }
 
   @Test


### PR DESCRIPTION
Hi,
I found "null" strings in my topics and digging in the code I found that everything is stringified if the string field is not Optional.
I don't want to debate about the approach "serialize everything", but at least null values have to fail if the field can't be null.
If someone really wants a string "null" somewhere, that's something that can be done with a pipeline.