### PR TITLE
Support Debezium CDC change stream events

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/ChangeStreamHandler.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/ChangeStreamHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: Apache License, Version 2.0, Copyright 2017 Hans-Peter Grahsl.
+ */
+
+package com.mongodb.kafka.connect.sink.cdc.debezium.mongodb;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
+import com.mongodb.kafka.connect.sink.cdc.CdcOperation;
+import com.mongodb.kafka.connect.sink.cdc.debezium.OperationType;
+
+public class ChangeStreamHandler extends MongoDbHandler {
+  private static final Map<OperationType, CdcOperation> DEFAULT_OPERATIONS =
+      new HashMap<OperationType, CdcOperation>() {
+        {
+          put(OperationType.CREATE, new MongoDbInsert());
+          put(OperationType.READ, new MongoDbInsert());
+          put(OperationType.UPDATE, new MongoDbUpdate(MongoDbUpdate.EventFormat.ChangeStream));
+          put(OperationType.DELETE, new MongoDbDelete());
+        }
+      };
+
+  public ChangeStreamHandler(final MongoSinkTopicConfig config) {
+    super(config, DEFAULT_OPERATIONS);
+  }
+}

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbHandler.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbHandler.java
@@ -44,7 +44,7 @@ public class MongoDbHandler extends DebeziumCdcHandler {
         {
           put(OperationType.CREATE, new MongoDbInsert());
           put(OperationType.READ, new MongoDbInsert());
-          put(OperationType.UPDATE, new MongoDbUpdate());
+          put(OperationType.UPDATE, new MongoDbUpdate(MongoDbUpdate.EventFormat.Oplog));
           put(OperationType.DELETE, new MongoDbDelete());
         }
       };

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbUpdate.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbUpdate.java
@@ -35,57 +35,99 @@ import com.mongodb.kafka.connect.sink.cdc.CdcOperation;
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 
 public class MongoDbUpdate implements CdcOperation {
+  public enum EventFormat {
+    Oplog,
+    ChangeStream
+  }
+
   private static final ReplaceOptions REPLACE_OPTIONS = new ReplaceOptions().upsert(true);
   private static final String JSON_DOC_FIELD_PATH = "patch";
+
+  private static final String JSON_DOC_FIELD_AFTER = "after";
   public static final String INTERNAL_OPLOG_FIELD_V = "$v";
+
+  private final EventFormat eventFormat;
+
+  public MongoDbUpdate(final EventFormat eventFormat) {
+    this.eventFormat = eventFormat;
+  }
 
   @Override
   public WriteModel<BsonDocument> perform(final SinkDocument doc) {
-
-    BsonDocument valueDoc =
-        doc.getValueDoc()
-            .orElseThrow(
-                () -> new DataException("Value document must not be missing for update operation"));
-
-    if (!valueDoc.containsKey(JSON_DOC_FIELD_PATH)) {
-      throw new DataException(format("Update document missing `%s` field.", JSON_DOC_FIELD_PATH));
-    }
-
     try {
-      BsonDocument updateDoc =
-          BsonDocument.parse(valueDoc.getString(JSON_DOC_FIELD_PATH).getValue());
-
-      // Check if the internal "$v" field is contained which was added to the
-      // oplog format in 3.6+ If so, then we simply remove it for now since
-      // it's not used by the sink connector at the moment and would break
-      // CDC-mode based "replication".
-      updateDoc.remove(INTERNAL_OPLOG_FIELD_V);
-
-      // patch contains full new document for replacement
-      if (updateDoc.containsKey(ID_FIELD)) {
-        BsonDocument filterDoc = new BsonDocument(ID_FIELD, updateDoc.get(ID_FIELD));
-        return new ReplaceOneModel<>(filterDoc, updateDoc, REPLACE_OPTIONS);
+      if (EventFormat.ChangeStream.equals(this.eventFormat)) {
+        return handleChangeStreamEvent(doc);
+      } else if (EventFormat.Oplog.equals(this.eventFormat)) {
+        return handleOplogEvent(doc);
+      } else {
+        throw new UnsupportedOperationException(
+            format("Unsupported event format '%s'.", this.eventFormat));
       }
-
-      // patch contains idempotent change only to update original document with
-      BsonDocument keyDoc =
-          doc.getKeyDoc()
-              .orElseThrow(
-                  () -> new DataException("Key document must not be missing for update operation"));
-
-      if (!keyDoc.containsKey(JSON_ID_FIELD)) {
-        throw new DataException(format("Update document missing `%s` field.", JSON_ID_FIELD));
-      }
-
-      BsonDocument filterDoc =
-          BsonDocument.parse(
-              format("{%s: %s}", ID_FIELD, keyDoc.getString(JSON_ID_FIELD).getValue()));
-      return new UpdateOneModel<>(filterDoc, updateDoc);
-
     } catch (DataException exc) {
       throw exc;
     } catch (Exception exc) {
       throw new DataException(exc.getMessage(), exc);
     }
+  }
+
+  private WriteModel<BsonDocument> handleOplogEvent(final SinkDocument doc) {
+    BsonDocument valueDoc = getDocumentValue(doc);
+
+    if (!valueDoc.containsKey(JSON_DOC_FIELD_PATH)) {
+      throw new DataException(format("Update document missing `%s` field.", JSON_DOC_FIELD_PATH));
+    }
+
+    BsonDocument updateDoc = BsonDocument.parse(valueDoc.getString(JSON_DOC_FIELD_PATH).getValue());
+
+    // Check if the internal "$v" field is contained which was added to the
+    // oplog format in 3.6+ If so, then we simply remove it for now since
+    // it's not used by the sink connector at the moment and would break
+    // CDC-mode based "replication".
+    updateDoc.remove(INTERNAL_OPLOG_FIELD_V);
+
+    // patch contains full new document for replacement
+    if (updateDoc.containsKey(ID_FIELD)) {
+      BsonDocument filterDoc = new BsonDocument(ID_FIELD, updateDoc.get(ID_FIELD));
+      return new ReplaceOneModel<>(filterDoc, updateDoc, REPLACE_OPTIONS);
+    }
+
+    // patch contains idempotent change only to update original document with
+    return new UpdateOneModel<>(getFilterDocByKeyId(doc), updateDoc);
+  }
+
+  private WriteModel<BsonDocument> handleChangeStreamEvent(final SinkDocument doc) {
+    BsonDocument valueDoc = getDocumentValue(doc);
+
+    if (!valueDoc.containsKey(JSON_DOC_FIELD_AFTER)) {
+      throw new DataException(format("Update document missing `%s` field.", JSON_DOC_FIELD_AFTER));
+    }
+
+    BsonDocument updateDoc =
+        BsonDocument.parse(valueDoc.getString(JSON_DOC_FIELD_AFTER).getValue());
+
+    return new ReplaceOneModel<>(getFilterDocByKeyId(doc), updateDoc, REPLACE_OPTIONS);
+  }
+
+  private BsonDocument getFilterDocByKeyId(final SinkDocument doc) {
+    BsonDocument keyDoc = getDocumentKey(doc);
+
+    if (!keyDoc.containsKey(JSON_ID_FIELD)) {
+      throw new DataException(format("Update document missing `%s` field.", JSON_ID_FIELD));
+    }
+
+    return BsonDocument.parse(
+        format("{%s: %s}", ID_FIELD, keyDoc.getString(JSON_ID_FIELD).getValue()));
+  }
+
+  private BsonDocument getDocumentKey(final SinkDocument doc) {
+    return doc.getKeyDoc()
+        .orElseThrow(
+            () -> new DataException("Key document must not be missing for update operation"));
+  }
+
+  private BsonDocument getDocumentValue(final SinkDocument doc) {
+    return doc.getValueDoc()
+        .orElseThrow(
+            () -> new DataException("Value document must not be missing for update operation"));
   }
 }

--- a/src/test/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/ChangeStreamHandlerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/ChangeStreamHandlerTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: Apache License, Version 2.0, Copyright 2017 Hans-Peter Grahsl.
+ */
+
+package com.mongodb.kafka.connect.sink.cdc.debezium.mongodb;
+
+import static com.mongodb.kafka.connect.sink.SinkTestHelper.createTopicConfig;
+import static java.util.Collections.emptyMap;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.apache.kafka.connect.errors.DataException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonNull;
+import org.bson.BsonString;
+
+import com.mongodb.client.model.DeleteOneModel;
+import com.mongodb.client.model.ReplaceOneModel;
+import com.mongodb.client.model.WriteModel;
+
+import com.mongodb.kafka.connect.sink.cdc.debezium.OperationType;
+import com.mongodb.kafka.connect.sink.converter.SinkDocument;
+
+class ChangeStreamHandlerTest {
+
+  private static final ChangeStreamHandler HANDLER_DEFAULT_MAPPING =
+      new ChangeStreamHandler(createTopicConfig());
+
+  @Test
+  @DisplayName("verify existing default config from base class")
+  void testExistingDefaultConfig() {
+    assertAll(
+        () ->
+            assertNotNull(
+                HANDLER_DEFAULT_MAPPING.getConfig(), "default config for handler must not be null"),
+        () ->
+            assertNotNull(
+                new MongoDbHandler(createTopicConfig(), emptyMap()).getConfig(),
+                "default config for handler must not be null"));
+  }
+
+  @Test
+  @DisplayName("when key document missing then DataException")
+  void testMissingKeyDocument() {
+    assertThrows(
+        DataException.class, () -> HANDLER_DEFAULT_MAPPING.handle(new SinkDocument(null, null)));
+  }
+
+  @Test
+  @DisplayName("when key doc contains 'id' field but value is empty then null due to tombstone")
+  void testTombstoneEvent() {
+    assertEquals(
+        Optional.empty(),
+        HANDLER_DEFAULT_MAPPING.handle(
+            new SinkDocument(new BsonDocument("id", new BsonInt32(1234)), new BsonDocument())),
+        "tombstone event must result in Optional.empty()");
+  }
+
+  @Test
+  @DisplayName("when value doc contains unknown operation type then DataException")
+  void testUnkownCdcOperationType() {
+    SinkDocument cdcEvent =
+        new SinkDocument(
+            new BsonDocument("id", new BsonInt32(1234)),
+            new BsonDocument("op", new BsonString("x")));
+    assertThrows(DataException.class, () -> HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
+  }
+
+  @Test
+  @DisplayName("when value doc contains unmapped operation type then DataException")
+  void testUnmappedCdcOperationType() {
+    SinkDocument cdcEvent =
+        new SinkDocument(
+            new BsonDocument("_id", new BsonInt32(1234)),
+            new BsonDocument("op", new BsonString("z"))
+                .append("after", new BsonString("{_id:1234,foo:\"blah\"}")));
+
+    assertThrows(DataException.class, () -> HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
+  }
+
+  @Test
+  @DisplayName("when value doc contains operation type other than string then DataException")
+  void testInvalidCdcOperationType() {
+    SinkDocument cdcEvent =
+        new SinkDocument(
+            new BsonDocument("id", new BsonInt32(1234)),
+            new BsonDocument("op", new BsonInt32('c')));
+
+    assertThrows(DataException.class, () -> HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
+  }
+
+  @Test
+  @DisplayName("when value doc is missing operation type then DataException")
+  void testMissingCdcOperationType() {
+    SinkDocument cdcEvent =
+        new SinkDocument(
+            new BsonDocument("id", new BsonInt32(1234)), new BsonDocument("po", BsonNull.VALUE));
+
+    assertThrows(DataException.class, () -> HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
+  }
+
+  @TestFactory
+  @DisplayName("when valid CDC event then correct WriteModel")
+  Stream<DynamicTest> testValidCdcDocument() {
+
+    return Stream.of(
+        dynamicTest(
+            "test operation " + OperationType.CREATE,
+            () -> {
+              Optional<WriteModel<BsonDocument>> result =
+                  HANDLER_DEFAULT_MAPPING.handle(
+                      new SinkDocument(
+                          new BsonDocument("_id", new BsonString("1234")),
+                          new BsonDocument("op", new BsonString("c"))
+                              .append("after", new BsonString("{_id:1234,foo:\"blah\"}"))));
+              assertTrue(result.isPresent());
+              assertTrue(
+                  result.get() instanceof ReplaceOneModel,
+                  "result expected to be of type ReplaceOneModel");
+            }),
+        dynamicTest(
+            "test operation " + OperationType.READ,
+            () -> {
+              Optional<WriteModel<BsonDocument>> result =
+                  HANDLER_DEFAULT_MAPPING.handle(
+                      new SinkDocument(
+                          new BsonDocument("_id", new BsonString("1234")),
+                          new BsonDocument("op", new BsonString("r"))
+                              .append("after", new BsonString("{_id:1234,foo:\"blah\"}"))));
+              assertTrue(result.isPresent());
+              assertTrue(
+                  result.get() instanceof ReplaceOneModel,
+                  "result expected to be of type ReplaceOneModel");
+            }),
+        dynamicTest(
+            "test operation " + OperationType.UPDATE,
+            () -> {
+              Optional<WriteModel<BsonDocument>> result =
+                  HANDLER_DEFAULT_MAPPING.handle(
+                      new SinkDocument(
+                          new BsonDocument("id", new BsonString("1234")),
+                          new BsonDocument("op", new BsonString("u"))
+                              .append("after", new BsonString("{_id:1234,foo:\"blah\"}"))));
+              assertTrue(result.isPresent());
+              assertTrue(
+                  result.get() instanceof ReplaceOneModel,
+                  "result expected to be of type ReplaceOneModel");
+            }),
+        dynamicTest(
+            "test operation " + OperationType.DELETE,
+            () -> {
+              Optional<WriteModel<BsonDocument>> result =
+                  HANDLER_DEFAULT_MAPPING.handle(
+                      new SinkDocument(
+                          new BsonDocument("id", new BsonString("1234")),
+                          new BsonDocument("op", new BsonString("d"))));
+              assertTrue(result.isPresent(), "write model result must be present");
+              assertTrue(
+                  result.get() instanceof DeleteOneModel,
+                  "result expected to be of type DeleteOneModel");
+            }));
+  }
+
+  @TestFactory
+  @DisplayName("when valid cdc operation type then correct MongoDB CdcOperation")
+  Stream<DynamicTest> testValidCdcOpertionTypes() {
+
+    return Stream.of(
+        dynamicTest(
+            "test operation " + OperationType.CREATE,
+            () ->
+                assertTrue(
+                    HANDLER_DEFAULT_MAPPING.getCdcOperation(
+                            new BsonDocument("op", new BsonString("c")))
+                        instanceof MongoDbInsert)),
+        dynamicTest(
+            "test operation " + OperationType.READ,
+            () ->
+                assertTrue(
+                    HANDLER_DEFAULT_MAPPING.getCdcOperation(
+                            new BsonDocument("op", new BsonString("r")))
+                        instanceof MongoDbInsert)),
+        dynamicTest(
+            "test operation " + OperationType.UPDATE,
+            () ->
+                assertTrue(
+                    HANDLER_DEFAULT_MAPPING.getCdcOperation(
+                            new BsonDocument("op", new BsonString("u")))
+                        instanceof MongoDbUpdate)),
+        dynamicTest(
+            "test operation " + OperationType.DELETE,
+            () ->
+                assertTrue(
+                    HANDLER_DEFAULT_MAPPING.getCdcOperation(
+                            new BsonDocument("op", new BsonString("d")))
+                        instanceof MongoDbDelete)));
+  }
+}

--- a/src/test/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbUpdateTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbUpdateTest.java
@@ -37,7 +37,11 @@ import com.mongodb.client.model.WriteModel;
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 
 class MongoDbUpdateTest {
-  private static final MongoDbUpdate UPDATE = new MongoDbUpdate();
+  private static final MongoDbUpdate OPLOG_UPDATE =
+      new MongoDbUpdate(MongoDbUpdate.EventFormat.Oplog);
+
+  private static final MongoDbUpdate CHANGE_STREAM_UPDATE =
+      new MongoDbUpdate(MongoDbUpdate.EventFormat.ChangeStream);
   private static final BsonDocument FILTER_DOC = BsonDocument.parse("{_id: 1234}");
   private static final BsonDocument REPLACEMENT_DOC =
       BsonDocument.parse("{_id: 1234, first_name: 'Grace', last_name: 'Hopper'}");
@@ -55,7 +59,7 @@ class MongoDbUpdateTest {
         new BsonDocument("op", new BsonString("u"))
             .append("patch", new BsonString(REPLACEMENT_DOC.toJson()));
 
-    WriteModel<BsonDocument> result = UPDATE.perform(new SinkDocument(keyDoc, valueDoc));
+    WriteModel<BsonDocument> result = OPLOG_UPDATE.perform(new SinkDocument(keyDoc, valueDoc));
     assertTrue(result instanceof ReplaceOneModel, "result expected to be of type ReplaceOneModel");
 
     ReplaceOneModel<BsonDocument> writeModel = (ReplaceOneModel<BsonDocument>) result;
@@ -82,7 +86,7 @@ class MongoDbUpdateTest {
         new BsonDocument("op", new BsonString("u"))
             .append("patch", new BsonString(UPDATE_DOC.toJson()));
 
-    WriteModel<BsonDocument> result = UPDATE.perform(new SinkDocument(keyDoc, valueDoc));
+    WriteModel<BsonDocument> result = OPLOG_UPDATE.perform(new SinkDocument(keyDoc, valueDoc));
     assertTrue(result instanceof UpdateOneModel, "result expected to be of type UpdateOneModel");
 
     UpdateOneModel<BsonDocument> writeModel = (UpdateOneModel<BsonDocument>) result;
@@ -102,7 +106,7 @@ class MongoDbUpdateTest {
         new BsonDocument("op", new BsonString("u"))
             .append("patch", new BsonString(UPDATE_DOC_WITH_OPLOG_INTERNALS.toJson()));
 
-    WriteModel<BsonDocument> result = UPDATE.perform(new SinkDocument(keyDoc, valueDoc));
+    WriteModel<BsonDocument> result = OPLOG_UPDATE.perform(new SinkDocument(keyDoc, valueDoc));
     assertTrue(
         result instanceof UpdateOneModel, () -> "result expected to be of type UpdateOneModel");
 
@@ -116,10 +120,40 @@ class MongoDbUpdateTest {
   }
 
   @Test
+  @DisplayName("when valid doc replace change stream cdc event then correct ReplaceOneModel")
+  void testValidChangeStreamSinkDocumentForReplacement() {
+
+    BsonDocument keyDoc = BsonDocument.parse("{id: '1234'}");
+    BsonDocument valueDoc =
+        new BsonDocument("op", new BsonString("u"))
+            .append("after", new BsonString(REPLACEMENT_DOC.toJson()));
+
+    WriteModel<BsonDocument> result =
+        CHANGE_STREAM_UPDATE.perform(new SinkDocument(keyDoc, valueDoc));
+    assertTrue(result instanceof ReplaceOneModel, "result expected to be of type ReplaceOneModel");
+
+    ReplaceOneModel<BsonDocument> writeModel = (ReplaceOneModel<BsonDocument>) result;
+
+    assertEquals(
+        REPLACEMENT_DOC,
+        writeModel.getReplacement(),
+        "replacement doc not matching what is expected");
+    assertTrue(
+        writeModel.getFilter() instanceof BsonDocument,
+        "filter expected to be of type BsonDocument");
+
+    assertEquals(FILTER_DOC, writeModel.getFilter());
+    assertTrue(
+        writeModel.getReplaceOptions().isUpsert(),
+        "replacement expected to be done in upsert mode");
+  }
+
+  @Test
   @DisplayName("when missing value doc then DataException")
   void testMissingValueDocument() {
     assertThrows(
-        DataException.class, () -> UPDATE.perform(new SinkDocument(new BsonDocument(), null)));
+        DataException.class,
+        () -> OPLOG_UPDATE.perform(new SinkDocument(new BsonDocument(), null)));
   }
 
   @Test
@@ -127,7 +161,7 @@ class MongoDbUpdateTest {
   void testMissingKeyDocument() {
     assertThrows(
         DataException.class,
-        () -> UPDATE.perform(new SinkDocument(null, BsonDocument.parse("{patch: {}}"))));
+        () -> OPLOG_UPDATE.perform(new SinkDocument(null, BsonDocument.parse("{patch: {}}"))));
   }
 
   @Test
@@ -136,7 +170,7 @@ class MongoDbUpdateTest {
     assertThrows(
         DataException.class,
         () ->
-            UPDATE.perform(
+            OPLOG_UPDATE.perform(
                 new SinkDocument(
                     BsonDocument.parse("{id: 1234}"), BsonDocument.parse("{nopatch: {}}"))));
   }
@@ -147,7 +181,7 @@ class MongoDbUpdateTest {
     assertThrows(
         DataException.class,
         () ->
-            UPDATE.perform(
+            OPLOG_UPDATE.perform(
                 new SinkDocument(
                     BsonDocument.parse("{id: 1234}"), BsonDocument.parse("{patch: {}}"))));
   }
@@ -158,7 +192,7 @@ class MongoDbUpdateTest {
     assertThrows(
         DataException.class,
         () ->
-            UPDATE.perform(
+            OPLOG_UPDATE.perform(
                 new SinkDocument(
                     BsonDocument.parse("{id: '{not-Json}'}"), BsonDocument.parse("{patch: {}}"))));
   }


### PR DESCRIPTION
[KAFKA-300](https://jira.mongodb.org/browse/KAFKA-300)
Debezium 1.8 support change stream in capture.mode config. The message format for update cdc event is different from oplog mode. Other events are still working with existing code. This PR add new handler class to handle change stream event with full document (debezium capture.mode set to change_streams_update_full).