### PR TITLE
start change stream at operation time

### DIFF
--- a/config/MongoSourceConnector.properties
+++ b/config/MongoSourceConnector.properties
@@ -17,3 +17,4 @@ pipeline=[]
 batch.size=0
 change.stream.full.document=updateLookup
 collation=
+change.stream.start.at.operation.time='2022-07-25 08:23:00.000'

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -210,6 +210,12 @@ public class MongoSourceConfig extends AbstractConfig {
           + "Use the `Collation.asDocument().toJson()` to create the specific json representation.";
   private static final String COLLATION_DEFAULT = EMPTY_STRING;
 
+  public static final String OPERATION_TIME_CONFIG = "change.stream.start.at.operation.time";
+  private static final String OPERATION_TIME_DISPLAY = "The resume token options";
+  private static final String OPERATION_TIME_DOC =
+      "The string represent to where the change stream start";
+  private static final String OPERATION_TIME_DEFAULT = EMPTY_STRING;
+
   public static final String POLL_MAX_BATCH_SIZE_CONFIG = "poll.max.batch.size";
   private static final String POLL_MAX_BATCH_SIZE_DISPLAY = "The maximum batch size";
   private static final String POLL_MAX_BATCH_SIZE_DOC =
@@ -619,6 +625,19 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         COLLATION_DISPLAY);
+
+    configDef.define(
+        OPERATION_TIME_CONFIG,
+        Type.STRING,
+        OPERATION_TIME_DEFAULT,
+        errorCheckingValueValidator(
+            "A valid operation time representing a string", ConfigHelper::dateTimeFromString),
+        Importance.HIGH,
+        OPERATION_TIME_DOC,
+        group,
+        ++orderInGroup,
+        Width.MEDIUM,
+        OPERATION_TIME_DISPLAY);
 
     configDef.define(
         POLL_MAX_BATCH_SIZE_CONFIG,

--- a/src/main/java/com/mongodb/kafka/connect/util/ConfigHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/ConfigHelper.java
@@ -17,6 +17,10 @@ package com.mongodb.kafka.connect.util;
 
 import static java.lang.String.format;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -94,6 +98,17 @@ public final class ConfigHelper {
       return Optional.empty();
     } else {
       return Optional.of(FullDocument.fromString(fullDocument));
+    }
+  }
+
+  public static Optional<ZonedDateTime> dateTimeFromString(final String operationTime) {
+    if (operationTime.isEmpty()) {
+      return Optional.empty();
+    } else {
+      ZonedDateTime zonedDateTime =
+          LocalDateTime.parse(operationTime, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS"))
+              .atZone(ZoneId.of("UTC"));
+      return Optional.of(zonedDateTime);
     }
   }
 


### PR DESCRIPTION
This feature to set change stream to start at specific time. When synchronizing the data from source to destination, it will have a gap of time during exporting and importing data. Some data could be lost between that gap. 
Thus, we can use this feature to start the change stream before exporting data from the source. 