### PR TITLE
Log mongo config errors as warning

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/MongoSinkConnector.java
+++ b/src/main/java/com/mongodb/kafka/connect/MongoSinkConnector.java
@@ -35,12 +35,15 @@ import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.mongodb.kafka.connect.sink.MongoSinkConfig;
 import com.mongodb.kafka.connect.sink.MongoSinkTask;
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
 
 public class MongoSinkConnector extends SinkConnector {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MongoSinkConnector.class);
   private static final List<String> REQUIRED_SINK_ACTIONS = asList("insert", "update", "remove");
   private static final List<String> REQUIRED_COLLSTATS_SINK_ACTIONS =
       asList("insert", "update", "remove", "collStats");
@@ -86,6 +89,7 @@ public class MongoSinkConnector extends SinkConnector {
     try {
       sinkConfig = new MongoSinkConfig(connectorConfigs);
     } catch (Exception e) {
+      LOGGER.warn(e.getMessage(), e);
       return config;
     }
 


### PR DESCRIPTION
Currently, errors in the mongo DB config are not logged, when creating a new connector which makes finding issues in production harder. This fixes at least one occurrence of this issue.

Steps to reproduce:
1. Create a connector using the mongo sink
2. Enter an invalid value for the connection.uri `mongodb://localhost:27017?ssl=true&tlsAllowInvalidCertificate=true` (s missing)
3. Start the connector

The original connector fails without a message. Log output:
```
2022-07-26 21:24:31.296 [ INFO] 82619 --- [der-connect-1-1] ct.runtime.distributed.DistributedHerder : [Worker clientId=connect-1, groupId=tmn-job-charging-kafka-connect] Starting connectors and tasks using config offset -1
2022-07-26 21:24:31.296 [ INFO] 82619 --- [der-connect-1-1] ct.runtime.distributed.DistributedHerder : [Worker clientId=connect-1, groupId=tmn-job-charging-kafka-connect] Finished starting connectors and tasks
2022-07-26 21:24:31.369 [ INFO] 82619 --- [-connect-config] ct.runtime.distributed.DistributedHerder : [Worker clientId=connect-1, groupId=tmn-job-charging-kafka-connect] Session key updated
2022-07-26 21:24:31.442 [ INFO] 82619 --- [pool-8-thread-1] pache.kafka.common.config.AbstractConfig : AbstractConfig values: 
```

new Logentry
````
2022-07-26 21:27:57.646 [ WARN] 83000 --- [pool-8-thread-1] fka.connect.sink.converter.SinkConverter : Invalid value mongodb://localhost:27017?ssl=true&tlsAllowInvalidCertificates=tr for configuration connection.uri: The connection string contains options without trailing slash
org.apache.kafka.common.config.ConfigException: Invalid value mongodb://localhost:27017?ssl=true&tlsAllowInvalidCertificates=tr for configuration connection.uri: The connection string contains options without trailing slash
...
```