### PR TITLE
new feature about CDC Handler for 1 => N(multi row) data handle

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkRecordProcessor.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkRecordProcessor.java
@@ -48,7 +48,8 @@ final class MongoSinkRecordProcessor {
       if (processedData.getException() != null) {
         errorReporter.report(processedData.getSinkRecord(), processedData.getException());
         continue;
-      } else if (processedData.getNamespace() == null || processedData.getWriteModel() == null) {
+      } else if (processedData.getNamespace() == null
+          || processedData.getWriteModelList() == null) {
         // Some CDC events can be Noops (eg tombstone events)
         continue;
       }

--- a/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
@@ -138,7 +138,8 @@ public final class StartedMongoSinkTask {
 
     List<WriteModel<BsonDocument>> writeModels =
         batch.stream()
-            .map(MongoProcessedSinkRecordData::getWriteModel)
+            .map(MongoProcessedSinkRecordData::getWriteModelList)
+            .flatMap(list -> list.stream())
             .collect(Collectors.toList());
     boolean bulkWriteOrdered = config.getBoolean(BULK_WRITE_ORDERED_CONFIG);
 

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/CdcMultiOperation.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/CdcMultiOperation.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: Apache License, Version 2.0, Copyright 2017 Hans-Peter Grahsl.
+ */
+
+package com.mongodb.kafka.connect.sink.cdc;
+
+import java.util.List;
+
+import org.bson.BsonDocument;
+
+import com.mongodb.client.model.WriteModel;
+
+import com.mongodb.kafka.connect.sink.converter.SinkDocument;
+
+public interface CdcMultiOperation {
+
+  List<WriteModel<BsonDocument>> perform(SinkDocument doc);
+}

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/CdcMultiRowHandler.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/CdcMultiRowHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: Apache License, Version 2.0, Copyright 2017 Hans-Peter Grahsl.
+ */
+
+package com.mongodb.kafka.connect.sink.cdc;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.bson.BsonDocument;
+
+import com.mongodb.client.model.WriteModel;
+
+import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
+import com.mongodb.kafka.connect.sink.converter.SinkDocument;
+
+public abstract class CdcMultiRowHandler {
+
+  private final MongoSinkTopicConfig config;
+
+  public CdcMultiRowHandler(final MongoSinkTopicConfig config) {
+    this.config = config;
+  }
+
+  public MongoSinkTopicConfig getConfig() {
+    return config;
+  }
+
+  public abstract Optional<List<WriteModel<BsonDocument>>> handle(SinkDocument doc);
+}

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordDataTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordDataTest.java
@@ -225,7 +225,7 @@ class MongoProcessedSinkRecordDataTest {
         new MongoProcessedSinkRecordData(sinkRecord, createSinkConfig(topicConfig));
     assertNull(processedData.getException());
     UpdateOneModel<BsonDocument> writeModel =
-        (UpdateOneModel<BsonDocument>) processedData.getWriteModel();
+        (UpdateOneModel<BsonDocument>) processedData.getWriteModelList().get(0);
     assertTrue(writeModel.getOptions().isUpsert());
     assertEquals(BsonDocument.parse("{'a': 'a', 'b': 'b', '_id': 'c'}"), writeModel.getFilter());
 
@@ -251,7 +251,7 @@ class MongoProcessedSinkRecordDataTest {
       final ReplaceOneModel<BsonDocument> expectedWriteModel) {
     assertNull(processedData.getException());
     ReplaceOneModel<BsonDocument> writeModel =
-        (ReplaceOneModel<BsonDocument>) processedData.getWriteModel();
+        (ReplaceOneModel<BsonDocument>) processedData.getWriteModelList().get(0);
     assertEquals(expectedWriteModel.getFilter(), writeModel.getFilter());
     assertEquals(expectedWriteModel.getReplacement(), writeModel.getReplacement());
     assertEquals(


### PR DESCRIPTION
I'd like to develop Custom CDC Handler for N data insert with 1 sinkData.
But I can't find any base kafka connect feature about this ( kafka connect options, SMT )
And CDCHandler, CDCOperation to make custom CDC Handle below 

CdcOperation
~~~
WriteModel<BsonDocument> perform(SinkDocument doc);
~~~

CdcHandler
~~~
  public abstract Optional<WriteModel<BsonDocument>> handle(SinkDocument doc);
~~~

only support 1 => 1 data handle.

so I make a PR about this new feature
- sink connector option added ( change.data.capture.multi.row.handler )
- CdcMultiRowOperation, CdcMultiRowHanlder added
- modified sink task logic that return list<WriteModel> and append to bulkWrite


Can you review this PR for new feature add?

or 

Is there any other way for this I don't know?