### PR TITLE
SLF4J usage issues

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbHandler.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbHandler.java
@@ -76,8 +76,8 @@ public class MongoDbHandler extends DebeziumCdcHandler {
       return Optional.empty();
     }
 
-    LOGGER.debug("key: " + keyDoc.toString());
-    LOGGER.debug("value: " + valueDoc.toString());
+    LOGGER.debug("key: {}", keyDoc);
+    LOGGER.debug("value: {}", valueDoc);
 
     return Optional.of(getCdcOperation(valueDoc).perform(doc));
   }

--- a/src/main/java/com/mongodb/kafka/connect/sink/converter/SinkConverter.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/converter/SinkConverter.java
@@ -39,7 +39,7 @@ public class SinkConverter {
   private static final RecordConverter BYTE_ARRAY_RECORD_CONVERTER = new ByteArrayRecordConverter();
 
   public SinkDocument convert(final SinkRecord record) {
-    LOGGER.debug(record.toString());
+    LOGGER.debug("record: {}", record);
 
     BsonDocument keyDoc = null;
     if (record.key() != null) {

--- a/src/main/java/com/mongodb/kafka/connect/sink/converter/types/sink/bson/SinkFieldConverter.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/converter/types/sink/bson/SinkFieldConverter.java
@@ -42,19 +42,18 @@ public abstract class SinkFieldConverter extends FieldConverter {
       if (data == null) {
         throw new DataException("Schema not optional but data was null");
       }
-      LOGGER.trace("field not optional and data is '{}'", data.toString());
+      LOGGER.trace("field not optional and data is '{}'", data);
       return toBson(data);
     }
 
     if (data != null) {
-      LOGGER.trace("field optional and data is '{}'", data.toString());
+      LOGGER.trace("field optional and data is '{}'", data);
       return toBson(data);
     }
 
     if (fieldSchema.defaultValue() != null) {
       LOGGER.trace(
-          "field optional and no data but default value is '{}'",
-          fieldSchema.defaultValue().toString());
+          "field optional and no data but default value is '{}'", fieldSchema.defaultValue());
       return toBson(fieldSchema.defaultValue());
     }
 

--- a/src/main/java/com/mongodb/kafka/connect/source/heartbeat/HeartbeatManager.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/heartbeat/HeartbeatManager.java
@@ -63,7 +63,8 @@ public class HeartbeatManager {
       return Optional.empty();
     }
     if (heartbeatIntervalMS <= 0) {
-      LOGGER.debug("Returning no heartbeat: heartbeatIntervalMS not positive: " + heartbeatIntervalMS);
+      LOGGER.debug(
+          "Returning no heartbeat: heartbeatIntervalMS not positive: {}", heartbeatIntervalMS);
       return Optional.empty();
     }
     long currentMS = time.milliseconds();

--- a/src/main/java/com/mongodb/kafka/connect/util/jmx/internal/MBeanServerUtils.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/jmx/internal/MBeanServerUtils.java
@@ -71,13 +71,13 @@ public final class MBeanServerUtils {
           server.registerMBean(mBean, new ObjectName(mBeanNameToTry));
           return mBeanNameToTry;
         } catch (InstanceAlreadyExistsException e) {
-          LOGGER.warn("MBean name conflict " + mBeanNameToTry, e);
+          LOGGER.warn("MBean name conflict {}", mBeanNameToTry, e);
           mBeanNameToTry = mBeanName + "-v" + NEXT_ID.getAndAdd(1);
         }
       }
     } catch (Exception e) {
       // JMX might not be available
-      LOGGER.warn("Unable to register MBean " + mBeanName, e);
+      LOGGER.warn("Unable to register MBean {}", mBeanName, e);
       return mBeanName + "-not-registered";
     }
   }
@@ -91,7 +91,7 @@ public final class MBeanServerUtils {
       }
     } catch (Exception e) {
       // JMX might not be available
-      LOGGER.warn("Unable to unregister MBean " + mBeanName, e);
+      LOGGER.warn("Unable to unregister MBean {}", mBeanName, e);
     }
   }
 


### PR DESCRIPTION
Premature `toString()` invocation and string concatenation may cause performance issues in high-load applications.

[KAFKA-328](https://jira.mongodb.org/browse/KAFKA-328)