### PR TITLE
Adds config 'skip.user.action.validation' to skip user permissions check

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/MongoSinkConnector.java
+++ b/src/main/java/com/mongodb/kafka/connect/MongoSinkConnector.java
@@ -102,36 +102,41 @@ public class MongoSinkConnector extends SinkConnector {
                                 topic -> {
                                   MongoSinkTopicConfig mongoSinkTopicConfig =
                                       sinkConfig.getMongoSinkTopicConfig(topic);
-                                  validateUserHasActions(
-                                      client,
-                                      sinkConfig.getConnectionString().getCredential(),
-                                      mongoSinkTopicConfig.isTimeseries()
-                                          ? REQUIRED_COLLSTATS_SINK_ACTIONS
-                                          : REQUIRED_SINK_ACTIONS,
-                                      mongoSinkTopicConfig.getString(
-                                          MongoSinkTopicConfig.DATABASE_CONFIG),
-                                      mongoSinkTopicConfig.getString(
-                                          MongoSinkTopicConfig.COLLECTION_CONFIG),
-                                      CONNECTION_URI_CONFIG,
-                                      config);
+
+                                  if (!sinkConfig.getSkipUserActionValidation()) {
+                                    validateUserHasActions(
+                                        client,
+                                        sinkConfig.getConnectionString().getCredential(),
+                                        mongoSinkTopicConfig.isTimeseries()
+                                            ? REQUIRED_COLLSTATS_SINK_ACTIONS
+                                            : REQUIRED_SINK_ACTIONS,
+                                        mongoSinkTopicConfig.getString(
+                                            MongoSinkTopicConfig.DATABASE_CONFIG),
+                                        mongoSinkTopicConfig.getString(
+                                            MongoSinkTopicConfig.COLLECTION_CONFIG),
+                                        CONNECTION_URI_CONFIG,
+                                        config);
+                                  }
                                   validateConfigAndCollection(client, mongoSinkTopicConfig, config);
                                 }));
                 sinkConfig
                     .getTopicRegex()
                     .ifPresent(
                         regex -> {
-                          validateUserHasActions(
-                              client,
-                              sinkConfig.getConnectionString().getCredential(),
-                              REQUIRED_SINK_ACTIONS,
-                              getConfigByName(config, MongoSinkTopicConfig.DATABASE_CONFIG)
-                                  .map(c -> (String) c.value())
-                                  .orElse(""),
-                              getConfigByName(config, MongoSinkTopicConfig.COLLECTION_CONFIG)
-                                  .map(c -> (String) c.value())
-                                  .orElse(""),
-                              CONNECTION_URI_CONFIG,
-                              config);
+                          if (!sinkConfig.getSkipUserActionValidation()) {
+                            validateUserHasActions(
+                                client,
+                                sinkConfig.getConnectionString().getCredential(),
+                                REQUIRED_SINK_ACTIONS,
+                                getConfigByName(config, MongoSinkTopicConfig.DATABASE_CONFIG)
+                                    .map(c -> (String) c.value())
+                                    .orElse(""),
+                                getConfigByName(config, MongoSinkTopicConfig.COLLECTION_CONFIG)
+                                    .map(c -> (String) c.value())
+                                    .orElse(""),
+                                CONNECTION_URI_CONFIG,
+                                config);
+                          }
                           validTopicRegexConfigAndCollection(client, sinkConfig, config);
                         });
               } catch (Exception e) {

--- a/src/main/java/com/mongodb/kafka/connect/MongoSourceConnector.java
+++ b/src/main/java/com/mongodb/kafka/connect/MongoSourceConnector.java
@@ -62,14 +62,16 @@ public class MongoSourceConnector extends SourceConnector {
             client -> {
               try {
                 validateServerApi(client, config);
-                validateUserHasActions(
-                    client,
-                    sourceConfig.getConnectionString().getCredential(),
-                    REQUIRED_SOURCE_ACTIONS,
-                    sourceConfig.getString(MongoSourceConfig.DATABASE_CONFIG),
-                    sourceConfig.getString(MongoSourceConfig.COLLECTION_CONFIG),
-                    MongoSourceConfig.CONNECTION_URI_CONFIG,
-                    config);
+                if (!sourceConfig.isSkipUserActionValidation()) {
+                  validateUserHasActions(
+                      client,
+                      sourceConfig.getConnectionString().getCredential(),
+                      REQUIRED_SOURCE_ACTIONS,
+                      sourceConfig.getString(MongoSourceConfig.DATABASE_CONFIG),
+                      sourceConfig.getString(MongoSourceConfig.COLLECTION_CONFIG),
+                      MongoSourceConfig.CONNECTION_URI_CONFIG,
+                      config);
+                }
               } catch (Exception e) {
                 // Ignore
               } finally {

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
@@ -76,6 +76,14 @@ public class MongoSinkConfig extends AbstractConfig {
       "The connection URI as supported by the official drivers. "
           + "eg: ``mongodb://user@pass@locahost/``.";
 
+  public static final String SKIP_USER_ACTION_VALIDATION_CONFIG = "skip.user.action.validation";
+  private static final boolean SKIP_USER_ACTION_VALIDATION_DEFAULT = false;
+  private static final String SKIP_USER_ACTION_VALIDATION_DISPLAY =
+      "Skips the check for user actions";
+  private static final String SKIP_USER_ACTION_VALIDATION_DOC =
+      "Optional, skips user action validations. Use with MongoDB "
+          + "backend that don't support MongoDB native RBAC checks (e.g., Azure CosmosDB)";
+
   public static final String TOPIC_OVERRIDE_CONFIG = "topic.override.%s.%s";
   private static final String TOPIC_OVERRIDE_DEFAULT = EMPTY_STRING;
   private static final String TOPIC_OVERRIDE_DISPLAY = "Per topic configuration overrides.";
@@ -98,6 +106,8 @@ public class MongoSinkConfig extends AbstractConfig {
   private final Optional<Pattern> topicsRegex;
   private Map<String, MongoSinkTopicConfig> topicSinkConnectorConfigMap;
   private ConnectionString connectionString;
+
+  private boolean skipUserActionValidation;
 
   public MongoSinkConfig(final Map<String, String> originals) {
     super(CONFIG, originals, false);
@@ -123,6 +133,9 @@ public class MongoSinkConfig extends AbstractConfig {
     }
 
     connectionString = new ConnectionString(getString(CONNECTION_URI_CONFIG));
+
+    skipUserActionValidation = getBoolean(SKIP_USER_ACTION_VALIDATION_CONFIG);
+
     topicSinkConnectorConfigMap =
         new ConcurrentHashMap<>(
             topics.orElse(emptyList()).stream()
@@ -157,6 +170,10 @@ public class MongoSinkConfig extends AbstractConfig {
 
   public ConnectionString getConnectionString() {
     return connectionString;
+  }
+
+  public boolean getSkipUserActionValidation() {
+    return skipUserActionValidation;
   }
 
   public Optional<List<String>> getTopics() {
@@ -279,6 +296,17 @@ public class MongoSinkConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         CONNECTION_URI_DISPLAY);
+
+    configDef.define(
+        SKIP_USER_ACTION_VALIDATION_CONFIG,
+        Type.BOOLEAN,
+        SKIP_USER_ACTION_VALIDATION_DEFAULT,
+        Importance.LOW,
+        SKIP_USER_ACTION_VALIDATION_DOC,
+        group,
+        ++orderInGroup,
+        Width.SHORT,
+        SKIP_USER_ACTION_VALIDATION_DISPLAY);
 
     addServerApiConfig(configDef);
 

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
@@ -19,6 +19,7 @@
 package com.mongodb.kafka.connect.sink;
 
 import static com.mongodb.kafka.connect.sink.MongoSinkConfig.CONNECTION_URI_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkConfig.SKIP_USER_ACTION_VALIDATION_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkConfig.TOPICS_CONFIG;
 import static com.mongodb.kafka.connect.util.ClassHelper.createInstance;
 import static com.mongodb.kafka.connect.util.FlexibleDateTimeParser.DEFAULT_DATE_TIME_FORMATTER_PATTERN;
@@ -639,6 +640,7 @@ public class MongoSinkTopicConfig extends AbstractConfig {
         (k, v) -> {
           if (!k.startsWith(TOPIC_OVERRIDE_PREFIX)
               && !k.equals(CONNECTION_URI_CONFIG)
+              && !k.equals(SKIP_USER_ACTION_VALIDATION_CONFIG)
               && !k.equals(TOPICS_CONFIG)) {
             topicConfig.put(k, v);
           }
@@ -682,6 +684,7 @@ public class MongoSinkTopicConfig extends AbstractConfig {
         (k, v) -> {
           if (!k.startsWith(TOPIC_OVERRIDE_PREFIX)
               && !k.equals(CONNECTION_URI_CONFIG)
+              && !k.equals(SKIP_USER_ACTION_VALIDATION_CONFIG)
               && !k.equals(TOPICS_CONFIG)) {
             topicConfig.put(k, v);
           }

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -74,6 +74,14 @@ public class MongoSourceConfig extends AbstractConfig {
       "The connection URI as supported by the official drivers. "
           + "eg: ``mongodb://user@pass@locahost/``.";
 
+  public static final String SKIP_USER_ACTION_VALIDATION_CONFIG = "skip.user.action.validation";
+  private static final boolean SKIP_USER_ACTION_VALIDATION_DEFAULT = false;
+  private static final String SKIP_USER_ACTION_VALIDATION_DISPLAY =
+      "Skips the check for user actions";
+  private static final String SKIP_USER_ACTION_VALIDATION_DOC =
+      "Optional, skips user action validations. Use with MongoDB "
+          + "backend that don't support MongoDB native RBAC checks (e.g., Azure CosmosDB)";
+
   public static final String OUTPUT_FORMAT_KEY_CONFIG = "output.format.key";
   private static final String OUTPUT_FORMAT_KEY_DEFAULT =
       OutputFormat.JSON.name().toLowerCase(Locale.ROOT);
@@ -378,6 +386,7 @@ public class MongoSourceConfig extends AbstractConfig {
   }
 
   private final ConnectionString connectionString;
+  private final boolean skipUserActionValidation;
   private TopicMapper topicMapper;
 
   public MongoSourceConfig(final Map<?, ?> originals) {
@@ -387,6 +396,7 @@ public class MongoSourceConfig extends AbstractConfig {
   private MongoSourceConfig(final Map<?, ?> originals, final boolean validateAll) {
     super(CONFIG, originals, false);
     connectionString = new ConnectionString(getString(CONNECTION_URI_CONFIG));
+    skipUserActionValidation = getBoolean(SKIP_USER_ACTION_VALIDATION_CONFIG);
 
     if (validateAll) {
       INITIALIZERS.forEach(i -> i.accept(this));
@@ -395,6 +405,10 @@ public class MongoSourceConfig extends AbstractConfig {
 
   public ConnectionString getConnectionString() {
     return connectionString;
+  }
+
+  public boolean isSkipUserActionValidation() {
+    return skipUserActionValidation;
   }
 
   public OutputFormat getKeyOutputFormat() {
@@ -551,6 +565,17 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         COLLECTION_DISPLAY);
+
+    configDef.define(
+        SKIP_USER_ACTION_VALIDATION_CONFIG,
+        Type.BOOLEAN,
+        SKIP_USER_ACTION_VALIDATION_DEFAULT,
+        Importance.LOW,
+        SKIP_USER_ACTION_VALIDATION_DOC,
+        group,
+        ++orderInGroup,
+        Width.SHORT,
+        SKIP_USER_ACTION_VALIDATION_DISPLAY);
 
     addServerApiConfig(configDef);
 


### PR DESCRIPTION
Ticket: https://jira.mongodb.org/browse/KAFKA-332

The idea is to have a configuration option that allows skipping user permission check if explicitly enabled.

Some backends emulating Mongo like CosmosDB Mongo API don't support the `connectionStatus` command and don't return the permissions. However, the user does have everything necessary for the connector to function normally.