### PR TITLE
Add the new `change.stream.full.document.before.change` config property

### DIFF
--- a/src/integrationTest/java/com/mongodb/kafka/connect/mongodb/MongoKafkaTestCase.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/mongodb/MongoKafkaTestCase.java
@@ -113,6 +113,7 @@ public class MongoKafkaTestCase {
   private static final int FOUR_DOT_ZERO_WIRE_VERSION = 7;
   private static final int FOUR_DOT_TWO_WIRE_VERSION = 8;
   public static final int FOUR_DOT_FOUR_WIRE_VERSION = 9;
+  private static final int SIX_DOT_ZERO_WIRE_VERSION = 17;
 
   public boolean isGreaterThanThreeDotSix() {
     return getMaxWireVersion() > THREE_DOT_SIX_WIRE_VERSION;
@@ -128,6 +129,10 @@ public class MongoKafkaTestCase {
 
   public boolean isGreaterThanFourDotFour() {
     return getMaxWireVersion() > FOUR_DOT_FOUR_WIRE_VERSION;
+  }
+
+  public boolean isAtLeastSixDotZero() {
+    return getMaxWireVersion() >= SIX_DOT_ZERO_WIRE_VERSION;
   }
 
   public int getMaxWireVersion() {

--- a/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationJunkTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationJunkTest.java
@@ -22,8 +22,6 @@ import static com.mongodb.kafka.connect.source.MongoSourceConfig.CONNECTION_URI_
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.DATABASE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.FULL_DOCUMENT_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.PIPELINE_CONFIG;
-import static com.mongodb.kafka.connect.source.SourceTestHelper.TEST_COLLECTION;
-import static com.mongodb.kafka.connect.source.SourceTestHelper.TEST_DATABASE;
 import static com.mongodb.kafka.connect.util.jmx.internal.MBeanServerUtils.getMBeanAttributes;
 import static java.lang.String.format;
 import static java.util.Collections.singletonMap;
@@ -33,6 +31,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -64,8 +63,15 @@ import com.mongodb.client.model.changestream.FullDocument;
 import com.mongodb.event.CommandFailedEvent;
 import com.mongodb.event.CommandSucceededEvent;
 
+import com.mongodb.kafka.connect.util.jmx.SourceTaskStatistics;
+
+/**
+ * This class contains tests that are supposed to be unit tests, but because of how these tests were
+ * written originally, they became integration tests as a result of refactoring {@link
+ * MongoSourceConfig}, and need to be completely rewritten to remain unit tests.
+ */
 @ExtendWith(MockitoExtension.class)
-class MongoSourceTaskTest {
+class MongoSourceTaskIntegrationJunkTest {
 
   @Mock private MongoClient mongoClient;
   @Mock private MongoDatabase mongoDatabase;
@@ -76,6 +82,8 @@ class MongoSourceTaskTest {
   @Mock private SourceTaskContext context;
   @Mock private OffsetStorageReader offsetStorageReader;
 
+  private static final String TEST_DATABASE = "myDB";
+  private static final String TEST_COLLECTION = "myColl";
   private static final BsonDocument RESUME_TOKEN = BsonDocument.parse("{resume: 'token'}");
   private static final Map<String, Object> OFFSET = singletonMap("_id", RESUME_TOKEN.toJson());
 
@@ -88,6 +96,7 @@ class MongoSourceTaskTest {
     cfgMap.put(DATABASE_CONFIG, TEST_DATABASE);
     cfgMap.put(COLLECTION_CONFIG, TEST_COLLECTION);
     MongoSourceConfig cfg = new MongoSourceConfig(cfgMap);
+    task.start(cfgMap);
 
     when(mongoClient.getDatabase(TEST_DATABASE)).thenReturn(mongoDatabase);
     when(mongoDatabase.getCollection(TEST_COLLECTION)).thenReturn(mongoCollection);
@@ -95,7 +104,7 @@ class MongoSourceTaskTest {
     when(changeStreamIterable.withDocumentClass(RawBsonDocument.class)).thenReturn(mongoIterable);
     when(mongoIterable.cursor()).thenReturn(mongoCursor);
 
-    task.createCursor(cfg, mongoClient);
+    task.startedTask().createCursor(cfg, mongoClient);
 
     verify(mongoClient, times(1)).getDatabase(TEST_DATABASE);
     verify(mongoDatabase, times(1)).getCollection(TEST_COLLECTION);
@@ -114,7 +123,7 @@ class MongoSourceTaskTest {
     when(changeStreamIterable.withDocumentClass(RawBsonDocument.class)).thenReturn(mongoIterable);
     when(mongoIterable.cursor()).thenReturn(mongoCursor);
 
-    task.createCursor(cfg, mongoClient);
+    task.startedTask().createCursor(cfg, mongoClient);
 
     verify(mongoClient, times(1)).getDatabase(TEST_DATABASE);
     verify(mongoDatabase, times(1)).getCollection(TEST_COLLECTION);
@@ -146,7 +155,7 @@ class MongoSourceTaskTest {
 
     task.initialize(context);
     when(context.offsetStorageReader()).thenReturn(offsetStorageReader);
-    when(offsetStorageReader.offset(task.createPartitionMap(cfg))).thenReturn(OFFSET);
+    when(offsetStorageReader.offset(MongoSourceTask.createPartitionMap(cfg))).thenReturn(OFFSET);
 
     when(mongoClient.getDatabase(TEST_DATABASE)).thenReturn(mongoDatabase);
     when(mongoDatabase.getCollection(TEST_COLLECTION)).thenReturn(mongoCollection);
@@ -158,7 +167,7 @@ class MongoSourceTaskTest {
     when(changeStreamIterable.withDocumentClass(RawBsonDocument.class)).thenReturn(mongoIterable);
     when(mongoIterable.cursor()).thenReturn(mongoCursor);
 
-    task.createCursor(cfg, mongoClient);
+    task.startedTask().createCursor(cfg, mongoClient);
 
     verify(mongoClient, times(1)).getDatabase(TEST_DATABASE);
     verify(mongoDatabase, times(1)).getCollection(TEST_COLLECTION);
@@ -169,6 +178,8 @@ class MongoSourceTaskTest {
     verify(changeStreamIterable, times(1)).startAfter(RESUME_TOKEN);
     verify(changeStreamIterable, times(1)).withDocumentClass(RawBsonDocument.class);
     verify(mongoIterable, times(1)).cursor();
+
+    task.stop();
   }
 
   @Test
@@ -179,13 +190,14 @@ class MongoSourceTaskTest {
     cfgMap.put(CONNECTION_URI_CONFIG, "mongodb://localhost");
     cfgMap.put(DATABASE_CONFIG, TEST_DATABASE);
     MongoSourceConfig cfg = new MongoSourceConfig(cfgMap);
+    task.start(cfgMap);
 
     when(mongoClient.getDatabase(TEST_DATABASE)).thenReturn(mongoDatabase);
     when(mongoDatabase.watch()).thenReturn(changeStreamIterable);
     when(changeStreamIterable.withDocumentClass(RawBsonDocument.class)).thenReturn(mongoIterable);
     when(mongoIterable.cursor()).thenReturn(mongoCursor);
 
-    task.createCursor(cfg, mongoClient);
+    task.startedTask().createCursor(cfg, mongoClient);
 
     verify(mongoClient, times(1)).getDatabase(TEST_DATABASE);
     verify(mongoDatabase, times(1)).watch();
@@ -202,7 +214,7 @@ class MongoSourceTaskTest {
     when(changeStreamIterable.withDocumentClass(RawBsonDocument.class)).thenReturn(mongoIterable);
     when(mongoIterable.cursor()).thenReturn(mongoCursor);
 
-    task.createCursor(cfg, mongoClient);
+    task.startedTask().createCursor(cfg, mongoClient);
 
     verify(mongoClient, times(1)).getDatabase(TEST_DATABASE);
     verify(mongoDatabase, times(1)).watch(cfg.getPipeline().get());
@@ -233,7 +245,7 @@ class MongoSourceTaskTest {
 
     task.initialize(context);
     when(context.offsetStorageReader()).thenReturn(offsetStorageReader);
-    when(offsetStorageReader.offset(task.createPartitionMap(cfg))).thenReturn(OFFSET);
+    when(offsetStorageReader.offset(MongoSourceTask.createPartitionMap(cfg))).thenReturn(OFFSET);
 
     when(mongoClient.getDatabase(TEST_DATABASE)).thenReturn(mongoDatabase);
     when(mongoDatabase.watch(cfg.getPipeline().get())).thenReturn(changeStreamIterable);
@@ -244,7 +256,7 @@ class MongoSourceTaskTest {
     when(changeStreamIterable.withDocumentClass(RawBsonDocument.class)).thenReturn(mongoIterable);
     when(mongoIterable.cursor()).thenReturn(mongoCursor);
 
-    task.createCursor(cfg, mongoClient);
+    task.startedTask().createCursor(cfg, mongoClient);
 
     verify(mongoClient, times(1)).getDatabase(TEST_DATABASE);
     verify(mongoDatabase, times(1)).watch(cfg.getPipeline().get());
@@ -254,6 +266,8 @@ class MongoSourceTaskTest {
     verify(changeStreamIterable, times(1)).startAfter(RESUME_TOKEN);
     verify(changeStreamIterable, times(1)).withDocumentClass(RawBsonDocument.class);
     verify(mongoIterable, times(1)).cursor();
+
+    task.stop();
   }
 
   @Test
@@ -263,12 +277,13 @@ class MongoSourceTaskTest {
     Map<String, String> cfgMap = new HashMap<>();
     cfgMap.put(CONNECTION_URI_CONFIG, "mongodb://localhost");
     MongoSourceConfig cfg = new MongoSourceConfig(cfgMap);
+    task.start(cfgMap);
 
     when(mongoClient.watch()).thenReturn(changeStreamIterable);
     when(changeStreamIterable.withDocumentClass(RawBsonDocument.class)).thenReturn(mongoIterable);
     when(mongoIterable.cursor()).thenReturn(mongoCursor);
 
-    task.createCursor(cfg, mongoClient);
+    task.startedTask().createCursor(cfg, mongoClient);
 
     verify(mongoClient, times(1)).watch();
     verify(changeStreamIterable, times(1)).withDocumentClass(RawBsonDocument.class);
@@ -283,7 +298,7 @@ class MongoSourceTaskTest {
     when(changeStreamIterable.withDocumentClass(RawBsonDocument.class)).thenReturn(mongoIterable);
     when(mongoIterable.cursor()).thenReturn(mongoCursor);
 
-    task.createCursor(cfg, mongoClient);
+    task.startedTask().createCursor(cfg, mongoClient);
 
     verify(mongoClient, times(1)).watch(cfg.getPipeline().get());
     verify(changeStreamIterable, times(1)).withDocumentClass(RawBsonDocument.class);
@@ -312,7 +327,7 @@ class MongoSourceTaskTest {
 
     task.initialize(context);
     when(context.offsetStorageReader()).thenReturn(offsetStorageReader);
-    when(offsetStorageReader.offset(task.createPartitionMap(cfg))).thenReturn(OFFSET);
+    when(offsetStorageReader.offset(MongoSourceTask.createPartitionMap(cfg))).thenReturn(OFFSET);
 
     when(mongoClient.watch(cfg.getPipeline().get())).thenReturn(changeStreamIterable);
     when(changeStreamIterable.batchSize(101)).thenReturn(changeStreamIterable);
@@ -322,7 +337,7 @@ class MongoSourceTaskTest {
     when(changeStreamIterable.withDocumentClass(RawBsonDocument.class)).thenReturn(mongoIterable);
     when(mongoIterable.cursor()).thenReturn(mongoCursor);
 
-    task.createCursor(cfg, mongoClient);
+    task.startedTask().createCursor(cfg, mongoClient);
 
     verify(mongoClient, times(1)).watch(cfg.getPipeline().get());
     verify(changeStreamIterable, times(1)).batchSize(101);
@@ -331,30 +346,30 @@ class MongoSourceTaskTest {
     verify(changeStreamIterable, times(1)).startAfter(RESUME_TOKEN);
     verify(changeStreamIterable, times(1)).withDocumentClass(RawBsonDocument.class);
     verify(mongoIterable, times(1)).cursor();
+
+    task.stop();
   }
 
   @Test
   @DisplayName("test handles legacy offsets")
   void testHandlesLegacyOffsets() {
-    MongoSourceTask task = new MongoSourceTask();
     Map<String, String> cfgMap = new HashMap<>();
     cfgMap.put(CONNECTION_URI_CONFIG, "mongodb://localhost");
     cfgMap.put(DATABASE_CONFIG, TEST_DATABASE);
     cfgMap.put(COLLECTION_CONFIG, TEST_COLLECTION);
     MongoSourceConfig cfg = new MongoSourceConfig(cfgMap);
 
-    task.initialize(context);
     when(context.offsetStorageReader()).thenReturn(offsetStorageReader);
-    when(offsetStorageReader.offset(task.createPartitionMap(cfg))).thenReturn(null);
-    when(offsetStorageReader.offset(task.createLegacyPartitionMap(cfg))).thenReturn(OFFSET);
+    when(offsetStorageReader.offset(MongoSourceTask.createPartitionMap(cfg))).thenReturn(null);
+    when(offsetStorageReader.offset(MongoSourceTask.createLegacyPartitionMap(cfg)))
+        .thenReturn(OFFSET);
 
-    assertEquals(OFFSET, task.getOffset(cfg));
+    assertEquals(OFFSET, MongoSourceTask.getOffset(context, cfg));
   }
 
   @Test
   @DisplayName("test creates the expected partition map")
   void testCreatesTheExpectedPartitionMap() {
-    MongoSourceTask task = new MongoSourceTask();
     Map<String, String> cfgMap = new HashMap<>();
     cfgMap.put(CONNECTION_URI_CONFIG, "mongodb+srv://user:password@localhost/");
     cfgMap.put(DATABASE_CONFIG, TEST_DATABASE);
@@ -363,31 +378,33 @@ class MongoSourceTaskTest {
 
     assertEquals(
         format("mongodb+srv://localhost/%s.%s", TEST_DATABASE, TEST_COLLECTION),
-        task.createDefaultPartitionName(cfg));
+        MongoSourceTask.createDefaultPartitionName(cfg));
     assertEquals(
         format("mongodb+srv://user:password@localhost//%s.%s", TEST_DATABASE, TEST_COLLECTION),
-        task.createLegacyPartitionName(cfg));
+        MongoSourceTask.createLegacyPartitionName(cfg));
 
     cfgMap.put(CONNECTION_URI_CONFIG, "mongodb://localhost/");
     cfg = new MongoSourceConfig(cfgMap);
     assertEquals(
         format("mongodb://localhost/%s.%s", TEST_DATABASE, TEST_COLLECTION),
-        task.createDefaultPartitionName(cfg));
+        MongoSourceTask.createDefaultPartitionName(cfg));
     assertEquals(
         format("mongodb://localhost//%s.%s", TEST_DATABASE, TEST_COLLECTION),
-        task.createLegacyPartitionName(cfg));
+        MongoSourceTask.createLegacyPartitionName(cfg));
 
     cfgMap.remove(COLLECTION_CONFIG);
     cfg = new MongoSourceConfig(cfgMap);
     assertEquals(
-        format("mongodb://localhost/%s", TEST_DATABASE), task.createDefaultPartitionName(cfg));
+        format("mongodb://localhost/%s", TEST_DATABASE),
+        MongoSourceTask.createDefaultPartitionName(cfg));
     assertEquals(
-        format("mongodb://localhost//%s.", TEST_DATABASE), task.createLegacyPartitionName(cfg));
+        format("mongodb://localhost//%s.", TEST_DATABASE),
+        MongoSourceTask.createLegacyPartitionName(cfg));
 
     cfgMap.remove(DATABASE_CONFIG);
     cfg = new MongoSourceConfig(cfgMap);
-    assertEquals("mongodb://localhost/", task.createDefaultPartitionName(cfg));
-    assertEquals("mongodb://localhost//.", task.createLegacyPartitionName(cfg));
+    assertEquals("mongodb://localhost/", MongoSourceTask.createDefaultPartitionName(cfg));
+    assertEquals("mongodb://localhost//.", MongoSourceTask.createLegacyPartitionName(cfg));
   }
 
   @Test
@@ -396,7 +413,7 @@ class MongoSourceTaskTest {
     String mBeanName =
         "com.mongodb.kafka.connect:type=source-task-metrics,task=source-task-change-stream-unknown";
     MongoSourceTask task = new MongoSourceTask();
-    task.initializeStatistics(false);
+    task.start(Collections.emptyMap());
 
     task.commitRecord(null, new RecordMetadata(null, 0, 0, 0, 0L, 0, 0));
 
@@ -421,10 +438,10 @@ class MongoSourceTaskTest {
     String mBeanName =
         "com.mongodb.kafka.connect:type=source-task-metrics,task=source-task-change-stream-unknown";
 
-    MongoSourceTask getmoreSuccessTask = new MongoSourceTask();
-    getmoreSuccessTask.initializeStatistics(false);
-    getmoreSuccessTask.mongoCommandSucceeded(
-        new CommandSucceededEvent(0, null, "getMore", new BsonDocument(), 100000000));
+    SourceTaskStatistics stats = new SourceTaskStatistics(mBeanName);
+    stats.register();
+    MongoSourceTask.mongoCommandSucceeded(
+        new CommandSucceededEvent(0, null, "getMore", new BsonDocument(), 100000000), stats);
     for (Map<String, Long> attrs : getMBeanAttributes(mBeanName).values()) {
       assertEquals(1, attrs.get("getmore-commands-successful"));
       assertEquals(100, attrs.get("getmore-commands-successful-duration-ms"));
@@ -432,12 +449,12 @@ class MongoSourceTaskTest {
       assertEquals(1, attrs.get("getmore-commands-successful-duration-over-10-ms"));
       assertEquals(4, attrs.values().stream().filter(v -> v != 0).count());
     }
-    getmoreSuccessTask.stop();
+    stats.unregister();
 
-    MongoSourceTask initiatingSuccessTask = new MongoSourceTask();
-    initiatingSuccessTask.initializeStatistics(false);
-    initiatingSuccessTask.mongoCommandSucceeded(
-        new CommandSucceededEvent(0, null, "aggregate", new BsonDocument(), 100000000));
+    stats = new SourceTaskStatistics(mBeanName);
+    stats.register();
+    MongoSourceTask.mongoCommandSucceeded(
+        new CommandSucceededEvent(0, null, "aggregate", new BsonDocument(), 100000000), stats);
     for (Map<String, Long> attrs : getMBeanAttributes(mBeanName).values()) {
       assertEquals(1, attrs.get("initial-commands-successful"));
       assertEquals(100, attrs.get("initial-commands-successful-duration-ms"));
@@ -445,12 +462,12 @@ class MongoSourceTaskTest {
       assertEquals(1, attrs.get("initial-commands-successful-duration-over-10-ms"));
       assertEquals(4, attrs.values().stream().filter(v -> v != 0).count());
     }
-    initiatingSuccessTask.stop();
+    stats.unregister();
 
-    MongoSourceTask getmoreFailedTask = new MongoSourceTask();
-    getmoreFailedTask.initializeStatistics(false);
-    getmoreFailedTask.mongoCommandFailed(
-        new CommandFailedEvent(0, null, "getMore", 100000000, null));
+    stats = new SourceTaskStatistics(mBeanName);
+    stats.register();
+    MongoSourceTask.mongoCommandFailed(
+        new CommandFailedEvent(0, null, "getMore", 100000000, null), stats);
     for (Map<String, Long> attrs : getMBeanAttributes(mBeanName).values()) {
       assertEquals(1, attrs.get("getmore-commands-failed"));
       assertEquals(100, attrs.get("getmore-commands-failed-duration-ms"));
@@ -458,12 +475,12 @@ class MongoSourceTaskTest {
       assertEquals(1, attrs.get("getmore-commands-failed-duration-over-10-ms"));
       assertEquals(4, attrs.values().stream().filter(v -> v != 0).count());
     }
-    getmoreFailedTask.stop();
+    stats.unregister();
 
-    MongoSourceTask initiatingFailedTask = new MongoSourceTask();
-    initiatingFailedTask.initializeStatistics(false);
-    initiatingFailedTask.mongoCommandFailed(
-        new CommandFailedEvent(0, null, "aggregate", 100000000, null));
+    stats = new SourceTaskStatistics(mBeanName);
+    stats.register();
+    MongoSourceTask.mongoCommandFailed(
+        new CommandFailedEvent(0, null, "aggregate", 100000000, null), stats);
     for (Map<String, Long> attrs : getMBeanAttributes(mBeanName).values()) {
       assertEquals(1, attrs.get("initial-commands-failed"));
       assertEquals(100, attrs.get("initial-commands-failed-duration-ms"));
@@ -471,7 +488,7 @@ class MongoSourceTaskTest {
       assertEquals(1, attrs.get("initial-commands-failed-duration-over-10-ms"));
       assertEquals(4, attrs.values().stream().filter(v -> v != 0).count());
     }
-    initiatingFailedTask.stop();
+    stats.unregister();
   }
 
   private void resetMocks() {

--- a/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest2.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest2.java
@@ -71,7 +71,7 @@ import com.mongodb.kafka.connect.util.jmx.SourceTaskStatistics;
  * MongoSourceConfig}, and need to be completely rewritten to remain unit tests.
  */
 @ExtendWith(MockitoExtension.class)
-class MongoSourceTaskIntegrationJunkTest {
+class MongoSourceTaskIntegrationTest2 {
 
   @Mock private MongoClient mongoClient;
   @Mock private MongoDatabase mongoDatabase;

--- a/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
@@ -76,6 +76,7 @@ final class StartedMongoSinkTask {
             (inTaskPutSample) -> {
               statistics.getInTaskPut().sample(inTaskPutSample.toMillis());
               if (LOGGER.isDebugEnabled()) {
+                // toJSON relatively expensive
                 LOGGER.debug(statistics.getName() + ": " + statistics.toJSON());
               }
             },

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -213,7 +213,8 @@ public class MongoSourceConfig extends AbstractConfig {
       "Determines what to return for update operations when using a Change Stream.\n"
           + "When set to 'updateLookup', the change stream for partial updates will include both a delta "
           + "describing the changes to the document as well as a copy of the entire document that was changed from *some time* after "
-          + "the change occurred.";
+          + "the change occurred.\n"
+          + "See https://www.mongodb.com/docs/manual/reference/method/db.collection.watch/ for more details and possible values.";
   private static final String FULL_DOCUMENT_DEFAULT = EMPTY_STRING;
 
   public static final String COLLATION_CONFIG = "collation";

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -199,7 +199,7 @@ public class MongoSourceConfig extends AbstractConfig {
   public static final String FULL_DOCUMENT_BEFORE_CHANGE_CONFIG =
       "change.stream.full.document.before.change";
   private static final String FULL_DOCUMENT_BEFORE_CHANGE_DISPLAY =
-      "The fullDocumentBeforeChange configuration.";
+      "The `fullDocumentBeforeChange` configuration.";
   private static final String FULL_DOCUMENT_BEFORE_CHANGE_DOC =
       "Specifies the pre-image configuration when creating a Change Stream.\n"
           + "The pre-image is not available in source records published while copying existing data as a result of"
@@ -208,7 +208,7 @@ public class MongoSourceConfig extends AbstractConfig {
   private static final String FULL_DOCUMENT_BEFORE_CHANGE_DEFAULT = EMPTY_STRING;
 
   public static final String FULL_DOCUMENT_CONFIG = "change.stream.full.document";
-  private static final String FULL_DOCUMENT_DISPLAY = "Set what to return for update operations";
+  private static final String FULL_DOCUMENT_DISPLAY = "The `fullDocument` configuration.";
   private static final String FULL_DOCUMENT_DOC =
       "Determines what to return for update operations when using a Change Stream.\n"
           + "When set to 'updateLookup', the change stream for partial updates will include both a delta "

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -202,6 +202,8 @@ public class MongoSourceConfig extends AbstractConfig {
       "The fullDocumentBeforeChange configuration.";
   private static final String FULL_DOCUMENT_BEFORE_CHANGE_DOC =
       "Specifies the pre-image configuration when creating a Change Stream.\n"
+          + "The pre-image is not available in source records published while copying existing data as a result of"
+          + " enabling `copy.existing`, and the pre-image configuration has no effect on copying.\n"
           + "See https://www.mongodb.com/docs/manual/reference/method/db.collection.watch/ for more details and possible values.";
   private static final String FULL_DOCUMENT_BEFORE_CHANGE_DEFAULT = EMPTY_STRING;
 

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -20,6 +20,7 @@ import static com.mongodb.kafka.connect.source.schema.AvroSchemaDefaults.DEFAULT
 import static com.mongodb.kafka.connect.source.schema.AvroSchemaDefaults.DEFAULT_AVRO_VALUE_SCHEMA;
 import static com.mongodb.kafka.connect.util.ClassHelper.createInstance;
 import static com.mongodb.kafka.connect.util.ConfigHelper.collationFromJson;
+import static com.mongodb.kafka.connect.util.ConfigHelper.fullDocumentBeforeChangeFromString;
 import static com.mongodb.kafka.connect.util.ConfigHelper.fullDocumentFromString;
 import static com.mongodb.kafka.connect.util.ConfigHelper.jsonArrayFromString;
 import static com.mongodb.kafka.connect.util.ServerApiConfig.addServerApiConfig;
@@ -50,6 +51,7 @@ import org.bson.json.JsonWriterSettings;
 import com.mongodb.ConnectionString;
 import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.changestream.FullDocument;
+import com.mongodb.client.model.changestream.FullDocumentBeforeChange;
 
 import com.mongodb.kafka.connect.source.json.formatter.JsonWriterSettingsProvider;
 import com.mongodb.kafka.connect.source.schema.AvroSchema;
@@ -193,6 +195,15 @@ public class MongoSourceConfig extends AbstractConfig {
       "Only publish the actual changed document rather than the full change "
           + "stream document. Automatically, sets `change.stream.full.document=updateLookup` so updated documents will be included.";
   private static final boolean PUBLISH_FULL_DOCUMENT_ONLY_DEFAULT = false;
+
+  public static final String FULL_DOCUMENT_BEFORE_CHANGE_CONFIG =
+      "change.stream.full.document.before.change";
+  private static final String FULL_DOCUMENT_BEFORE_CHANGE_DISPLAY =
+      "The fullDocumentBeforeChange configuration.";
+  private static final String FULL_DOCUMENT_BEFORE_CHANGE_DOC =
+      "Specifies the pre-image configuration when creating a Change Stream.\n"
+          + "See https://www.mongodb.com/docs/manual/reference/method/db.collection.watch/ for more details and possible values.";
+  private static final String FULL_DOCUMENT_BEFORE_CHANGE_DEFAULT = EMPTY_STRING;
 
   public static final String FULL_DOCUMENT_CONFIG = "change.stream.full.document";
   private static final String FULL_DOCUMENT_DISPLAY = "Set what to return for update operations";
@@ -417,6 +428,10 @@ public class MongoSourceConfig extends AbstractConfig {
     return collationFromJson(getString(COLLATION_CONFIG));
   }
 
+  public Optional<FullDocumentBeforeChange> getFullDocumentBeforeChange() {
+    return fullDocumentBeforeChangeFromString(getString(FULL_DOCUMENT_BEFORE_CHANGE_CONFIG));
+  }
+
   public Optional<FullDocument> getFullDocument() {
     if (getBoolean(PUBLISH_FULL_DOCUMENT_ONLY_CONFIG)) {
       return Optional.of(FullDocument.UPDATE_LOOKUP);
@@ -590,6 +605,23 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         PUBLISH_FULL_DOCUMENT_ONLY_DISPLAY);
+
+    configDef.define(
+        FULL_DOCUMENT_BEFORE_CHANGE_CONFIG,
+        Type.STRING,
+        FULL_DOCUMENT_BEFORE_CHANGE_DEFAULT,
+        emptyString()
+            .or(
+                Validators.EnumValidatorAndRecommender.in(
+                    FullDocumentBeforeChange.values(), FullDocumentBeforeChange::getValue)),
+        Importance.HIGH,
+        FULL_DOCUMENT_BEFORE_CHANGE_DOC,
+        group,
+        ++orderInGroup,
+        Width.MEDIUM,
+        FULL_DOCUMENT_BEFORE_CHANGE_DISPLAY,
+        Validators.EnumValidatorAndRecommender.in(
+            FullDocumentBeforeChange.values(), FullDocumentBeforeChange::getValue));
 
     configDef.define(
         FULL_DOCUMENT_CONFIG,

--- a/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
@@ -613,6 +613,7 @@ final class StartedMongoSourceTask implements AutoCloseable {
     if (batchSize > 0) {
       changeStream.batchSize(batchSize);
     }
+    sourceConfig.getFullDocumentBeforeChange().ifPresent(changeStream::fullDocumentBeforeChange);
     sourceConfig.getFullDocument().ifPresent(changeStream::fullDocument);
     sourceConfig.getCollation().ifPresent(changeStream::collation);
     return changeStream;

--- a/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
@@ -1,0 +1,648 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: Apache License, Version 2.0, Copyright 2017 Hans-Peter Grahsl.
+ */
+package com.mongodb.kafka.connect.source;
+
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.BATCH_SIZE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.COLLECTION_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.DATABASE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.HEARTBEAT_INTERVAL_MS_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.HEARTBEAT_TOPIC_NAME_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_AWAIT_TIME_MS_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_MAX_BATCH_SIZE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.PUBLISH_FULL_DOCUMENT_ONLY_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceTask.COPY_KEY;
+import static com.mongodb.kafka.connect.source.MongoSourceTask.ID_FIELD;
+import static com.mongodb.kafka.connect.source.MongoSourceTask.createPartitionMap;
+import static com.mongodb.kafka.connect.source.MongoSourceTask.doesNotSupportsStartAfter;
+import static com.mongodb.kafka.connect.source.MongoSourceTask.getOffset;
+import static com.mongodb.kafka.connect.source.heartbeat.HeartbeatManager.HEARTBEAT_KEY;
+import static com.mongodb.kafka.connect.source.producer.SchemaAndValueProducers.createKeySchemaAndValueProvider;
+import static com.mongodb.kafka.connect.source.producer.SchemaAndValueProducers.createValueSchemaAndValueProvider;
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.utils.SystemTime;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.source.SourceTaskContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentWrapper;
+import org.bson.Document;
+import org.bson.RawBsonDocument;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoCommandException;
+import com.mongodb.MongoException;
+import com.mongodb.client.ChangeStreamIterable;
+import com.mongodb.client.MongoChangeStreamCursor;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.changestream.ChangeStreamDocument;
+import com.mongodb.lang.Nullable;
+
+import com.mongodb.kafka.connect.source.heartbeat.HeartbeatManager;
+import com.mongodb.kafka.connect.source.producer.SchemaAndValueProducer;
+import com.mongodb.kafka.connect.source.statistics.StatisticsManager;
+import com.mongodb.kafka.connect.source.topic.mapping.TopicMapper;
+import com.mongodb.kafka.connect.util.VisibleForTesting;
+import com.mongodb.kafka.connect.util.jmx.SourceTaskStatistics;
+import com.mongodb.kafka.connect.util.time.InnerOuterTimer;
+import com.mongodb.kafka.connect.util.time.InnerOuterTimer.InnerTimer;
+
+final class StartedMongoSourceTask implements AutoCloseable {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MongoSourceTask.class);
+  private static final String FULL_DOCUMENT = "fullDocument";
+  private static final int NAMESPACE_NOT_FOUND_ERROR = 26;
+  private static final int ILLEGAL_OPERATION_ERROR = 20;
+  private static final int INVALIDATED_RESUME_TOKEN_ERROR = 260;
+  private static final int CHANGE_STREAM_FATAL_ERROR = 280;
+  private static final int CHANGE_STREAM_HISTORY_LOST = 286;
+  private static final int BSON_OBJECT_TOO_LARGE = 10334;
+  private static final Set<Integer> INVALID_CHANGE_STREAM_ERRORS =
+      new HashSet<>(
+          asList(
+              INVALIDATED_RESUME_TOKEN_ERROR,
+              CHANGE_STREAM_FATAL_ERROR,
+              CHANGE_STREAM_HISTORY_LOST,
+              BSON_OBJECT_TOO_LARGE));
+  private static final String RESUME_TOKEN = "resume token";
+  private static final String RESUME_POINT = "resume point";
+  private static final String NOT_FOUND = "not found";
+  private static final String DOES_NOT_EXIST = "does not exist";
+  private static final String INVALID_RESUME_TOKEN = "invalid resume token";
+  private static final String NO_LONGER_IN_THE_OPLOG = "no longer be in the oplog";
+
+  private final Supplier<SourceTaskContext> sourceTaskContextAccessor;
+  private final Time time;
+  private volatile boolean isRunning;
+  private boolean isCopying;
+
+  private final MongoSourceConfig sourceConfig;
+  private final Map<String, Object> partitionMap;
+  private final MongoClient mongoClient;
+  private HeartbeatManager heartbeatManager;
+
+  private boolean supportsStartAfter = true;
+  private boolean invalidatedCursor = false;
+  @Nullable private final MongoCopyDataManager copyDataManager;
+  private BsonDocument cachedResult;
+  private BsonDocument cachedResumeToken;
+
+  private MongoChangeStreamCursor<? extends BsonDocument> cursor;
+  private final StatisticsManager statisticsManager;
+  private final InnerOuterTimer inTaskPollInConnectFrameworkTimer;
+
+  StartedMongoSourceTask(
+      final Supplier<SourceTaskContext> sourceTaskContextAccessor,
+      final MongoSourceConfig sourceConfig,
+      final MongoClient mongoClient,
+      @Nullable final MongoCopyDataManager copyDataManager,
+      final StatisticsManager statisticsManager) {
+    this.sourceTaskContextAccessor = sourceTaskContextAccessor;
+    this.sourceConfig = sourceConfig;
+    this.mongoClient = mongoClient;
+    isRunning = true;
+    boolean shouldCopyData = copyDataManager != null;
+    isCopying = shouldCopyData;
+    time = new SystemTime();
+    partitionMap = createPartitionMap(sourceConfig);
+    this.copyDataManager = copyDataManager;
+    if (shouldCopyData) {
+      setCachedResultAndResumeToken();
+    } else {
+      initializeCursorAndHeartbeatManager();
+    }
+    this.statisticsManager = statisticsManager;
+    inTaskPollInConnectFrameworkTimer =
+        InnerOuterTimer.start(
+            (inTaskPollSample) -> {
+              SourceTaskStatistics statistics = statisticsManager.currentStatistics();
+              statistics.getInTaskPoll().sample(inTaskPollSample.toMillis());
+              if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(statistics.getName() + ": " + statistics.toJSON());
+              }
+            },
+            (inFrameworkSample) ->
+                statisticsManager
+                    .currentStatistics()
+                    .getInConnectFramework()
+                    .sample(inFrameworkSample.toMillis()));
+  }
+
+  /** @see MongoSourceTask#poll() */
+  @SuppressWarnings("try")
+  List<SourceRecord> poll() {
+    if (!isCopying) {
+      statisticsManager.switchToStreamStatistics();
+    }
+    try (InnerTimer automatic = inTaskPollInConnectFrameworkTimer.sampleOuter()) {
+      List<SourceRecord> sourceRecords = pollInternal();
+      if (sourceRecords != null) {
+        statisticsManager.currentStatistics().getRecords().sample(sourceRecords.size());
+      }
+      return sourceRecords;
+    }
+  }
+
+  private List<SourceRecord> pollInternal() {
+    final long startPoll = time.milliseconds();
+    LOGGER.debug("Polling Start: {}", startPoll);
+    List<SourceRecord> sourceRecords = new ArrayList<>();
+    TopicMapper topicMapper = sourceConfig.getTopicMapper();
+    boolean publishFullDocumentOnly = sourceConfig.getBoolean(PUBLISH_FULL_DOCUMENT_ONLY_CONFIG);
+    int maxBatchSize = sourceConfig.getInt(POLL_MAX_BATCH_SIZE_CONFIG);
+    long nextUpdate = startPoll + sourceConfig.getLong(POLL_AWAIT_TIME_MS_CONFIG);
+
+    SchemaAndValueProducer keySchemaAndValueProducer =
+        createKeySchemaAndValueProvider(sourceConfig);
+    SchemaAndValueProducer valueSchemaAndValueProducer =
+        createValueSchemaAndValueProvider(sourceConfig);
+
+    while (isRunning) {
+      Optional<BsonDocument> next = getNextDocument();
+      long untilNext = nextUpdate - time.milliseconds();
+
+      if (!next.isPresent()) {
+        if (untilNext > 0) {
+          LOGGER.debug("Waiting {} ms to poll", untilNext);
+          time.sleep(untilNext);
+          continue; // Re-check stop flag before continuing
+        }
+        if (!sourceRecords.isEmpty()) {
+          LOGGER.debug("Returning {} source records", sourceRecords.size());
+          return sourceRecords;
+        }
+        if (heartbeatManager != null) {
+          Optional<SourceRecord> heartbeat = heartbeatManager.heartbeat();
+          if (heartbeat.isPresent()) {
+            LOGGER.debug("Returning single heartbeat record");
+            return singletonList(heartbeat.get());
+          } else {
+            return null;
+          }
+        }
+        LOGGER.debug("Returning null because there are no source records and no heartbeat manager");
+        return null;
+      } else {
+        BsonDocument changeStreamDocument = next.get();
+
+        Map<String, String> sourceOffset = new HashMap<>();
+        sourceOffset.put(ID_FIELD, changeStreamDocument.getDocument(ID_FIELD).toJson());
+        if (isCopying) {
+          sourceOffset.put(COPY_KEY, "true");
+        }
+
+        String topicName = topicMapper.getTopic(changeStreamDocument);
+        if (topicName.isEmpty()) {
+          LOGGER.warn(
+              "No topic set. Could not publish the message: {}", changeStreamDocument.toJson());
+          return sourceRecords;
+        }
+
+        Optional<BsonDocument> valueDocument = Optional.empty();
+        if (publishFullDocumentOnly) {
+          if (changeStreamDocument.containsKey(FULL_DOCUMENT)
+              && changeStreamDocument.get(FULL_DOCUMENT).isDocument()) {
+            valueDocument = Optional.of(changeStreamDocument.getDocument(FULL_DOCUMENT));
+          }
+        } else {
+          valueDocument = Optional.of(changeStreamDocument);
+        }
+
+        valueDocument.ifPresent(
+            (BsonDocument valueDoc) -> {
+              LOGGER.trace("Adding {} to {}: {}", valueDoc, topicName, sourceOffset);
+
+              if (valueDoc instanceof RawBsonDocument) {
+                int sizeBytes = ((RawBsonDocument) valueDoc).getByteBuffer().limit();
+                statisticsManager.currentStatistics().getMongodbBytesRead().sample(sizeBytes);
+              }
+
+              BsonDocument keyDocument =
+                  sourceConfig.getKeyOutputFormat() == MongoSourceConfig.OutputFormat.SCHEMA
+                      ? changeStreamDocument
+                      : new BsonDocument(ID_FIELD, changeStreamDocument.get(ID_FIELD));
+
+              createSourceRecord(
+                      keySchemaAndValueProducer,
+                      valueSchemaAndValueProducer,
+                      sourceOffset,
+                      topicName,
+                      keyDocument,
+                      valueDoc)
+                  .map(sourceRecords::add);
+            });
+
+        if (sourceRecords.size() == maxBatchSize) {
+          LOGGER.debug(
+              "Reached '{}': {}, returning records", POLL_MAX_BATCH_SIZE_CONFIG, maxBatchSize);
+          return sourceRecords;
+        } else {
+          LOGGER.debug(
+              "Continuing to loop because sourceRecords size {} is less than maxBatchSize {}",
+              sourceRecords.size(),
+              maxBatchSize);
+        }
+      }
+    }
+    LOGGER.debug("Returning null because connector is no longer running");
+    return null;
+  }
+
+  private Optional<SourceRecord> createSourceRecord(
+      final SchemaAndValueProducer keySchemaAndValueProducer,
+      final SchemaAndValueProducer valueSchemaAndValueProducer,
+      final Map<String, String> sourceOffset,
+      final String topicName,
+      final BsonDocument keyDocument,
+      final BsonDocument valueDocument) {
+
+    try {
+      SchemaAndValue keySchemaAndValue = keySchemaAndValueProducer.get(keyDocument);
+      SchemaAndValue valueSchemaAndValue = valueSchemaAndValueProducer.get(valueDocument);
+      return Optional.of(
+          new SourceRecord(
+              partitionMap,
+              sourceOffset,
+              topicName,
+              keySchemaAndValue.schema(),
+              keySchemaAndValue.value(),
+              valueSchemaAndValue.schema(),
+              valueSchemaAndValue.value()));
+    } catch (Exception e) {
+      Supplier<String> errorMessage =
+          () ->
+              format(
+                  "%s : Exception creating Source record for: Key=%s Value=%s",
+                  e.getMessage(), keyDocument.toJson(), valueDocument.toJson());
+      if (sourceConfig.logErrors()) {
+        LOGGER.error(errorMessage.get(), e);
+      }
+      if (sourceConfig.tolerateErrors()) {
+        if (sourceConfig.getDlqTopic().isEmpty()) {
+          return Optional.empty();
+        }
+        return Optional.of(
+            new SourceRecord(
+                partitionMap,
+                sourceOffset,
+                sourceConfig.getDlqTopic(),
+                Schema.STRING_SCHEMA,
+                keyDocument.toJson(),
+                Schema.STRING_SCHEMA,
+                valueDocument.toJson()));
+      }
+      throw new DataException(errorMessage.get(), e);
+    }
+  }
+
+  /** @see MongoSourceTask#stop() */
+  @SuppressWarnings("try")
+  @Override
+  public void close() {
+    LOGGER.info("Stopping MongoDB source task");
+    isRunning = false;
+
+    //noinspection EmptyTryBlock
+    try (StatisticsManager autoCloseable4 = this.statisticsManager;
+        MongoClient autoCloseable3 = this.mongoClient;
+        MongoChangeStreamCursor<? extends BsonDocument> autoCloseable2 = this.cursor;
+        MongoCopyDataManager autoCloseable1 = this.copyDataManager) {
+      // just using try-with-resources to ensure they all get closed, even in the case of exceptions
+    }
+  }
+
+  private void initializeCursorAndHeartbeatManager() {
+    cursor = createCursor(sourceConfig, mongoClient);
+    heartbeatManager =
+        new HeartbeatManager(
+            time,
+            cursor,
+            sourceConfig.getLong(HEARTBEAT_INTERVAL_MS_CONFIG),
+            sourceConfig.getString(HEARTBEAT_TOPIC_NAME_CONFIG),
+            partitionMap);
+  }
+
+  @VisibleForTesting(otherwise = VisibleForTesting.AccessModifier.PRIVATE)
+  MongoChangeStreamCursor<? extends BsonDocument> createCursor(
+      final MongoSourceConfig sourceConfig, final MongoClient mongoClient) {
+    LOGGER.debug("Creating a MongoCursor");
+    return tryCreateCursor(sourceConfig, mongoClient, getResumeToken(sourceConfig));
+  }
+
+  private MongoChangeStreamCursor<? extends BsonDocument> tryRecreateCursor(
+      final MongoException e) {
+    int errorCode =
+        e instanceof MongoCommandException
+            ? ((MongoCommandException) e).getErrorCode()
+            : e.getCode();
+    String errorMessage =
+        e instanceof MongoCommandException
+            ? ((MongoCommandException) e).getErrorMessage()
+            : e.getMessage();
+    LOGGER.warn(
+        "Failed to resume change stream: {} {}\n"
+            + "===================================================================================\n"
+            + "When the resume token is no longer available there is the potential for data loss.\n\n"
+            + "Restarting the change stream with no resume token because `errors.tolerance=all`.\n"
+            + "===================================================================================\n",
+        errorMessage,
+        errorCode);
+    invalidatedCursor = true;
+    return tryCreateCursor(sourceConfig, mongoClient, null);
+  }
+
+  private MongoChangeStreamCursor<? extends BsonDocument> tryCreateCursor(
+      final MongoSourceConfig sourceConfig,
+      final MongoClient mongoClient,
+      final BsonDocument resumeToken) {
+    try {
+      ChangeStreamIterable<Document> changeStreamIterable =
+          getChangeStreamIterable(sourceConfig, mongoClient);
+      if (resumeToken != null && supportsStartAfter) {
+        LOGGER.info("Resuming the change stream after the previous offset: {}", resumeToken);
+        changeStreamIterable.startAfter(resumeToken);
+      } else if (resumeToken != null && !invalidatedCursor) {
+        LOGGER.info(
+            "Resuming the change stream after the previous offset using resumeAfter: {}",
+            resumeToken);
+        changeStreamIterable.resumeAfter(resumeToken);
+      } else {
+        LOGGER.info("New change stream cursor created without offset.");
+      }
+      return (MongoChangeStreamCursor<RawBsonDocument>)
+          changeStreamIterable.withDocumentClass(RawBsonDocument.class).cursor();
+    } catch (MongoCommandException e) {
+      if (resumeToken != null) {
+        if (invalidatedResumeToken(e)) {
+          invalidatedCursor = true;
+          return tryCreateCursor(sourceConfig, mongoClient, null);
+        } else if (doesNotSupportsStartAfter(e)) {
+          supportsStartAfter = false;
+          return tryCreateCursor(sourceConfig, mongoClient, resumeToken);
+        } else if (sourceConfig.tolerateErrors() && changeStreamNotValid(e)) {
+          return tryRecreateCursor(e);
+        }
+      }
+      if (e.getErrorCode() == NAMESPACE_NOT_FOUND_ERROR) {
+        LOGGER.info("Namespace not found cursor closed.");
+      } else if (e.getErrorCode() == ILLEGAL_OPERATION_ERROR) {
+        LOGGER.warn(
+            "Illegal $changeStream operation: {} {}\n\n"
+                + "=====================================================================================\n"
+                + "{}\n\n"
+                + "Please Note: Not all aggregation pipeline operations are suitable for modifying the\n"
+                + "change stream output. For more information, please see the official documentation:\n"
+                + "   https://docs.mongodb.com/manual/changeStreams/\n"
+                + "=====================================================================================\n",
+            e.getErrorMessage(),
+            e.getErrorCode(),
+            e.getErrorMessage());
+        throw new ConnectException("Illegal $changeStream operation", e);
+      } else {
+        LOGGER.warn(
+            "Failed to resume change stream: {} {}\n\n"
+                + "=====================================================================================\n"
+                + "If the resume token is no longer available then there is the potential for data loss.\n"
+                + "Saved resume tokens are managed by Kafka and stored with the offset data.\n\n"
+                + "To restart the change stream with no resume token either: \n"
+                + "  * Create a new partition name using the `offset.partition.name` configuration.\n"
+                + "  * Set `errors.tolerance=all` and ignore the erroring resume token. \n"
+                + "  * Manually remove the old offset from its configured storage.\n\n"
+                + "Resetting the offset will allow for the connector to be resume from the latest resume\n"
+                + "token. Using `copy.existing=true` ensures that all data will be outputted by the\n"
+                + "connector but it will duplicate existing data.\n"
+                + "=====================================================================================\n",
+            e.getErrorMessage(),
+            e.getErrorCode());
+        if (changeStreamNotValid(e)) {
+          throw new ConnectException(
+              "ResumeToken not found. Cannot create a change stream cursor", e);
+        }
+      }
+      return null;
+    }
+  }
+
+  private static boolean invalidatedResumeToken(final MongoCommandException e) {
+    return e.getErrorCode() == INVALIDATED_RESUME_TOKEN_ERROR;
+  }
+
+  private static boolean changeStreamNotValid(final MongoException e) {
+    if (INVALID_CHANGE_STREAM_ERRORS.contains(e.getCode())) {
+      return true;
+    }
+    String errorMessage =
+        e instanceof MongoCommandException
+            ? ((MongoCommandException) e).getErrorMessage().toLowerCase(Locale.ROOT)
+            : e.getMessage().toLowerCase(Locale.ROOT);
+    return (errorMessage.contains(RESUME_TOKEN) || errorMessage.contains(RESUME_POINT))
+        && (errorMessage.contains(NOT_FOUND)
+            || errorMessage.contains(DOES_NOT_EXIST)
+            || errorMessage.contains(INVALID_RESUME_TOKEN)
+            || errorMessage.contains(NO_LONGER_IN_THE_OPLOG));
+  }
+
+  /**
+   * This method also is responsible for caching the {@code resumeAfter} value for the change
+   * stream.
+   */
+  private void setCachedResultAndResumeToken() {
+    MongoChangeStreamCursor<ChangeStreamDocument<Document>> changeStreamCursor;
+
+    try {
+      changeStreamCursor = getChangeStreamIterable(sourceConfig, mongoClient).cursor();
+    } catch (MongoCommandException e) {
+      if (e.getErrorCode() == NAMESPACE_NOT_FOUND_ERROR) {
+        return;
+      }
+      throw new ConnectException(e);
+    }
+    ChangeStreamDocument<Document> firstResult = changeStreamCursor.tryNext();
+    if (firstResult != null) {
+      cachedResult =
+          new BsonDocumentWrapper<>(
+              firstResult,
+              ChangeStreamDocument.createCodec(
+                  Document.class, MongoClientSettings.getDefaultCodecRegistry()));
+    }
+    cachedResumeToken =
+        firstResult != null ? firstResult.getResumeToken() : changeStreamCursor.getResumeToken();
+    changeStreamCursor.close();
+  }
+
+  /**
+   * Returns the next document to be delivered to Kafka.
+   *
+   * <p>
+   *
+   * <ol>
+   *   <li>If copying data is in progress, returns the next result.
+   *   <li>If copying data and all data has been copied and there is a cached result return the
+   *       cached result.
+   *   <li>Otherwise, return the next result from the change stream cursor. Creating a new cursor if
+   *       necessary.
+   * </ol>
+   *
+   * @return the next document
+   */
+  private Optional<BsonDocument> getNextDocument() {
+    if (isCopying) {
+      Optional<BsonDocument> result = copyDataManager.poll();
+      if (result.isPresent() || copyDataManager.isCopying()) {
+        return result;
+      }
+
+      isCopying = false;
+      LOGGER.info("Finished copying existing data from the collection(s).");
+      if (cachedResult != null) {
+        result = Optional.of(cachedResult);
+        cachedResult = null;
+        return result;
+      }
+    }
+
+    if (cursor == null) {
+      initializeCursorAndHeartbeatManager();
+    }
+
+    if (cursor != null) {
+      try {
+        BsonDocument next = cursor.tryNext();
+        // The cursor has been closed by the server
+        if (next == null && cursor.getServerCursor() == null) {
+          invalidateCursorAndReinitialize();
+          next = cursor != null ? cursor.tryNext() : null;
+        }
+        return Optional.ofNullable(next);
+      } catch (MongoException e) {
+        closeCursor();
+        if (isRunning) {
+          if (sourceConfig.tolerateErrors() && changeStreamNotValid(e)) {
+            cursor = tryRecreateCursor(e);
+          } else {
+            LOGGER.info(
+                "An exception occurred when trying to get the next item from the Change Stream", e);
+          }
+        }
+        return Optional.empty();
+      } catch (Exception e) {
+        closeCursor();
+        if (isRunning) {
+          throw new ConnectException("Unexpected error: " + e.getMessage(), e);
+        }
+      }
+    }
+    return Optional.empty();
+  }
+
+  private void closeCursor() {
+    if (cursor != null) {
+      try {
+        cursor.close();
+      } catch (Exception e1) {
+        // ignore
+      }
+      cursor = null;
+    }
+  }
+
+  private void invalidateCursorAndReinitialize() {
+    invalidatedCursor = true;
+    cursor.close();
+    cursor = null;
+    initializeCursorAndHeartbeatManager();
+  }
+
+  private static ChangeStreamIterable<Document> getChangeStreamIterable(
+      final MongoSourceConfig sourceConfig, final MongoClient mongoClient) {
+    String database = sourceConfig.getString(DATABASE_CONFIG);
+    String collection = sourceConfig.getString(COLLECTION_CONFIG);
+
+    Optional<List<Document>> pipeline = sourceConfig.getPipeline();
+    ChangeStreamIterable<Document> changeStream;
+    if (database.isEmpty()) {
+      LOGGER.info("Watching all changes on the cluster");
+      changeStream = pipeline.map(mongoClient::watch).orElse(mongoClient.watch());
+    } else if (collection.isEmpty()) {
+      LOGGER.info("Watching for database changes on '{}'", database);
+      MongoDatabase db = mongoClient.getDatabase(database);
+      changeStream = pipeline.map(db::watch).orElse(db.watch());
+    } else {
+      LOGGER.info("Watching for collection changes on '{}.{}'", database, collection);
+      MongoCollection<Document> coll = mongoClient.getDatabase(database).getCollection(collection);
+      changeStream = pipeline.map(coll::watch).orElse(coll.watch());
+    }
+
+    int batchSize = sourceConfig.getInt(BATCH_SIZE_CONFIG);
+    if (batchSize > 0) {
+      changeStream.batchSize(batchSize);
+    }
+    sourceConfig.getFullDocument().ifPresent(changeStream::fullDocument);
+    sourceConfig.getCollation().ifPresent(changeStream::collation);
+    return changeStream;
+  }
+
+  private BsonDocument getResumeToken(final MongoSourceConfig sourceConfig) {
+    BsonDocument resumeToken = null;
+    if (cachedResumeToken != null) {
+      resumeToken = cachedResumeToken;
+      cachedResumeToken = null;
+    } else if (invalidatedCursor) {
+      invalidatedCursor = false;
+    } else {
+      Map<String, Object> offset = getOffset(sourceTaskContextAccessor.get(), sourceConfig);
+      if (offset != null && offset.containsKey(ID_FIELD) && !offset.containsKey(COPY_KEY)) {
+        resumeToken = BsonDocument.parse((String) offset.get(ID_FIELD));
+        if (offset.containsKey(HEARTBEAT_KEY)) {
+          LOGGER.info("Resume token from heartbeat: {}", resumeToken);
+        }
+      }
+    }
+    return resumeToken;
+  }
+
+  /** @see MongoSourceTask#commitRecord(SourceRecord, RecordMetadata) */
+  void commitRecord(final SourceRecord record, final RecordMetadata metadata) {
+    if (metadata == null) {
+      statisticsManager.currentStatistics().getRecordsFiltered().sample(1);
+    } else {
+      statisticsManager.currentStatistics().getRecordsAcknowledged().sample(1);
+    }
+  }
+}

--- a/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
@@ -154,6 +154,7 @@ final class StartedMongoSourceTask implements AutoCloseable {
               SourceTaskStatistics statistics = statisticsManager.currentStatistics();
               statistics.getInTaskPoll().sample(inTaskPollSample.toMillis());
               if (LOGGER.isDebugEnabled()) {
+                // toJSON relatively expensive
                 LOGGER.debug(statistics.getName() + ": " + statistics.toJSON());
               }
             },

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/AvroSchemaDefaults.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/AvroSchemaDefaults.java
@@ -34,6 +34,7 @@ public final class AvroSchemaDefaults {
           + "  \"fields\": ["
           + "    { \"name\": \"_id\", \"type\": \"string\" },"
           + "    { \"name\": \"operationType\", \"type\": [\"string\", \"null\"] },"
+          + "    { \"name\": \"fullDocumentBeforeChange\", \"type\": [\"string\", \"null\"] },"
           + "    { \"name\": \"fullDocument\", \"type\": [\"string\", \"null\"] },"
           + "    { \"name\": \"ns\","
           + "      \"type\": [{\"name\": \"ns\", \"type\": \"record\", \"fields\": ["

--- a/src/main/java/com/mongodb/kafka/connect/source/statistics/JmxStatisticsManager.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/statistics/JmxStatisticsManager.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: Apache License, Version 2.0, Copyright 2017 Hans-Peter Grahsl.
+ */
+package com.mongodb.kafka.connect.source.statistics;
+
+import com.mongodb.annotations.ThreadSafe;
+
+import com.mongodb.kafka.connect.util.jmx.SourceTaskStatistics;
+import com.mongodb.kafka.connect.util.jmx.internal.CombinedMongoMBean;
+import com.mongodb.kafka.connect.util.jmx.internal.MBeanServerUtils;
+
+@ThreadSafe
+public final class JmxStatisticsManager implements StatisticsManager {
+  private static final String COPY_BEAN = "source-task-copy-existing";
+  private static final String STREAM_BEAN = "source-task-change-stream";
+  private static final String COMBINED_BEAN = "source-task";
+
+  private final SourceTaskStatistics copyStatistics;
+  private final SourceTaskStatistics streamStatistics;
+  private final CombinedMongoMBean combinedStatistics;
+  private volatile SourceTaskStatistics currentStatistics;
+
+  public JmxStatisticsManager(final boolean startWithCopyStatistics) {
+    copyStatistics = new SourceTaskStatistics(getMBeanName(COPY_BEAN));
+    streamStatistics = new SourceTaskStatistics(getMBeanName(STREAM_BEAN));
+    combinedStatistics =
+        new CombinedMongoMBean(getMBeanName(COMBINED_BEAN), copyStatistics, streamStatistics);
+    currentStatistics = startWithCopyStatistics ? copyStatistics : streamStatistics;
+    copyStatistics.register();
+    streamStatistics.register();
+    combinedStatistics.register();
+  }
+
+  @Override
+  public SourceTaskStatistics currentStatistics() {
+    return currentStatistics;
+  }
+
+  @Override
+  public void switchToStreamStatistics() {
+    currentStatistics = streamStatistics;
+  }
+
+  @Override
+  public void close() {
+    copyStatistics.unregister();
+    streamStatistics.unregister();
+    combinedStatistics.unregister();
+  }
+
+  private static String getMBeanName(final String mBean) {
+    String id = MBeanServerUtils.taskIdFromCurrentThread();
+    return "com.mongodb.kafka.connect:type=source-task-metrics,task=" + mBean + "-" + id;
+  }
+}

--- a/src/main/java/com/mongodb/kafka/connect/source/statistics/StatisticsManager.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/statistics/StatisticsManager.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: Apache License, Version 2.0, Copyright 2017 Hans-Peter Grahsl.
+ */
+package com.mongodb.kafka.connect.source.statistics;
+
+import com.mongodb.annotations.ThreadSafe;
+
+import com.mongodb.kafka.connect.util.jmx.SourceTaskStatistics;
+
+@ThreadSafe
+public interface StatisticsManager extends AutoCloseable {
+  SourceTaskStatistics currentStatistics();
+
+  void switchToStreamStatistics();
+
+  void close();
+}

--- a/src/main/java/com/mongodb/kafka/connect/source/statistics/package-info.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/statistics/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains program elements related to statistics gathered by {@link
+ * com.mongodb.kafka.connect.source.MongoSourceTask}.
+ */
+package com.mongodb.kafka.connect.source.statistics;

--- a/src/main/java/com/mongodb/kafka/connect/util/Assertions.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/Assertions.java
@@ -31,6 +31,20 @@ public final class Assertions {
   /**
    * @param value A value to check.
    * @param <T> The type of {@code value}.
+   * @return {@code null}.
+   * @throws AssertionError If {@code value} is not {@code null}.
+   */
+  @Nullable
+  public static <T> T assertNull(@Nullable final T value) throws AssertionError {
+    if (value != null) {
+      throw new AssertionError(value.toString());
+    }
+    return null;
+  }
+
+  /**
+   * @param value A value to check.
+   * @param <T> The type of {@code value}.
    * @return {@code value}
    * @throws AssertionError If {@code value} is {@code null}.
    */
@@ -51,6 +65,37 @@ public final class Assertions {
       throw new AssertionError();
     }
     return true;
+  }
+
+  /**
+   * @param value A value to check.
+   * @return {@code false}.
+   * @throws AssertionError If {@code value} is {@code true}.
+   */
+  public static boolean assertFalse(final boolean value) throws AssertionError {
+    if (value) {
+      throw new AssertionError();
+    }
+    return false;
+  }
+
+  /**
+   * @throws AssertionError Always
+   * @return Never completes normally. The return type is {@link AssertionError} to allow writing
+   *     {@code throw fail()}. This may be helpful in non-{@code void} methods.
+   */
+  public static AssertionError fail() throws AssertionError {
+    throw new AssertionError();
+  }
+
+  /**
+   * @param msg The failure message.
+   * @throws AssertionError Always
+   * @return Never completes normally. The return type is {@link AssertionError} to allow writing
+   *     {@code throw fail("failure message")}. This may be helpful in non-{@code void} methods.
+   */
+  public static AssertionError fail(final String msg) throws AssertionError {
+    throw new AssertionError(assertNotNull(msg));
   }
 
   private Assertions() {}

--- a/src/main/java/com/mongodb/kafka/connect/util/ConfigHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/ConfigHelper.java
@@ -35,6 +35,7 @@ import com.mongodb.client.model.CollationCaseFirst;
 import com.mongodb.client.model.CollationMaxVariable;
 import com.mongodb.client.model.CollationStrength;
 import com.mongodb.client.model.changestream.FullDocument;
+import com.mongodb.client.model.changestream.FullDocumentBeforeChange;
 
 import com.mongodb.kafka.connect.Versions;
 
@@ -86,6 +87,15 @@ public final class ConfigHelper {
               jsonArray.replace("\\", "\\\\"), new ConfigException("Not a valid JSON array", e));
         }
       }
+    }
+  }
+
+  public static Optional<FullDocumentBeforeChange> fullDocumentBeforeChangeFromString(
+      final String s) {
+    if (s.isEmpty()) {
+      return Optional.empty();
+    } else {
+      return Optional.of(FullDocumentBeforeChange.fromString(s));
     }
   }
 

--- a/src/main/java/com/mongodb/kafka/connect/util/time/InnerOuterTimer.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/time/InnerOuterTimer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: Apache License, Version 2.0, Copyright 2017 Hans-Peter Grahsl.
+ */
+package com.mongodb.kafka.connect.util.time;
+
+import static com.mongodb.kafka.connect.util.Assertions.assertFalse;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+
+import com.mongodb.lang.Nullable;
+
+/**
+ * A timer that measures time spent executing a sequentially repeated task (inner duration) as well
+ * as time spent executing anything but this task (outer duration).
+ */
+public final class InnerOuterTimer {
+  private final Consumer<Duration> innerConsumer;
+  private final Consumer<Duration> outerConsumer;
+  private final Timer timer;
+  @Nullable private Duration tPreviousEndTask;
+
+  private InnerOuterTimer(
+      final Timer timer,
+      final Consumer<Duration> innerConsumer,
+      final Consumer<Duration> outerConsumer) {
+    this.innerConsumer = innerConsumer;
+    this.outerConsumer = outerConsumer;
+    this.timer = timer;
+  }
+
+  public static InnerOuterTimer start(
+      final Consumer<Duration> innerConsumer, final Consumer<Duration> outerConsumer) {
+    return new InnerOuterTimer(Timer.start(), innerConsumer, outerConsumer);
+  }
+
+  /**
+   * Samples the duration between the end of a previous execution of the task and the beginning of a
+   * new task execution.
+   *
+   * <p>Call this method when execution reaches the beginning of the repeated task to sample the
+   * outer duration. {@linkplain AutoCloseable#close() Close} the returned {@link InnerTimer} when
+   * the execution reaches the end of the task.
+   */
+  public InnerTimer sampleOuter() {
+    Duration tBeginTask = timer.getElapsedTime();
+    if (tPreviousEndTask != null) {
+      Duration outer = tBeginTask.minus(tPreviousEndTask);
+      assertFalse(outer.isNegative());
+      outerConsumer.accept(outer);
+    }
+    return () -> {
+      Duration tEndTask = timer.getElapsedTime();
+      Duration inner = tEndTask.minus(tBeginTask);
+      assertFalse(inner.isNegative());
+      innerConsumer.accept(inner);
+      tPreviousEndTask = tEndTask;
+    };
+  }
+
+  /**
+   * A timer that measures time spent on a single execution of the task.
+   *
+   * @see #sampleOuter()
+   */
+  public interface InnerTimer extends AutoCloseable {
+    /** Samples the duration of a single task execution. */
+    void close();
+  }
+}

--- a/src/main/java/com/mongodb/kafka/connect/util/time/Timer.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/time/Timer.java
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-package com.mongodb.kafka.connect.util.jmx;
+package com.mongodb.kafka.connect.util.time;
 
-import java.util.concurrent.TimeUnit;
+import static com.mongodb.kafka.connect.util.Assertions.assertTrue;
+
+import java.time.Duration;
 
 public final class Timer {
   private final long startTime;
@@ -29,17 +31,14 @@ public final class Timer {
     return new Timer();
   }
 
-  public long nanosElapsed() {
-    return System.nanoTime() - this.startTime;
-  }
-
   /**
-   * Gets the elapsed time in the given unit of time.
+   * Gets the elapsed time.
    *
-   * @param timeUnit the time unit in which to get the elapsed time
    * @return the elapsed time
    */
-  public long getElapsedTime(final TimeUnit timeUnit) {
-    return timeUnit.convert(nanosElapsed(), TimeUnit.NANOSECONDS);
+  public Duration getElapsedTime() {
+    long elapsedNanos = System.nanoTime() - this.startTime;
+    assertTrue(elapsedNanos >= 0);
+    return Duration.ofNanos(elapsedNanos);
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/util/time/package-info.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/time/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Contains program elements useful when measuring time. */
+package com.mongodb.kafka.connect.util.time;

--- a/src/test/java/com/mongodb/kafka/connect/source/MongoSourceConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/MongoSourceConfigTest.java
@@ -24,6 +24,7 @@ import static com.mongodb.kafka.connect.source.MongoSourceConfig.COPY_EXISTING_P
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.ERRORS_LOG_ENABLE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.ERRORS_TOLERANCE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.FULL_DOCUMENT_BEFORE_CHANGE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.FULL_DOCUMENT_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.HEARTBEAT_INTERVAL_MS_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.HEARTBEAT_TOPIC_NAME_CONFIG;
@@ -66,6 +67,7 @@ import com.mongodb.client.model.CollationCaseFirst;
 import com.mongodb.client.model.CollationMaxVariable;
 import com.mongodb.client.model.CollationStrength;
 import com.mongodb.client.model.changestream.FullDocument;
+import com.mongodb.client.model.changestream.FullDocumentBeforeChange;
 
 import com.mongodb.kafka.connect.source.MongoSourceConfig.OutputFormat;
 import com.mongodb.kafka.connect.source.topic.mapping.DefaultTopicMapper;
@@ -254,6 +256,34 @@ class MongoSourceConfigTest {
               createSourceConfig(COLLATION_CONFIG, collation.asDocument().toJson()).getCollation());
         },
         () -> assertInvalid(COLLATION_CONFIG, "not a collation"));
+  }
+
+  @Test
+  @DisplayName("test fullDocumentBeforeChange")
+  void testFullDocumentBeforeChange() {
+    assertAll(
+        "fullDocumentBeforeChange checks",
+        () -> assertFalse(createSourceConfig().getFullDocumentBeforeChange().isPresent()),
+        () ->
+            assertFalse(
+                createSourceConfig(FULL_DOCUMENT_BEFORE_CHANGE_CONFIG, "")
+                    .getFullDocumentBeforeChange()
+                    .isPresent()),
+        () ->
+            assertEquals(
+                Optional.of(FullDocumentBeforeChange.DEFAULT),
+                createSourceConfig(
+                        FULL_DOCUMENT_BEFORE_CHANGE_CONFIG,
+                        FullDocumentBeforeChange.DEFAULT.getValue())
+                    .getFullDocumentBeforeChange()),
+        () ->
+            assertEquals(
+                Optional.of(FullDocumentBeforeChange.WHEN_AVAILABLE),
+                createSourceConfig(
+                        FULL_DOCUMENT_BEFORE_CHANGE_CONFIG,
+                        FullDocumentBeforeChange.WHEN_AVAILABLE.getValue())
+                    .getFullDocumentBeforeChange()),
+        () -> assertInvalid(FULL_DOCUMENT_BEFORE_CHANGE_CONFIG, "madeUp"));
   }
 
   @Test

--- a/src/test/java/com/mongodb/kafka/connect/source/StartedMongoSourceTaskTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/StartedMongoSourceTaskTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.kafka.connect.source;
+
+import static java.util.Collections.emptyMap;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.source.SourceTaskContext;
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.mongodb.client.ChangeStreamIterable;
+import com.mongodb.client.MongoChangeStreamCursor;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.model.changestream.FullDocumentBeforeChange;
+
+import com.mongodb.kafka.connect.source.statistics.JmxStatisticsManager;
+
+final class StartedMongoSourceTaskTest {
+  static final class FullDocumentBeforeChangeTest {
+    private final Map<String, String> properties = new HashMap<>();
+    private StartedMongoSourceTask task;
+
+    @BeforeEach
+    void setUp() {
+      properties.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+      if (task != null) {
+        task.close();
+      }
+    }
+
+    @Test
+    void fullDocumentBeforeChange() {
+      FullDocumentBeforeChange expected = FullDocumentBeforeChange.WHEN_AVAILABLE;
+      properties.put(MongoSourceConfig.FULL_DOCUMENT_BEFORE_CHANGE_CONFIG, expected.getValue());
+      MongoSourceConfig cfg = new MongoSourceConfig(properties);
+      SourceTaskContext context = mock(SourceTaskContext.class);
+      OffsetStorageReader offsetStorageReader = mock(OffsetStorageReader.class);
+      when(offsetStorageReader.offset(any())).thenReturn(emptyMap());
+      when(context.offsetStorageReader()).thenReturn(offsetStorageReader);
+      ChangeStreamIterable<?> changeStreamIterable = cast(mock(ChangeStreamIterable.class));
+      MongoClient client = mock(MongoClient.class);
+      when(changeStreamIterable.withDocumentClass(any())).thenReturn(cast(changeStreamIterable));
+      when(changeStreamIterable.cursor()).thenReturn(cast(mock(MongoChangeStreamCursor.class)));
+      when(client.watch()).thenReturn(cast(changeStreamIterable));
+      task =
+          new StartedMongoSourceTask(
+              () -> context, cfg, client, null, new JmxStatisticsManager(false));
+      task.poll();
+      ArgumentCaptor<FullDocumentBeforeChange> argCaptor =
+          ArgumentCaptor.forClass(FullDocumentBeforeChange.class);
+      verify(changeStreamIterable, atLeastOnce()).fullDocumentBeforeChange(argCaptor.capture());
+      List<FullDocumentBeforeChange> capturedArgs = argCaptor.getAllValues();
+      assertTrue(capturedArgs.stream().allMatch(v -> v.equals(expected)), capturedArgs::toString);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T cast(final Object o) {
+    return (T) o;
+  }
+}

--- a/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
@@ -279,8 +279,6 @@ public class SchemaAndValueProducerTest {
     assertAll(
         "Assert schema and value matches",
         () -> assertEquals(Schema.BYTES_SCHEMA.schema(), actual.schema()),
-        // Ensure the data length is truncated.
-        () -> assertEquals(1712, ((byte[]) actual.value()).length),
         () -> assertEquals(CHANGE_STREAM_DOCUMENT, new RawBsonDocument((byte[]) actual.value())));
 
     RawBsonDocument rawBsonDocument = RawBsonDocument.parse(CHANGE_STREAM_DOCUMENT_JSON);
@@ -288,8 +286,6 @@ public class SchemaAndValueProducerTest {
     assertAll(
         "Assert schema and value matches for raw bson document",
         () -> assertEquals(Schema.BYTES_SCHEMA.schema(), rawSchemaValue.schema()),
-        // Ensure the data length is truncated.
-        () -> assertEquals(1712, ((byte[]) rawSchemaValue.value()).length),
         () ->
             assertEquals(
                 CHANGE_STREAM_DOCUMENT, new RawBsonDocument((byte[]) rawSchemaValue.value())));
@@ -299,8 +295,6 @@ public class SchemaAndValueProducerTest {
     assertAll(
         "Assert schema and value matches for raw bson sub document",
         () -> assertEquals(Schema.BYTES_SCHEMA.schema(), rawSchemaValueForSubDocument.schema()),
-        // Ensure the data length is truncated.
-        () -> assertEquals(615, ((byte[]) rawSchemaValueForSubDocument.value()).length),
         () ->
             assertEquals(
                 CHANGE_STREAM_DOCUMENT.getDocument("fullDocument"),

--- a/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
@@ -280,7 +280,8 @@ public class SchemaAndValueProducerTest {
         "Assert schema and value matches",
         () -> assertEquals(Schema.BYTES_SCHEMA.schema(), actual.schema()),
         // Ensure the data length is truncated.
-        () -> assertEquals(1071, ((byte[]) actual.value()).length),
+        // VAKOTODO what is this arbitrary number of bytes?
+        () -> assertEquals(1712, ((byte[]) actual.value()).length),
         () -> assertEquals(CHANGE_STREAM_DOCUMENT, new RawBsonDocument((byte[]) actual.value())));
 
     RawBsonDocument rawBsonDocument = RawBsonDocument.parse(CHANGE_STREAM_DOCUMENT_JSON);
@@ -289,7 +290,7 @@ public class SchemaAndValueProducerTest {
         "Assert schema and value matches for raw bson document",
         () -> assertEquals(Schema.BYTES_SCHEMA.schema(), rawSchemaValue.schema()),
         // Ensure the data length is truncated.
-        () -> assertEquals(1071, ((byte[]) rawSchemaValue.value()).length),
+        () -> assertEquals(1712, ((byte[]) rawSchemaValue.value()).length),
         () ->
             assertEquals(
                 CHANGE_STREAM_DOCUMENT, new RawBsonDocument((byte[]) rawSchemaValue.value())));
@@ -312,6 +313,7 @@ public class SchemaAndValueProducerTest {
       {
         put("_id", "{\"_data\": \"5f15aab12435743f9bd126a4\"}");
         put("operationType", "<operation>");
+        put("fullDocumentBeforeChange", getFullDocumentBeforeChange(simplified));
         put("fullDocument", getFullDocument(simplified));
         put(
             "ns",
@@ -350,6 +352,10 @@ public class SchemaAndValueProducerTest {
             });
       }
     };
+  }
+
+  private static String getFullDocumentBeforeChange(final boolean simplified) {
+    return getFullDocument(simplified);
   }
 
   static String getFullDocument(final boolean simplified) {
@@ -392,6 +398,7 @@ public class SchemaAndValueProducerTest {
     return format(
         "{\"_id\": {\"_data\": \"5f15aab12435743f9bd126a4\"},"
             + " \"operationType\": \"<operation>\","
+            + " \"fullDocumentBeforeChange\": %s,"
             + " \"fullDocument\": %s,"
             + " \"ns\": {\"db\": \"<database>\", \"coll\": \"<collection>\"},"
             + " \"to\": {\"db\": \"<to_database>\", \"coll\": \"<to_collection>\"},"
@@ -403,6 +410,7 @@ public class SchemaAndValueProducerTest {
             + " \"txnNumber\": 987654321,"
             + " \"lsid\": {\"id\": %s, \"uid\": %s}"
             + "}",
+        getFullDocumentBeforeChange(simplified),
         getFullDocument(simplified),
         getDocumentKey(simplified),
         getUpdatedField(simplified),

--- a/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
@@ -280,7 +280,6 @@ public class SchemaAndValueProducerTest {
         "Assert schema and value matches",
         () -> assertEquals(Schema.BYTES_SCHEMA.schema(), actual.schema()),
         // Ensure the data length is truncated.
-        // VAKOTODO what is this arbitrary number of bytes?
         () -> assertEquals(1712, ((byte[]) actual.value()).length),
         () -> assertEquals(CHANGE_STREAM_DOCUMENT, new RawBsonDocument((byte[]) actual.value())));
 

--- a/src/test/java/com/mongodb/kafka/connect/util/time/InnerOuterTimerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/util/time/InnerOuterTimerTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: Apache License, Version 2.0, Copyright 2017 Hans-Peter Grahsl.
+ */
+package com.mongodb.kafka.connect.util.time;
+
+import static com.mongodb.kafka.connect.util.Assertions.fail;
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import com.mongodb.kafka.connect.util.time.InnerOuterTimer.InnerTimer;
+
+final class InnerOuterTimerTest {
+  private static final Duration TOLERANCE = Duration.ofMillis(50);
+
+  @Test
+  @SuppressWarnings("try")
+  void singleTaskExecution() throws InterruptedException {
+    MutableDuration innerDuration = MutableDuration.zero();
+    MutableDuration outerDuration = MutableDuration.zero();
+    InnerOuterTimer timer = InnerOuterTimer.start(innerDuration::add, outerDuration::add);
+    // a time gap between starting a timer and taking measurements must have no effect
+    Thread.sleep(TOLERANCE.toMillis());
+    Duration innerSleep = TOLERANCE.multipliedBy(4);
+    try (InnerTimer automatic = timer.sampleOuter()) {
+      Thread.sleep(innerSleep.toMillis());
+    }
+    assertEquals(Duration.ZERO, outerDuration.get());
+    assertAtLeast(innerSleep, innerDuration.get());
+  }
+
+  @Test
+  @SuppressWarnings("try")
+  void multipleTaskExecutions() {
+    MutableDuration innerDuration = MutableDuration.zero();
+    MutableDuration outerDuration = MutableDuration.zero();
+    InnerOuterTimer timer = InnerOuterTimer.start(innerDuration::add, outerDuration::add);
+    Timer total = Timer.start();
+    for (int i = 0; i < 20_000_000; i++) {
+      // measurements must be correct regardless of how little time is spent not executing the task
+      try (InnerTimer automatic = timer.sampleOuter()) {
+        // Measurements must be correct regardless
+        // of how little time an individual task execution takes.
+      }
+    }
+    Duration totalDuration = total.getElapsedTime();
+    Duration innerPlusOuterDuration = outerDuration.get().plus(innerDuration.get());
+    assertAtLeast(innerPlusOuterDuration, totalDuration);
+    assertEquals(
+        0.5,
+        (float) innerDuration.get().toNanos() / innerPlusOuterDuration.toNanos(),
+        0.1,
+        () ->
+            format(
+                "Inner duration %s must be about half of the inner+outer %s",
+                innerDuration, innerPlusOuterDuration));
+  }
+
+  private static void assertAtLeast(final Duration expected, final Duration actual) {
+    if (expected.compareTo(TOLERANCE) <= 0) {
+      fail(format("Expected %s must be greater than tolerance %s", expected, TOLERANCE));
+    }
+    assertTrue(actual.compareTo(expected) >= 0, () -> format("%s, %s", expected, actual));
+    Duration overmeasure = actual.minus(expected);
+    assertTrue(
+        overmeasure.compareTo(TOLERANCE) < 0, () -> format("%s, %s", TOLERANCE, overmeasure));
+  }
+
+  private static final class MutableDuration {
+    private Duration v;
+
+    private MutableDuration(final Duration v) {
+      this.v = v;
+    }
+
+    static MutableDuration zero() {
+      return new MutableDuration(Duration.ZERO);
+    }
+
+    void add(final Duration delta) {
+      this.v = this.v.plus(delta);
+    }
+
+    Duration get() {
+      return v;
+    }
+
+    @Override
+    public String toString() {
+      return v.toString();
+    }
+  }
+}


### PR DESCRIPTION
This new property is equivalent to [`ChangeStreamIterable.fullDocumentBeforeChange`](https://mongodb.github.io/mongo-java-driver/4.7/apidocs/mongodb-driver-sync/com/mongodb/client/ChangeStreamIterable.html#fullDocumentBeforeChange(com.mongodb.client.model.changestream.FullDocumentBeforeChange)) in the driver API.

**Problems**:

- ~~4 tests in `MongoSourceTaskTest` accidentally became integration tests (they need a running MongoDB). These tests need to be refactored.~~
  - **Solution**: rename `MongoSourceTaskTest` to `MongoSourceTaskIntegrationJunkTest` and move it to integration tests. These tests are irredeemable and need to be rewritten to become unit tests.

[KAFKA-308](https://jira.mongodb.org/browse/KAFKA-308)