### PR TITLE
Report all exceptions to the DLQ when `mongo.errors.tolerance` is `"all"`

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
@@ -224,7 +224,9 @@ public final class StartedMongoSinkTask {
       if (logErrors) {
         log(batch, e);
       }
-      if (!tolerateErrors) {
+      if (tolerateErrors) {
+        batch.forEach(record -> errorReporter.report(record, e));
+      } else {
         throw new DataException(e);
       }
     }


### PR DESCRIPTION
This change is in accordance with the original DLQ scope document: https://jira.mongodb.org/browse/WRITING-9407.

KAFKA-331