### PR TITLE
Use type Attribute for attributes in JMX mbeans

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/util/jmx/internal/CombinedMongoMBean.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/jmx/internal/CombinedMongoMBean.java
@@ -48,7 +48,7 @@ public class CombinedMongoMBean implements DynamicMBean {
   public Object getAttribute(final String attribute)
       throws AttributeNotFoundException, MBeanException, ReflectionException {
     if (metricsMap.containsKey(attribute)) {
-      return metricsMap.get(attribute).get();
+      return new Attribute(attribute, metricsMap.get(attribute).get());
     } else {
       throw new AttributeNotFoundException(
           "getAttribute failed: value not found for: " + attribute);
@@ -60,7 +60,7 @@ public class CombinedMongoMBean implements DynamicMBean {
     AttributeList list = new AttributeList();
     for (String name : attributes) {
       if (metricsMap.containsKey(name)) {
-        list.add(metricsMap.get(name).get());
+        list.add(new Attribute(name, metricsMap.get(name).get()));
       }
     }
     return list;

--- a/src/main/java/com/mongodb/kafka/connect/util/jmx/internal/MBeanServerUtils.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/jmx/internal/MBeanServerUtils.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.management.Attribute;
 import javax.management.AttributeNotFoundException;
 import javax.management.DynamicMBean;
 import javax.management.InstanceAlreadyExistsException;
@@ -130,6 +131,8 @@ public final class MBeanServerUtils {
           Object value = mBeanServer.getAttribute(mBeanName, attributeInfo.getName());
           if (value instanceof Long) {
             attributes.put(attributeInfo.getName(), (Long) value);
+          } else if (value instanceof Attribute && ((Attribute) value).getValue() instanceof Long) {
+            attributes.put(attributeInfo.getName(), (Long) ((Attribute) value).getValue());
           }
         }
         mbeansMap.put(mBeanName.toString(), attributes);

--- a/src/main/java/com/mongodb/kafka/connect/util/jmx/internal/MongoMBean.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/jmx/internal/MongoMBean.java
@@ -87,7 +87,7 @@ public class MongoMBean implements DynamicMBean {
   @Override
   public Object getAttribute(final String name) throws AttributeNotFoundException {
     if (metricsMap.containsKey(name)) {
-      return metricsMap.get(name).get();
+      return new Attribute(name, metricsMap.get(name).get());
     } else {
       throw new AttributeNotFoundException("getAttribute failed: value not found for: " + name);
     }
@@ -98,7 +98,7 @@ public class MongoMBean implements DynamicMBean {
     AttributeList list = new AttributeList();
     for (String name : attributes) {
       if (metricsMap.containsKey(name)) {
-        list.add(metricsMap.get(name).get());
+        list.add(new Attribute(name, metricsMap.get(name).get()));
       }
     }
     return list;

--- a/src/test/java/com/mongodb/kafka/connect/util/jmx/internal/MongoMBeanTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/util/jmx/internal/MongoMBeanTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import javax.management.Attribute;
 import javax.management.AttributeNotFoundException;
 import javax.management.DynamicMBean;
 import javax.management.MBeanException;
@@ -210,10 +211,10 @@ public class MongoMBeanTest {
             .map(
                 name -> {
                   try {
-                    Long value1 = (Long) bean.getAttribute(name);
-                    Long value2 = (Long) bean.getAttributes(new String[] {name}).get(0);
+                    Attribute value1 = (Attribute) bean.getAttribute(name);
+                    Attribute value2 = (Attribute) bean.getAttributes(new String[] {name}).get(0);
                     assertEquals(value1, value2);
-                    return value1;
+                    return (Long) value1.getValue();
                   } catch (AttributeNotFoundException | MBeanException | ReflectionException e) {
                     throw new RuntimeException(e);
                   }


### PR DESCRIPTION
The classes **`MongoMBean`** and **`CombinedMongoMBean`** in `com.mongodb.kafka.connect..util.jmx.internal` currently return metric values directly from their _`getAttribute()`_ method and inside the `AttributeList` from their _`getAttributes()`_ method, but the documentation for `AttributeList` specifically says (emphasis mine):

> For compatibility reasons, it is possible, **though highly discouraged**, to add objects to an AttributeList that are not instances of Attribute.

The current behavior breaks at the very least https://github.com/prometheus/jmx_exporter, since they ignore non-`Attribute` values in their metric export.

The proposed change makes it so that the `AttributeList` returned by _`getAttributes()`_ is filled with `Attribute`s wrapping the the metric values, and _`getAttribute()`_ returns an `Attribute` for coherence and general compliance with the interface's intentions.

Edit: bungled the integration test change, it's now fixed, apologies.