### PR TITLE
Combine compatible schemas for array elements

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
@@ -16,26 +16,37 @@
 
 package com.mongodb.kafka.connect.source.schema;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Timestamp;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonValue;
 
+import com.mongodb.kafka.connect.source.MongoSourceTask;
+
 public final class BsonDocumentToSchema {
 
+  static final Logger LOGGER = LoggerFactory.getLogger(MongoSourceTask.class);
+
+  private static final String SENTINEL_FOR_NULL_OR_EMPTY = "";
   private static final String ID_FIELD = "_id";
   private static final Schema DEFAULT_INFER_SCHEMA_TYPE = Schema.OPTIONAL_STRING_SCHEMA;
   public static final String DEFAULT_FIELD_NAME = "default";
 
   public static Schema inferDocumentSchema(final BsonDocument document) {
-    return createSchemaBuilder(DEFAULT_FIELD_NAME, document).required().build();
+    Schema schema = createSchemaBuilder(DEFAULT_FIELD_NAME, document).required().build();
+    return normalizeSchema(schema);
   }
 
   private static Schema inferDocumentSchema(final String fieldPath, final BsonDocument document) {
@@ -80,24 +91,39 @@ public final class BsonDocumentToSchema {
       case DOCUMENT:
         return inferDocumentSchema(fieldPath, bsonValue.asDocument());
       case ARRAY:
-        List<BsonValue> values = bsonValue.asArray().getValues();
-        Schema firstItemSchema =
-            values.isEmpty() ? DEFAULT_INFER_SCHEMA_TYPE : inferSchema(fieldPath, values.get(0));
-        if (values.isEmpty()
-            || values.stream()
-                .anyMatch(bv -> !Objects.equals(inferSchema(fieldPath, bv), firstItemSchema))) {
-          return SchemaBuilder.array(DEFAULT_INFER_SCHEMA_TYPE).name(fieldPath).optional().build();
+        BsonArray bsonArray = bsonValue.asArray();
+        if (bsonArray.isEmpty()) {
+          return SchemaBuilder.array(
+                  SchemaBuilder.string()
+                      .optional()
+                      // Sentinel value added to detect the empty array case.
+                      .defaultValue(SENTINEL_FOR_NULL_OR_EMPTY)
+                      .build())
+              .name(fieldPath)
+              .optional()
+              .build();
         }
-        return SchemaBuilder.array(inferSchema(fieldPath, bsonValue.asArray().getValues().get(0)))
-            .name(fieldPath)
-            .optional()
-            .build();
+        Schema combinedSchema = inferSchema(fieldPath, bsonArray.get(0));
+        for (int i = 1; i < bsonArray.size(); i++) {
+          combinedSchema = combine(combinedSchema, inferSchema(fieldPath, bsonArray.get(i)));
+          if (combinedSchema == null) {
+            break;
+          }
+        }
+        return combinedSchema == null
+            ? SchemaBuilder.array(DEFAULT_INFER_SCHEMA_TYPE).name(fieldPath).optional().build()
+            : SchemaBuilder.array(combinedSchema).name(fieldPath).optional().build();
       case BINARY:
         return Schema.OPTIONAL_BYTES_SCHEMA;
       case SYMBOL:
       case STRING:
-      case NULL:
         return Schema.OPTIONAL_STRING_SCHEMA;
+      case NULL:
+        return SchemaBuilder.string()
+            .optional()
+            // Sentinel value added to detect the empty array case.
+            .defaultValue(SENTINEL_FOR_NULL_OR_EMPTY)
+            .build();
       case OBJECT_ID:
       case REGULAR_EXPRESSION:
       case DB_POINTER:
@@ -109,6 +135,134 @@ public final class BsonDocumentToSchema {
       default:
         return DEFAULT_INFER_SCHEMA_TYPE;
     }
+  }
+
+  private static Schema combine(final Schema firstSchema, final Schema secondSchema) {
+    if (firstSchema.equals(secondSchema)) {
+      return firstSchema;
+    }
+
+    if (firstSchema.type() != secondSchema.type()) {
+      LOGGER.debug(
+          "Can't combine non-matching schema types: {} and {}",
+          firstSchema.type(),
+          secondSchema.type());
+      return null;
+    }
+
+    if (firstSchema.type() != Schema.Type.STRUCT || secondSchema.type() != Schema.Type.STRUCT) {
+      LOGGER.debug("Can't combine non-equal schema that are not both structs");
+      return null;
+    }
+
+    SchemaBuilder builder = SchemaBuilder.struct().name(firstSchema.name()).optional();
+
+    for (Field firstField : firstSchema.fields()) {
+      Field secondField = secondSchema.field(firstField.name());
+      if (secondField == null || firstField.schema().equals(secondField.schema())) {
+        builder.field(firstField.name(), firstField.schema());
+      } else if (isSentinelValueSet(firstField.schema())) {
+        builder.field(secondField.name(), secondField.schema());
+      } else if (isSentinelValueSet(secondField.schema())) {
+        builder.field(firstField.name(), firstField.schema());
+      } else if (firstField.schema().type() == Schema.Type.STRUCT
+          && secondField.schema().type() == Schema.Type.STRUCT) {
+        Schema combinedSchema = combine(firstField.schema(), secondField.schema());
+        if (combinedSchema == null) {
+          LOGGER.debug(
+              "Can't combine non-matching struct fields: {} and {}", firstField, secondField);
+          return null;
+        }
+        builder.field(firstField.name(), combinedSchema);
+      } else if (firstField.schema().type() == Schema.Type.ARRAY
+          && secondField.schema().type() == Schema.Type.ARRAY) {
+        if (isSentinelValueSet(secondField.schema().valueSchema())) {
+          builder.field(firstField.name(), firstField.schema());
+        } else if (isSentinelValueSet(firstField.schema().valueSchema())) {
+          builder.field(secondField.name(), secondField.schema());
+        } else {
+          Schema combinedSchema =
+              combine(firstField.schema().valueSchema(), secondField.schema().valueSchema());
+          if (combinedSchema == null) {
+            LOGGER.debug(
+                "Can't combine non-matching array element value schema: {} and {}",
+                firstField,
+                secondField);
+            return null;
+          }
+          builder.field(
+              firstField.name(),
+              SchemaBuilder.array(combinedSchema).name(firstField.name()).optional().build());
+        }
+      } else {
+        LOGGER.debug("Can't combine non-matching fields: {} and {}", firstField, secondField);
+        return null;
+      }
+    }
+
+    for (Field secondField : secondSchema.fields()) {
+      if (firstSchema.field(secondField.name()) == null) {
+        builder.field(secondField.name(), secondField.schema());
+      }
+    }
+
+    return builder.build();
+  }
+
+  // Relies on the sentinel value added above
+  private static boolean isSentinelValueSet(final Schema schema) {
+    return schema.type() == Schema.Type.STRING
+        && SENTINEL_FOR_NULL_OR_EMPTY.equals(schema.defaultValue());
+  }
+
+  /**
+   * This method normalizes the schema that had been denormalized due to the array element
+   * schema-combining logic applied as part of schema building process.
+   */
+  private static Schema normalizeSchema(final Schema schema) {
+    switch (schema.type()) {
+      case STRUCT:
+        return normalizeStructSchema(schema);
+      case ARRAY:
+        SchemaBuilder arraySchemaBuilder =
+            SchemaBuilder.array(normalizeSchema(schema.valueSchema())).name(schema.name());
+        if (schema.isOptional()) {
+          arraySchemaBuilder.optional();
+        }
+        return arraySchemaBuilder.build();
+      case STRING:
+        SchemaBuilder stringSchemaBuilder = SchemaBuilder.string().name(schema.name());
+        if (schema.isOptional()) {
+          stringSchemaBuilder.optional();
+        }
+        return stringSchemaBuilder.build();
+      default:
+        return schema;
+    }
+  }
+
+  private static Schema normalizeStructSchema(final Schema schema) {
+    SchemaBuilder builder = SchemaBuilder.struct().name(schema.name());
+    if (schema.isOptional()) {
+      builder.optional();
+    }
+
+    List<Field> fields = new ArrayList<>(schema.fields());
+    fields.sort(Comparator.comparing(Field::name));
+
+    Field idField = schema.field(ID_FIELD);
+    if (idField != null) {
+      builder.field(idField.name(), normalizeSchema(idField.schema()));
+    }
+
+    for (Field cur : fields) {
+      if (cur.name().equals(ID_FIELD)) {
+        continue;
+      }
+      builder.field(cur.name(), normalizeSchema(cur.schema()));
+    }
+
+    return builder.build();
   }
 
   private static String createFieldPath(final String fieldPath, final String fieldName) {

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
@@ -147,8 +147,8 @@ public final class BsonDocumentToSchema {
             firstSchema.fields().stream().map(Field::name),
             secondSchema.fields().stream().map(Field::name))
         .filter(name -> !name.equals(ID_FIELD))
-        .sorted()
         .distinct()
+        .sorted()
         .forEach(
             name ->
                 builder.field(
@@ -169,9 +169,6 @@ public final class BsonDocumentToSchema {
       return secondField.schema();
     } else if (isSentinel(secondField.schema())) {
       return firstField.schema();
-    } else if (firstField.schema().type() == Schema.Type.STRUCT
-        && secondField.schema().type() == Schema.Type.STRUCT) {
-      return combine(firstField.schema(), secondField.schema());
     } else if (firstField.schema().type() == Schema.Type.ARRAY
         && secondField.schema().type() == Schema.Type.ARRAY) {
       if (isSentinel(secondField.schema().valueSchema())) {

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
@@ -45,8 +45,7 @@ public final class BsonDocumentToSchema {
   public static final String DEFAULT_FIELD_NAME = "default";
 
   public static Schema inferDocumentSchema(final BsonDocument document) {
-    Schema schema = createSchemaBuilder(DEFAULT_FIELD_NAME, document).required().build();
-    return normalizeSchema(schema);
+    return createSchemaBuilder(DEFAULT_FIELD_NAME, document).required().build();
   }
 
   private static Schema inferDocumentSchema(final String fieldPath, final BsonDocument document) {
@@ -112,7 +111,8 @@ public final class BsonDocumentToSchema {
         }
         return combinedSchema == null
             ? SchemaBuilder.array(DEFAULT_INFER_SCHEMA_TYPE).name(fieldPath).optional().build()
-            : SchemaBuilder.array(combinedSchema).name(fieldPath).optional().build();
+            : normalizeSchema(
+                SchemaBuilder.array(combinedSchema).name(fieldPath).optional().build());
       case BINARY:
         return Schema.OPTIONAL_BYTES_SCHEMA;
       case SYMBOL:

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
@@ -45,7 +45,8 @@ public final class BsonDocumentToSchema {
   public static final String DEFAULT_FIELD_NAME = "default";
 
   public static Schema inferDocumentSchema(final BsonDocument document) {
-    return createSchemaBuilder(DEFAULT_FIELD_NAME, document).required().build();
+    Schema schema = createSchemaBuilder(DEFAULT_FIELD_NAME, document).required().build();
+    return normalizeSchema(schema);
   }
 
   private static Schema inferDocumentSchema(final String fieldPath, final BsonDocument document) {
@@ -111,8 +112,7 @@ public final class BsonDocumentToSchema {
         }
         return combinedSchema == null
             ? SchemaBuilder.array(DEFAULT_INFER_SCHEMA_TYPE).name(fieldPath).optional().build()
-            : normalizeSchema(
-                SchemaBuilder.array(combinedSchema).name(fieldPath).optional().build());
+            : SchemaBuilder.array(combinedSchema).name(fieldPath).optional().build();
       case BINARY:
         return Schema.OPTIONAL_BYTES_SCHEMA;
       case SYMBOL:

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
@@ -136,10 +136,10 @@ public final class BsonDocumentToSchema {
     SchemaBuilder builder = SchemaBuilder.struct().name(firstSchema.name()).optional();
 
     // _id field first
-    Field _id1 = firstSchema.field(ID_FIELD);
-    Field _id2 = secondSchema.field(ID_FIELD);
-    if (_id1 != null || _id2 != null) {
-      builder.field(ID_FIELD, combineFieldSchema(_id1, _id2));
+    Field id1 = firstSchema.field(ID_FIELD);
+    Field id2 = secondSchema.field(ID_FIELD);
+    if (id1 != null || id2 != null) {
+      builder.field(ID_FIELD, combineFieldSchema(id1, id2));
     }
     // Combine other fields in name order
     Stream.concat(

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
@@ -35,8 +35,8 @@ public final class BsonDocumentToSchema {
   public static final String DEFAULT_FIELD_NAME = "default";
   private static final Logger LOGGER = LoggerFactory.getLogger(BsonDocumentToSchema.class);
   private static final String ID_FIELD = "_id";
-  private static final Schema DEFAULT_INFER_SCHEMA_TYPE = Schema.OPTIONAL_STRING_SCHEMA;
-  private static final Schema SENTINEL_STRING_TYPE =
+  static final Schema DEFAULT_INFER_SCHEMA_TYPE = Schema.OPTIONAL_STRING_SCHEMA;
+  static final Schema SENTINEL_STRING_TYPE =
       SchemaBuilder.type(Schema.Type.STRING).optional().build();
 
   public static Schema inferDocumentSchema(final BsonDocument document) {

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
@@ -89,7 +89,7 @@ public final class BsonDocumentToSchema {
         Schema combinedSchema =
             values.stream()
                 .map(i -> inferSchema(fieldPath, i))
-                .reduce(SENTINEL_STRING_TYPE, BsonDocumentToSchema::combine);
+                .reduce(SENTINEL_STRING_TYPE, BsonDocumentToSchema::combineArrayValueSchema);
         return SchemaBuilder.array(combinedSchema).name(fieldPath).optional().build();
       case BINARY:
         return Schema.OPTIONAL_BYTES_SCHEMA;
@@ -110,7 +110,8 @@ public final class BsonDocumentToSchema {
     }
   }
 
-  private static Schema combine(final Schema firstSchema, final Schema secondSchema) {
+  private static Schema combineArrayValueSchema(
+      final Schema firstSchema, final Schema secondSchema) {
     if (isSentinel(firstSchema)) {
       return secondSchema;
     } else if (isSentinel(secondSchema)) {
@@ -177,7 +178,8 @@ public final class BsonDocumentToSchema {
         return secondField.schema();
       } else {
         Schema combinedArrayValueSchema =
-            combine(firstField.schema().valueSchema(), secondField.schema().valueSchema());
+            combineArrayValueSchema(
+                firstField.schema().valueSchema(), secondField.schema().valueSchema());
         return SchemaBuilder.array(combinedArrayValueSchema)
             .name(firstField.name())
             .optional()

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
@@ -34,7 +34,6 @@ import org.bson.BsonValue;
 public final class BsonDocumentToSchema {
   public static final String DEFAULT_FIELD_NAME = "default";
   private static final Logger LOGGER = LoggerFactory.getLogger(BsonDocumentToSchema.class);
-  private static final String ID_FIELD = "_id";
   static final Schema INCOMPATIBLE_SCHEMA_TYPE = Schema.OPTIONAL_STRING_SCHEMA;
   static final Schema SENTINEL_STRING_TYPE =
       SchemaBuilder.type(Schema.Type.STRING).optional().build();
@@ -51,11 +50,7 @@ public final class BsonDocumentToSchema {
       final String fieldPath, final BsonDocument document) {
     SchemaBuilder builder = SchemaBuilder.struct();
     builder.name(fieldPath);
-    if (document.containsKey(ID_FIELD)) {
-      builder.field(ID_FIELD, inferSchema(ID_FIELD, document.get(ID_FIELD)));
-    }
     document.entrySet().stream()
-        .filter(kv -> !kv.getKey().equals(ID_FIELD))
         .sorted(Map.Entry.comparingByKey())
         .forEach(
             kv ->
@@ -137,17 +132,10 @@ public final class BsonDocumentToSchema {
 
     SchemaBuilder builder = SchemaBuilder.struct().name(firstSchema.name()).optional();
 
-    // _id field first
-    Field id1 = firstSchema.field(ID_FIELD);
-    Field id2 = secondSchema.field(ID_FIELD);
-    if (id1 != null || id2 != null) {
-      builder.field(ID_FIELD, combineFieldSchema(id1, id2));
-    }
-    // Combine other fields in name order
+    // Combine fields in field name order
     Stream.concat(
             firstSchema.fields().stream().map(Field::name),
             secondSchema.fields().stream().map(Field::name))
-        .filter(name -> !name.equals(ID_FIELD))
         .distinct()
         .sorted()
         .forEach(

--- a/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
@@ -168,7 +168,12 @@ public class SchemaAndValueProducerTest {
                     .build())
             .field(
                 "arrayComplexMixedTypes",
-                SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA)
+                SchemaBuilder.array(
+                        SchemaBuilder.struct()
+                            .field("a", Schema.OPTIONAL_STRING_SCHEMA)
+                            .name("arrayComplexMixedTypes_a")
+                            .optional()
+                            .build())
                     .optional()
                     .name("arrayComplexMixedTypes")
                     .build())
@@ -218,6 +223,8 @@ public class SchemaAndValueProducerTest {
             .build();
 
     Schema arrayComplexValueSchema = expectedSchema.field("arrayComplex").schema().valueSchema();
+    Schema arrayComplexMixedTypesValueSchema =
+        expectedSchema.field("arrayComplexMixedTypes").schema().valueSchema();
     Schema documentSchema = expectedSchema.field("document").schema();
 
     SchemaAndValue expectedSchemaAndValue =
@@ -232,7 +239,11 @@ public class SchemaAndValueProducerTest {
                         new Struct(arrayComplexValueSchema).put("a", 1),
                         new Struct(arrayComplexValueSchema).put("a", 2)))
                 .put("arrayMixedTypes", asList("1", "2", "true", "[1, 2, 3]", "{\"a\": 2}"))
-                .put("arrayComplexMixedTypes", asList("{\"a\": 1}", "{\"a\": \"a\"}"))
+                .put(
+                    "arrayComplexMixedTypes",
+                    asList(
+                        new Struct(arrayComplexMixedTypesValueSchema).put("a", "1"),
+                        new Struct(arrayComplexMixedTypesValueSchema).put("a", "a")))
                 .put("binary", Base64.getDecoder().decode("S2Fma2Egcm9ja3Mh"))
                 .put("boolean", true)
                 .put("code", "{\"$code\": \"int i = 0;\"}")

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
@@ -17,8 +17,12 @@
 package com.mongodb.kafka.connect.source.schema;
 
 import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.DEFAULT_FIELD_NAME;
+import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.DEFAULT_INFER_SCHEMA_TYPE;
+import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.SENTINEL_STRING_TYPE;
 import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.inferDocumentSchema;
 import static com.mongodb.kafka.connect.source.schema.SchemaUtils.assertSchemaEquals;
+import static com.mongodb.kafka.connect.util.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -208,6 +212,13 @@ public class BsonDocumentToSchemaTest {
             .build();
 
     assertSchemaEquals(expected, inferDocumentSchema(bsonDocument));
+  }
+
+  @Test
+  void testSentinelTypeCanary() {
+    assertEquals(SENTINEL_STRING_TYPE, DEFAULT_INFER_SCHEMA_TYPE);
+
+    assertFalse(SENTINEL_STRING_TYPE == DEFAULT_INFER_SCHEMA_TYPE);
   }
 
   static Schema createArray(final String name, final Schema valueSchema) {

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
@@ -158,10 +158,10 @@ public class BsonDocumentToSchemaTest {
     BsonDocument bsonDocument =
         BsonDocument.parse(
             "{"
-                + " structs: [{a: 1, b: true, c: 'foo', d: 4, e: {'$numberLong': '5'}}],"
+                + " structs: [{a: 1, b: true, c: 'foo'}, {b: false, d: 4, e: {'$numberLong': '5'}}],"
                 + " structsEmpty: [{a: 1, b: true}, {}, {c: 'foo'}, {d: 4, e: {'$numberLong': '5'}}],"
                 + " structsEmptyFirst: [{}, {a: 1, b: true}, {c: 'foo'}, {d: 4, e: {'$numberLong': '5'}}],"
-                + " structsNull: [{a: 1, b: true}, null, {c: 'foo'}, {d: 4, e: {'$numberLong': '5'}}],"
+                + " structsNull: [{a: 1, b: true, c : null, d: null}, null, {d: 4, e: {'$numberLong': '5'}}],"
                 + " structsNullFirst: [null, {a: 1, b: true}, {c: 'foo'}, {d: 4, e: {'$numberLong': '5'}}],"
                 + " structsOrdering: [{e: {'$numberLong': '5'}, c: 'foo', b: true, d: 4, a: 1}],"
                 + " structsWithMixedTypes: [{a: 1, b: 2, c: 3, d: 4, e: 5}, {a: 'a', b: 'b', c: 'c', d: 'd', e: 'e'}]}");
@@ -188,10 +188,10 @@ public class BsonDocumentToSchemaTest {
     BsonDocument bsonDocument =
         BsonDocument.parse(
             "{"
-                + " arrayStructs: [[{a: 1, b: true, c: 'foo', d: 4, e: {'$numberLong': '5'}}]],"
+                + " arrayStructs: [[{a: 1, b: true,} {c: 'foo'}], [{b: false}, {d: 4, e: {'$numberLong': '5'}}]],"
                 + " arrayStructsEmpty: [[{a: 1, b: true}], [{}], [{c: 'foo'}], [], [{d: 4, e: {'$numberLong': '5'}}]],"
                 + " arrayStructsEmptyFirst: [[{}], [{a: 1, b: true}, {c: 'foo'}], [{d: 4, e: {'$numberLong': '5'}}]],"
-                + " arrayStructsNull: [[{a: 1, b: true}, null], null, [{c: 'foo'}, {d: 4, e: {'$numberLong': '5'}}]],"
+                + " arrayStructsNull: [[{a: 1, b: true, c: null, d: null}, null], null, [{d: 4, e: {'$numberLong': '5'}}]],"
                 + " arrayStructsNullFirst: [null, [null], [{a: 1, b: true}, {c: 'foo'}, {d: 4, e: {'$numberLong': '5'}}]],"
                 + " arrayStructsOrdering: [[{e: {'$numberLong': '5'}, c: 'foo'}], [{b: true}], [{d: 4, a: 1}]],"
                 + " arrayStructsWithMixedTypes: [[{a: 1, b: 2, c: 3, d: 4, e: 5}], [{a: 'a', 'b': 'b'}], [{c: 'c', d: 'd', e: 'e'}]]}");
@@ -211,6 +211,45 @@ public class BsonDocumentToSchemaTest {
             .field(
                 "arrayStructsWithMixedTypes",
                 createNestedArray("arrayStructsWithMixedTypes", SIMPLE_STRUCT_STRINGS))
+            .build();
+
+    assertSchemaEquals(expected, inferDocumentSchema(bsonDocument));
+  }
+
+  @Test
+  void testArraysWithStructsWithArrays() {
+    BsonDocument bsonDocument =
+        BsonDocument.parse(
+            "{"
+                + " structs: [{inner: [{a: 1, b: true}]}, {inner: [{c: 'foo'}]}, {inner: [{b: false, d: 4, e: {'$numberLong': '5'}}]}],"
+                + " structsEmpty: [{inner: []}, {inner: [{a: 1, b: true}]}, {inner: []}, {},"
+                + "                {inner: [{c: 'foo', d: 4}]}, {inner: [{e: {'$numberLong': '5'}}]}],"
+                + " structsEmptyFirst: [{}, {inner: [{a: 1, b: true}]}, {inner: [{c: 'foo', d: 4, e: {'$numberLong': '5'}}]}],"
+                + " structsNull: [{inner: [{a: 1, b: true, c: null, d: null}]}, null, {inner: null}, "
+                + "               {inner: [{d: 4, e: {'$numberLong': '5'}}]}],"
+                + " structsNullFirst: [null, {inner: [{a: 1, b: true}]}, {inner: [{c: 'foo', d: 4, e: {'$numberLong': '5'}}]}],"
+                + " structsOrdering: [{inner: [{e: {'$numberLong': '5'}, c:'foo', b: true}]}, {inner: [{d: 4, a: 1}]}],"
+                + " structsWithMixedTypes: [{inner: [{a: 1, b: 2, c: 3, d: 4, e: 5}]}, "
+                + "                                  {inner: [{a: 'a', b: 'b', c: 'c', d: 'd', e: 'e'}]}]}");
+
+    Schema expected =
+        SchemaBuilder.struct()
+            .name(DEFAULT_FIELD_NAME)
+            .field("structs", createArray("structs", createArray("inner", SIMPLE_STRUCT)))
+            .field("structsEmpty", createArray("structsEmpty", createArray("inner", SIMPLE_STRUCT)))
+            .field(
+                "structsEmptyFirst",
+                createArray("structsEmptyFirst", createArray("inner", SIMPLE_STRUCT)))
+            .field("structsNull", createArray("structsNull", createArray("inner", SIMPLE_STRUCT)))
+            .field(
+                "structsNullFirst",
+                createArray("structsNullFirst", createArray("inner", SIMPLE_STRUCT)))
+            .field(
+                "structsOrdering",
+                createArray("structsOrdering", createArray("inner", SIMPLE_STRUCT)))
+            .field(
+                "structsWithMixedTypes",
+                createArray("structsWithMixedTypes", createArray("inner", SIMPLE_STRUCT_STRINGS)))
             .build();
 
     assertSchemaEquals(expected, inferDocumentSchema(bsonDocument));

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.source.schema;
+
+import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.inferDocumentSchema;
+import static java.util.Arrays.asList;
+import static org.apache.kafka.connect.data.Schema.Type.ARRAY;
+import static org.apache.kafka.connect.data.Schema.Type.INT32;
+import static org.apache.kafka.connect.data.Schema.Type.STRING;
+import static org.apache.kafka.connect.data.Schema.Type.STRUCT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.jupiter.api.Test;
+
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonNull;
+import org.bson.BsonString;
+
+@SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
+public class BsonDocumentToSchemaTest {
+
+  @Test
+  void testEmptyArray() {
+    BsonDocument document =
+        new BsonDocument()
+            .append(
+                "outerArray",
+                new BsonArray(
+                    asList(
+                        new BsonDocument("innerArray", new BsonArray()),
+                        new BsonDocument(
+                            "innerArray",
+                            new BsonArray(asList(new BsonInt32(1), new BsonInt32(2)))),
+                        new BsonDocument(
+                            "innerArray",
+                            new BsonArray(asList(new BsonInt32(3), new BsonInt32(4)))))));
+
+    Schema schema = inferDocumentSchema(document);
+    assertEquals(STRUCT, schema.type());
+
+    Schema outerArraySchema = schema.field("outerArray").schema();
+    assertEquals(STRUCT, outerArraySchema.valueSchema().type());
+
+    Schema innerArraySchema = outerArraySchema.valueSchema().field("innerArray").schema();
+    assertEquals(ARRAY, innerArraySchema.type());
+    assertEquals(INT32, innerArraySchema.valueSchema().type());
+  }
+
+  @Test
+  void testStructCombining() {
+    BsonDocument document =
+        new BsonDocument()
+            .append(
+                "outerArray",
+                new BsonArray(
+                    asList(
+                        new BsonDocument()
+                            .append("a", new BsonInt32(1))
+                            .append("b", new BsonString("foo")),
+                        new BsonDocument()
+                            .append("b", new BsonString("foo"))
+                            .append("c", new BsonInt32(2)))));
+
+    Schema schema = inferDocumentSchema(document);
+    assertEquals(STRUCT, schema.type());
+
+    Schema outerArraySchema = schema.field("outerArray").schema();
+    assertEquals(STRUCT, outerArraySchema.valueSchema().type());
+
+    Schema outerArrayValueSchema = outerArraySchema.valueSchema();
+    assertEquals(STRUCT, outerArrayValueSchema.type());
+
+    assertEquals(INT32, outerArrayValueSchema.field("a").schema().type());
+    assertEquals(STRING, outerArrayValueSchema.field("b").schema().type());
+    assertEquals(INT32, outerArrayValueSchema.field("c").schema().type());
+  }
+
+  @Test
+  void testStructCombiningNestedArrays() {
+    BsonDocument document =
+        new BsonDocument()
+            .append(
+                "outerArray",
+                new BsonArray(
+                    asList(
+                        new BsonDocument()
+                            .append(
+                                "innerArray",
+                                new BsonArray(
+                                    asList(
+                                        new BsonDocument()
+                                            .append("a", new BsonInt32(1))
+                                            .append("b", new BsonString("foo"))))),
+                        new BsonDocument()
+                            .append(
+                                "innerArray",
+                                new BsonArray(
+                                    asList(
+                                        new BsonDocument()
+                                            .append("b", new BsonString("foo"))
+                                            .append("c", new BsonInt32(2))))))));
+
+    Schema schema = inferDocumentSchema(document);
+    assertEquals(STRUCT, schema.type());
+
+    Schema outerArraySchema = schema.field("outerArray").schema();
+    assertEquals(STRUCT, outerArraySchema.valueSchema().type());
+
+    Schema outerArrayValueSchema = outerArraySchema.valueSchema();
+    assertEquals(STRUCT, outerArrayValueSchema.type());
+
+    Schema innerArraySchema = outerArrayValueSchema.field("innerArray").schema();
+    assertEquals(ARRAY, innerArraySchema.type());
+
+    Schema innerArrayValueSchema = innerArraySchema.valueSchema();
+    assertEquals(STRUCT, innerArrayValueSchema.type());
+
+    assertEquals(INT32, innerArrayValueSchema.field("a").schema().type());
+    assertEquals(STRING, innerArrayValueSchema.field("b").schema().type());
+    assertEquals(INT32, innerArrayValueSchema.field("c").schema().type());
+  }
+
+  @Test
+  void testStructCombiningWithNulls() {
+    BsonDocument document =
+        new BsonDocument()
+            .append(
+                "outerArray",
+                new BsonArray(
+                    asList(
+                        new BsonDocument()
+                            .append("a", new BsonInt32(1))
+                            .append("b", new BsonString("foo"))
+                            .append("c", BsonNull.VALUE)
+                            .append("d", BsonNull.VALUE)
+                            .append("e", new BsonArray()),
+                        new BsonDocument()
+                            .append("a", BsonNull.VALUE)
+                            .append("b", new BsonString("foo"))
+                            .append("c", new BsonInt32(2)))));
+
+    Schema schema = inferDocumentSchema(document);
+    assertEquals(STRUCT, schema.type());
+
+    Schema outerArraySchema = schema.field("outerArray").schema();
+    assertEquals(STRUCT, outerArraySchema.valueSchema().type());
+
+    Schema outerArrayValueSchema = outerArraySchema.valueSchema();
+    assertEquals(STRUCT, outerArrayValueSchema.type());
+
+    assertEquals(INT32, outerArrayValueSchema.field("a").schema().type());
+    assertEquals(STRING, outerArrayValueSchema.field("b").schema().type());
+    assertEquals(INT32, outerArrayValueSchema.field("c").schema().type());
+    assertEquals(STRING, outerArrayValueSchema.field("d").schema().type());
+    assertNull(outerArrayValueSchema.field("d").schema().defaultValue());
+    assertEquals(STRING, outerArrayValueSchema.field("e").schema().valueSchema().type());
+    assertNull(outerArrayValueSchema.field("e").schema().valueSchema().defaultValue());
+  }
+
+  @Test
+  void testUncombinableDocumentArrayElements() {
+    BsonDocument document =
+        new BsonDocument()
+            .append(
+                "outerArray",
+                new BsonArray(
+                    asList(
+                        new BsonDocument("a", new BsonArray(asList(new BsonInt32(1)))),
+                        new BsonDocument("a", new BsonArray(asList(new BsonString("foo")))))));
+
+    Schema schema = inferDocumentSchema(document);
+    assertEquals(STRUCT, schema.type());
+
+    Schema outerArraySchema = schema.field("outerArray").schema();
+    assertEquals(STRING, outerArraySchema.valueSchema().type());
+  }
+
+  @Test
+  void testUncombinableArrayArrayElements() {
+    BsonDocument document =
+        new BsonDocument()
+            .append(
+                "outerArray",
+                new BsonArray(
+                    asList(
+                        new BsonArray(asList(new BsonInt32(1))),
+                        new BsonArray(asList(new BsonString("foo"))))));
+
+    Schema schema = inferDocumentSchema(document);
+    assertEquals(STRUCT, schema.type());
+
+    Schema outerArraySchema = schema.field("outerArray").schema();
+    assertEquals(STRING, outerArraySchema.valueSchema().type());
+  }
+}

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
@@ -16,7 +16,9 @@
 
 package com.mongodb.kafka.connect.source.schema;
 
+import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.DEFAULT_FIELD_NAME;
 import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.inferDocumentSchema;
+import static com.mongodb.kafka.connect.source.schema.SchemaUtils.assertSchemaEquals;
 import static java.util.Arrays.asList;
 import static org.apache.kafka.connect.data.Schema.Type.ARRAY;
 import static org.apache.kafka.connect.data.Schema.Type.BOOLEAN;
@@ -26,7 +28,10 @@ import static org.apache.kafka.connect.data.Schema.Type.STRUCT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Timestamp;
 import org.junit.jupiter.api.Test;
 
 import org.bson.BsonArray;
@@ -38,6 +43,182 @@ import org.bson.BsonString;
 
 @SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
 public class BsonDocumentToSchemaTest {
+
+  @Test
+  void testInferringAllBsonTypes() {
+    BsonDocument bsonDocument =
+        BsonDocument.parse(
+            "{"
+                + "\"array\": [{\"$numberInt\": \"1\"}, {\"$numberInt\": \"2\"}, {\"$numberInt\": \"3\"}], "
+                + "\"binary\": {\"$binary\": {\"base64\": \"S2Fma2Egcm9ja3Mh\", \"subType\": \"00\"}}, "
+                + "\"boolean\": true, "
+                + "\"code\": {\"$code\": \"int i = 0;\"}, "
+                + "\"codeWithScope\": {\"$code\": \"int x = y\", \"$scope\": {\"y\": {\"$numberInt\": \"1\"}}}, "
+                + "\"dateTime\": {\"$date\": {\"$numberLong\": \"1577836801000\"}}, "
+                + "\"decimal128\": {\"$numberDecimal\": \"1.0\"}, "
+                + "\"document\": {\"a\": {\"$numberInt\": \"1\"}}, "
+                + "\"double\": {\"$numberDouble\": \"62.0\"}, "
+                + "\"int32\": {\"$numberInt\": \"42\"}, "
+                + "\"int64\": {\"$numberLong\": \"52\"}, "
+                + "\"maxKey\": {\"$maxKey\": 1}, "
+                + "\"minKey\": {\"$minKey\": 1}, "
+                + "\"null\": null, "
+                + "\"objectId\": {\"$oid\": \"5f3d1bbde0ca4d2829c91e1d\"}, "
+                + "\"regex\": {\"$regularExpression\": {\"pattern\": \"^test.*regex.*xyz$\", \"options\": \"i\"}}, "
+                + "\"string\": \"the fox ...\", "
+                + "\"symbol\": {\"$symbol\": \"ruby stuff\"}, "
+                + "\"timestamp\": {\"$timestamp\": {\"t\": 305419896, \"i\": 5}}, "
+                + "\"undefined\": {\"$undefined\": true}"
+                + "}");
+
+    Schema expected =
+        SchemaBuilder.struct()
+            .name(DEFAULT_FIELD_NAME)
+            .field("array", createArray("array", Schema.OPTIONAL_INT32_SCHEMA))
+            .field("binary", Schema.OPTIONAL_BYTES_SCHEMA)
+            .field("boolean", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+            .field("code", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("codeWithScope", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("dateTime", Timestamp.builder().optional().build())
+            .field("decimal128", Decimal.builder(1).optional().build())
+            .field(
+                "document",
+                SchemaBuilder.struct()
+                    .field("a", Schema.OPTIONAL_INT32_SCHEMA)
+                    .name("document")
+                    .optional()
+                    .build())
+            .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
+            .field("int32", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("int64", Schema.OPTIONAL_INT64_SCHEMA)
+            .field("maxKey", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("minKey", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("null", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("objectId", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("regex", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("string", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("symbol", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("timestamp", Timestamp.builder().optional().build())
+            .field("undefined", Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
+
+    assertSchemaEquals(expected, inferDocumentSchema(bsonDocument));
+  }
+
+  @Test
+  void testArraysSimple() {
+    BsonDocument bsonDocument =
+        BsonDocument.parse(
+            "{"
+                + "empty: [],"
+                + "ints: [1, 2, 3],"
+                + "intsNull: [1, null, 3],"
+                + "intsNullFirst: [null, 1, 3],"
+                + "mixedTypes: [1, 'foo', {a: 1}]}");
+
+    Schema expected =
+        SchemaBuilder.struct()
+            .name(DEFAULT_FIELD_NAME)
+            .field("empty", createArray("empty", Schema.OPTIONAL_STRING_SCHEMA))
+            .field("ints", createArray("ints", Schema.OPTIONAL_INT32_SCHEMA))
+            .field("intsNull", createArray("intsNull", Schema.OPTIONAL_INT32_SCHEMA))
+            .field("intsNullFirst", createArray("intsNullFirst", Schema.OPTIONAL_INT32_SCHEMA))
+            .field("mixedTypes", createArray("mixedTypes", Schema.OPTIONAL_STRING_SCHEMA))
+            .build();
+
+    assertSchemaEquals(expected, inferDocumentSchema(bsonDocument));
+  }
+
+  @Test
+  void testArraysSimpleNesting() {
+    BsonDocument bsonDocument =
+        BsonDocument.parse(
+            "{"
+                + " arrays: [[1], [2], [3]],"
+                + " arraysEmpty: [[1], [], [2]],"
+                + " arraysEmptyFirst: [[], [1], [2]],"
+                + " arraysNull: [[1], null, [2]],"
+                + " arraysNullFirst: [[1], null, [2]],"
+                + " arraysWithMixedTypes: [[1], ['2'], [{a: 1}]]}");
+
+    Schema expected =
+        SchemaBuilder.struct()
+            .name(DEFAULT_FIELD_NAME)
+            .field("arrays", createNestedArray("arrays", Schema.OPTIONAL_INT32_SCHEMA))
+            .field("arraysEmpty", createNestedArray("arraysEmpty", Schema.OPTIONAL_INT32_SCHEMA))
+            .field(
+                "arraysEmptyFirst",
+                createNestedArray("arraysEmptyFirst", Schema.OPTIONAL_INT32_SCHEMA))
+            .field("arraysNull", createNestedArray("arraysNull", Schema.OPTIONAL_INT32_SCHEMA))
+            .field(
+                "arraysNullFirst",
+                createNestedArray("arraysNullFirst", Schema.OPTIONAL_INT32_SCHEMA))
+            .field(
+                "arraysWithMixedTypes",
+                createNestedArray("arraysWithMixedTypes", Schema.OPTIONAL_STRING_SCHEMA))
+            .build();
+
+    assertSchemaEquals(expected, inferDocumentSchema(bsonDocument));
+  }
+
+  @Test
+  void testArraysWithStructs() {
+    BsonDocument bsonDocument =
+        BsonDocument.parse(
+            "{"
+                + " structs: [{a: 1, b: true, c: 'foo', d: 4, e: {'$numberLong': '5'}}],"
+                + " structsEmpty: [{a: 1, b: true}, {}, {c: 'foo'}, {d: 4, e: {'$numberLong': '5'}}],"
+                + " structsEmptyFirst: [{}, {a: 1, b: true}, {c: 'foo'}, {d: 4, e: {'$numberLong': '5'}}],"
+                + " structsNull: [{a: 1, b: true}, null, {c: 'foo'}, {d: 4, e: {'$numberLong': '5'}}],"
+                + " structsNullFirst: [null, {a: 1, b: true}, {c: 'foo'}, {d: 4, e: {'$numberLong': '5'}}],"
+                + " structsWithMixedTypes: [{a: 1, b: 2, c: 3, d: 4, e: 5}, {a: 'a', b: 'b', c: 'c', d: 'd', e: 'e'}]}");
+
+    Schema expected =
+        SchemaBuilder.struct()
+            .name(DEFAULT_FIELD_NAME)
+            .field("structs", createArray("structs", SIMPLE_STRUCT))
+            .field("structsEmpty", createArray("structsEmpty", SIMPLE_STRUCT))
+            .field("structsEmptyFirst", createArray("structsEmptyFirst", SIMPLE_STRUCT))
+            .field("structsNull", createArray("structsNull", SIMPLE_STRUCT))
+            .field("structsNullFirst", createArray("structsNullFirst", SIMPLE_STRUCT))
+            .field(
+                "structsWithMixedTypes",
+                createArray("structsWithMixedTypes", SIMPLE_STRUCT_STRINGS))
+            .build();
+
+    assertSchemaEquals(expected, inferDocumentSchema(bsonDocument));
+  }
+
+  @Test
+  void testArraysOfArraysWithStructs() {
+    BsonDocument bsonDocument =
+        BsonDocument.parse(
+            "{"
+                + " arrayStructs: [[{a: 1, b: true, c: 'foo', d: 4, e: {'$numberLong': '5'}}]],"
+                + " arrayStructsEmpty: [[{a: 1, b: true}], [{}], [{c: 'foo'}], [], [{d: 4, e: {'$numberLong': '5'}}]],"
+                + " arrayStructsEmptyFirst: [[{}], [{a: 1, b: true}, {c: 'foo'}], [{d: 4, e: {'$numberLong': '5'}}]],"
+                + " arrayStructsNull: [[{a: 1, b: true}, null], null, [{c: 'foo'}, {d: 4, e: {'$numberLong': '5'}}]],"
+                + " arrayStructsNullFirst: [null, [null], [{a: 1, b: true}, {c: 'foo'}, {d: 4, e: {'$numberLong': '5'}}]],"
+                + " arrayStructsWithMixedTypes: [[{a: 1, b: 2, c: 3, d: 4, e: 5}], [{a: 'a', 'b': 'b'}], [{c: 'c', d: 'd', e: 'e'}]]}");
+
+    Schema expected =
+        SchemaBuilder.struct()
+            .name(DEFAULT_FIELD_NAME)
+            .field("arrayStructs", createNestedArray("arrayStructs", SIMPLE_STRUCT))
+            .field("arrayStructsEmpty", createNestedArray("arrayStructsEmpty", SIMPLE_STRUCT))
+            .field(
+                "arrayStructsEmptyFirst",
+                createNestedArray("arrayStructsEmptyFirst", SIMPLE_STRUCT))
+            .field("arrayStructsNull", createNestedArray("arrayStructsNull", SIMPLE_STRUCT))
+            .field(
+                "arrayStructsNullFirst", createNestedArray("arrayStructsNullFirst", SIMPLE_STRUCT))
+            .field(
+                "arrayStructsWithMixedTypes",
+                createNestedArray("arrayStructsWithMixedTypes", SIMPLE_STRUCT_STRINGS))
+            .build();
+
+    assertSchemaEquals(expected, inferDocumentSchema(bsonDocument));
+  }
 
   @Test
   void testEmptyArray() {
@@ -196,24 +377,44 @@ public class BsonDocumentToSchemaTest {
     assertEquals(STRUCT, schema.type());
 
     Schema outerArraySchema = schema.field("outerArray").schema();
-    assertEquals(STRING, outerArraySchema.valueSchema().type());
+    assertEquals(ARRAY, outerArraySchema.type());
+
+    Schema outerArrayValueSchema = outerArraySchema.valueSchema();
+    assertEquals(STRUCT, outerArrayValueSchema.type());
+
+    Schema fieldSchema = outerArrayValueSchema.field("a").schema();
+    assertEquals(ARRAY, fieldSchema.type());
+    assertEquals(STRING, fieldSchema.valueSchema().type());
   }
 
-  @Test
-  void testUncombinableArrayArrayElements() {
-    BsonDocument document =
-        new BsonDocument()
-            .append(
-                "outerArray",
-                new BsonArray(
-                    asList(
-                        new BsonArray(asList(new BsonInt32(1))),
-                        new BsonArray(asList(new BsonString("foo"))))));
-
-    Schema schema = inferDocumentSchema(document);
-    assertEquals(STRUCT, schema.type());
-
-    Schema outerArraySchema = schema.field("outerArray").schema();
-    assertEquals(STRING, outerArraySchema.valueSchema().type());
+  static Schema createArray(final String name, final Schema valueSchema) {
+    return SchemaBuilder.array(valueSchema).optional().name(name).build();
   }
+
+  static Schema createNestedArray(final String name, final Schema valueSchema) {
+    return SchemaBuilder.array(SchemaBuilder.array(valueSchema).optional().name(name).build())
+        .optional()
+        .name(name)
+        .build();
+  }
+
+  private static final Schema SIMPLE_STRUCT =
+      SchemaBuilder.struct()
+          .name("default")
+          .field("a", Schema.OPTIONAL_INT32_SCHEMA)
+          .field("b", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+          .field("c", Schema.OPTIONAL_STRING_SCHEMA)
+          .field("d", Schema.OPTIONAL_INT32_SCHEMA)
+          .field("e", Schema.OPTIONAL_INT64_SCHEMA)
+          .build();
+
+  private static final Schema SIMPLE_STRUCT_STRINGS =
+      SchemaBuilder.struct()
+          .name("default")
+          .field("a", Schema.OPTIONAL_STRING_SCHEMA)
+          .field("b", Schema.OPTIONAL_STRING_SCHEMA)
+          .field("c", Schema.OPTIONAL_STRING_SCHEMA)
+          .field("d", Schema.OPTIONAL_STRING_SCHEMA)
+          .field("e", Schema.OPTIONAL_STRING_SCHEMA)
+          .build();
 }

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
@@ -19,14 +19,6 @@ package com.mongodb.kafka.connect.source.schema;
 import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.DEFAULT_FIELD_NAME;
 import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.inferDocumentSchema;
 import static com.mongodb.kafka.connect.source.schema.SchemaUtils.assertSchemaEquals;
-import static java.util.Arrays.asList;
-import static org.apache.kafka.connect.data.Schema.Type.ARRAY;
-import static org.apache.kafka.connect.data.Schema.Type.BOOLEAN;
-import static org.apache.kafka.connect.data.Schema.Type.INT32;
-import static org.apache.kafka.connect.data.Schema.Type.STRING;
-import static org.apache.kafka.connect.data.Schema.Type.STRUCT;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -34,12 +26,7 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Timestamp;
 import org.junit.jupiter.api.Test;
 
-import org.bson.BsonArray;
-import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
-import org.bson.BsonInt32;
-import org.bson.BsonNull;
-import org.bson.BsonString;
 
 @SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
 public class BsonDocumentToSchemaTest {
@@ -222,173 +209,6 @@ public class BsonDocumentToSchemaTest {
             .build();
 
     assertSchemaEquals(expected, inferDocumentSchema(bsonDocument));
-  }
-
-  @Test
-  void testEmptyArray() {
-    BsonDocument document =
-        new BsonDocument()
-            .append(
-                "outerArray",
-                new BsonArray(
-                    asList(
-                        new BsonDocument("innerArray", new BsonArray()),
-                        new BsonDocument(
-                            "innerArray",
-                            new BsonArray(asList(new BsonInt32(1), new BsonInt32(2)))),
-                        new BsonDocument(
-                            "innerArray",
-                            new BsonArray(asList(new BsonInt32(3), new BsonInt32(4)))))));
-
-    Schema schema = inferDocumentSchema(document);
-    assertEquals(STRUCT, schema.type());
-
-    Schema outerArraySchema = schema.field("outerArray").schema();
-    assertEquals(STRUCT, outerArraySchema.valueSchema().type());
-
-    Schema innerArraySchema = outerArraySchema.valueSchema().field("innerArray").schema();
-    assertEquals(ARRAY, innerArraySchema.type());
-    assertEquals(INT32, innerArraySchema.valueSchema().type());
-  }
-
-  @Test
-  void testStructCombining() {
-    BsonDocument document =
-        new BsonDocument()
-            .append(
-                "outerArray",
-                new BsonArray(
-                    asList(
-                        new BsonDocument()
-                            .append("c", new BsonString(""))
-                            .append("b", new BsonInt32(1)),
-                        new BsonDocument()
-                            .append("a", BsonBoolean.TRUE)
-                            .append("b", new BsonInt32(2)))));
-
-    Schema schema = inferDocumentSchema(document);
-    assertEquals(STRUCT, schema.type());
-
-    Schema outerArraySchema = schema.field("outerArray").schema();
-    assertEquals(STRUCT, outerArraySchema.valueSchema().type());
-
-    Schema outerArrayValueSchema = outerArraySchema.valueSchema();
-    assertEquals(STRUCT, outerArrayValueSchema.type());
-
-    assertEquals(BOOLEAN, outerArrayValueSchema.field("a").schema().type());
-    assertEquals(INT32, outerArrayValueSchema.field("b").schema().type());
-    assertEquals(STRING, outerArrayValueSchema.field("c").schema().type());
-
-    assertEquals("a", outerArrayValueSchema.fields().get(0).name());
-    assertEquals("b", outerArrayValueSchema.fields().get(1).name());
-    assertEquals("c", outerArrayValueSchema.fields().get(2).name());
-  }
-
-  @Test
-  void testStructCombiningNestedArrays() {
-    BsonDocument document =
-        new BsonDocument()
-            .append(
-                "outerArray",
-                new BsonArray(
-                    asList(
-                        new BsonDocument()
-                            .append(
-                                "innerArray",
-                                new BsonArray(
-                                    asList(
-                                        new BsonDocument()
-                                            .append("a", new BsonInt32(1))
-                                            .append("b", new BsonString("foo"))))),
-                        new BsonDocument()
-                            .append(
-                                "innerArray",
-                                new BsonArray(
-                                    asList(
-                                        new BsonDocument()
-                                            .append("b", new BsonString("foo"))
-                                            .append("c", new BsonInt32(2))))))));
-
-    Schema schema = inferDocumentSchema(document);
-    assertEquals(STRUCT, schema.type());
-
-    Schema outerArraySchema = schema.field("outerArray").schema();
-    assertEquals(STRUCT, outerArraySchema.valueSchema().type());
-
-    Schema outerArrayValueSchema = outerArraySchema.valueSchema();
-    assertEquals(STRUCT, outerArrayValueSchema.type());
-
-    Schema innerArraySchema = outerArrayValueSchema.field("innerArray").schema();
-    assertEquals(ARRAY, innerArraySchema.type());
-
-    Schema innerArrayValueSchema = innerArraySchema.valueSchema();
-    assertEquals(STRUCT, innerArrayValueSchema.type());
-
-    assertEquals(INT32, innerArrayValueSchema.field("a").schema().type());
-    assertEquals(STRING, innerArrayValueSchema.field("b").schema().type());
-    assertEquals(INT32, innerArrayValueSchema.field("c").schema().type());
-  }
-
-  @Test
-  void testStructCombiningWithNulls() {
-    BsonDocument document =
-        new BsonDocument()
-            .append(
-                "outerArray",
-                new BsonArray(
-                    asList(
-                        new BsonDocument()
-                            .append("a", new BsonInt32(1))
-                            .append("b", new BsonString("foo"))
-                            .append("c", BsonNull.VALUE)
-                            .append("d", BsonNull.VALUE)
-                            .append("e", new BsonArray()),
-                        new BsonDocument()
-                            .append("a", BsonNull.VALUE)
-                            .append("b", new BsonString("foo"))
-                            .append("c", new BsonInt32(2)))));
-
-    Schema schema = inferDocumentSchema(document);
-    assertEquals(STRUCT, schema.type());
-
-    Schema outerArraySchema = schema.field("outerArray").schema();
-    assertEquals(STRUCT, outerArraySchema.valueSchema().type());
-
-    Schema outerArrayValueSchema = outerArraySchema.valueSchema();
-    assertEquals(STRUCT, outerArrayValueSchema.type());
-
-    assertEquals(INT32, outerArrayValueSchema.field("a").schema().type());
-    assertEquals(STRING, outerArrayValueSchema.field("b").schema().type());
-    assertEquals(INT32, outerArrayValueSchema.field("c").schema().type());
-    assertEquals(STRING, outerArrayValueSchema.field("d").schema().type());
-    assertNull(outerArrayValueSchema.field("d").schema().defaultValue());
-    assertEquals(STRING, outerArrayValueSchema.field("e").schema().valueSchema().type());
-    assertNull(outerArrayValueSchema.field("e").schema().valueSchema().defaultValue());
-  }
-
-  @Test
-  void testUncombinableDocumentArrayElements() {
-    BsonDocument document =
-        new BsonDocument()
-            .append(
-                "outerArray",
-                new BsonArray(
-                    asList(
-                        new BsonDocument("a", new BsonArray(asList(new BsonInt32(1)))),
-                        new BsonDocument("a", new BsonArray(asList(new BsonString("foo")))))));
-
-    Schema schema = inferDocumentSchema(document);
-    assertEquals(STRUCT, schema.type());
-
-    Schema outerArraySchema = schema.field("outerArray").schema();
-    assertEquals(ARRAY, outerArraySchema.type());
-
-    Schema outerArrayValueSchema = outerArraySchema.valueSchema();
-    assertEquals(STRUCT, outerArrayValueSchema.type());
-
-    Schema fieldSchema = outerArrayValueSchema.field("a").schema();
-    assertEquals(ARRAY, fieldSchema.type());
-    assertEquals(STRING, fieldSchema.valueSchema().type());
   }
 
   static Schema createArray(final String name, final Schema valueSchema) {

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
@@ -133,16 +133,16 @@ public class BsonDocumentToSchemaTest {
     Schema expected =
         SchemaBuilder.struct()
             .name(DEFAULT_FIELD_NAME)
-            .field("_a", Schema.OPTIONAL_STRING_SCHEMA)
             .field("_id", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("_a", Schema.OPTIONAL_STRING_SCHEMA)
             .field(
                 "arrays",
                 createArray(
                     "arrays",
                     SchemaBuilder.struct()
                         .name("arrays")
-                        .field("_a", Schema.OPTIONAL_STRING_SCHEMA)
                         .field("_id", Schema.OPTIONAL_STRING_SCHEMA)
+                        .field("_a", Schema.OPTIONAL_STRING_SCHEMA)
                         .field("a", Schema.OPTIONAL_STRING_SCHEMA)
                         .build()))
             .build();

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 
 import org.bson.BsonDocument;
 
-@SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
 public class BsonDocumentToSchemaTest {
 
   @Test

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
@@ -122,6 +122,35 @@ public class BsonDocumentToSchemaTest {
   }
 
   @Test
+  void testFieldOrderingHandling() {
+    BsonDocument bsonDocument =
+        BsonDocument.parse(
+            "{"
+                + " arrays: [{_a: 'foo', _id: 'foo'}, {_id: 'bar', a: ''}],"
+                + "_id: 'foo'"
+                + "_a: 'bar'}");
+
+    Schema expected =
+        SchemaBuilder.struct()
+            .name(DEFAULT_FIELD_NAME)
+            .field("_id", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("_a", Schema.OPTIONAL_STRING_SCHEMA)
+            .field(
+                "arrays",
+                createArray(
+                    "arrays",
+                    SchemaBuilder.struct()
+                        .name("arrays")
+                        .field("_id", Schema.OPTIONAL_STRING_SCHEMA)
+                        .field("_a", Schema.OPTIONAL_STRING_SCHEMA)
+                        .field("a", Schema.OPTIONAL_STRING_SCHEMA)
+                        .build()))
+            .build();
+
+    assertSchemaEquals(expected, inferDocumentSchema(bsonDocument));
+  }
+
+  @Test
   void testArraysSimpleNesting() {
     BsonDocument bsonDocument =
         BsonDocument.parse(

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
@@ -133,16 +133,16 @@ public class BsonDocumentToSchemaTest {
     Schema expected =
         SchemaBuilder.struct()
             .name(DEFAULT_FIELD_NAME)
-            .field("_id", Schema.OPTIONAL_STRING_SCHEMA)
             .field("_a", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("_id", Schema.OPTIONAL_STRING_SCHEMA)
             .field(
                 "arrays",
                 createArray(
                     "arrays",
                     SchemaBuilder.struct()
                         .name("arrays")
-                        .field("_id", Schema.OPTIONAL_STRING_SCHEMA)
                         .field("_a", Schema.OPTIONAL_STRING_SCHEMA)
+                        .field("_id", Schema.OPTIONAL_STRING_SCHEMA)
                         .field("a", Schema.OPTIONAL_STRING_SCHEMA)
                         .build()))
             .build();

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
@@ -19,6 +19,7 @@ package com.mongodb.kafka.connect.source.schema;
 import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.inferDocumentSchema;
 import static java.util.Arrays.asList;
 import static org.apache.kafka.connect.data.Schema.Type.ARRAY;
+import static org.apache.kafka.connect.data.Schema.Type.BOOLEAN;
 import static org.apache.kafka.connect.data.Schema.Type.INT32;
 import static org.apache.kafka.connect.data.Schema.Type.STRING;
 import static org.apache.kafka.connect.data.Schema.Type.STRUCT;
@@ -29,6 +30,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.junit.jupiter.api.Test;
 
 import org.bson.BsonArray;
+import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.BsonNull;
@@ -73,11 +75,11 @@ public class BsonDocumentToSchemaTest {
                 new BsonArray(
                     asList(
                         new BsonDocument()
-                            .append("a", new BsonInt32(1))
-                            .append("b", new BsonString("foo")),
+                            .append("c", new BsonString(""))
+                            .append("b", new BsonInt32(1)),
                         new BsonDocument()
-                            .append("b", new BsonString("foo"))
-                            .append("c", new BsonInt32(2)))));
+                            .append("a", BsonBoolean.TRUE)
+                            .append("b", new BsonInt32(2)))));
 
     Schema schema = inferDocumentSchema(document);
     assertEquals(STRUCT, schema.type());
@@ -88,9 +90,13 @@ public class BsonDocumentToSchemaTest {
     Schema outerArrayValueSchema = outerArraySchema.valueSchema();
     assertEquals(STRUCT, outerArrayValueSchema.type());
 
-    assertEquals(INT32, outerArrayValueSchema.field("a").schema().type());
-    assertEquals(STRING, outerArrayValueSchema.field("b").schema().type());
-    assertEquals(INT32, outerArrayValueSchema.field("c").schema().type());
+    assertEquals(BOOLEAN, outerArrayValueSchema.field("a").schema().type());
+    assertEquals(INT32, outerArrayValueSchema.field("b").schema().type());
+    assertEquals(STRING, outerArrayValueSchema.field("c").schema().type());
+
+    assertEquals("a", outerArrayValueSchema.fields().get(0).name());
+    assertEquals("b", outerArrayValueSchema.fields().get(1).name());
+    assertEquals("c", outerArrayValueSchema.fields().get(2).name());
   }
 
   @Test

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
@@ -17,12 +17,14 @@
 package com.mongodb.kafka.connect.source.schema;
 
 import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.DEFAULT_FIELD_NAME;
-import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.DEFAULT_INFER_SCHEMA_TYPE;
+import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.INCOMPATIBLE_SCHEMA_TYPE;
 import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.SENTINEL_STRING_TYPE;
 import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.inferDocumentSchema;
+import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.isSentinel;
 import static com.mongodb.kafka.connect.source.schema.SchemaUtils.assertSchemaEquals;
-import static com.mongodb.kafka.connect.util.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -215,10 +217,10 @@ public class BsonDocumentToSchemaTest {
   }
 
   @Test
-  void testSentinelTypeCanary() {
-    assertEquals(SENTINEL_STRING_TYPE, DEFAULT_INFER_SCHEMA_TYPE);
-
-    assertFalse(SENTINEL_STRING_TYPE == DEFAULT_INFER_SCHEMA_TYPE);
+  void testSentinelType() {
+    assertEquals(SENTINEL_STRING_TYPE, INCOMPATIBLE_SCHEMA_TYPE);
+    assertFalse(isSentinel(INCOMPATIBLE_SCHEMA_TYPE));
+    assertTrue(isSentinel(SENTINEL_STRING_TYPE));
   }
 
   static Schema createArray(final String name, final Schema valueSchema) {

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
@@ -171,6 +171,7 @@ public class BsonDocumentToSchemaTest {
                 + " structsEmptyFirst: [{}, {a: 1, b: true}, {c: 'foo'}, {d: 4, e: {'$numberLong': '5'}}],"
                 + " structsNull: [{a: 1, b: true}, null, {c: 'foo'}, {d: 4, e: {'$numberLong': '5'}}],"
                 + " structsNullFirst: [null, {a: 1, b: true}, {c: 'foo'}, {d: 4, e: {'$numberLong': '5'}}],"
+                + " structsOrdering: [{e: {'$numberLong': '5'}, c: 'foo', b: true, d: 4, a: 1}],"
                 + " structsWithMixedTypes: [{a: 1, b: 2, c: 3, d: 4, e: 5}, {a: 'a', b: 'b', c: 'c', d: 'd', e: 'e'}]}");
 
     Schema expected =
@@ -181,6 +182,7 @@ public class BsonDocumentToSchemaTest {
             .field("structsEmptyFirst", createArray("structsEmptyFirst", SIMPLE_STRUCT))
             .field("structsNull", createArray("structsNull", SIMPLE_STRUCT))
             .field("structsNullFirst", createArray("structsNullFirst", SIMPLE_STRUCT))
+            .field("structsOrdering", createArray("structsOrdering", SIMPLE_STRUCT))
             .field(
                 "structsWithMixedTypes",
                 createArray("structsWithMixedTypes", SIMPLE_STRUCT_STRINGS))
@@ -199,6 +201,7 @@ public class BsonDocumentToSchemaTest {
                 + " arrayStructsEmptyFirst: [[{}], [{a: 1, b: true}, {c: 'foo'}], [{d: 4, e: {'$numberLong': '5'}}]],"
                 + " arrayStructsNull: [[{a: 1, b: true}, null], null, [{c: 'foo'}, {d: 4, e: {'$numberLong': '5'}}]],"
                 + " arrayStructsNullFirst: [null, [null], [{a: 1, b: true}, {c: 'foo'}, {d: 4, e: {'$numberLong': '5'}}]],"
+                + " arrayStructsOrdering: [[{e: {'$numberLong': '5'}, c: 'foo'}], [{b: true}], [{d: 4, a: 1}]],"
                 + " arrayStructsWithMixedTypes: [[{a: 1, b: 2, c: 3, d: 4, e: 5}], [{a: 'a', 'b': 'b'}], [{c: 'c', d: 'd', e: 'e'}]]}");
 
     Schema expected =
@@ -212,6 +215,7 @@ public class BsonDocumentToSchemaTest {
             .field("arrayStructsNull", createNestedArray("arrayStructsNull", SIMPLE_STRUCT))
             .field(
                 "arrayStructsNullFirst", createNestedArray("arrayStructsNullFirst", SIMPLE_STRUCT))
+            .field("arrayStructsOrdering", createNestedArray("arrayStructsOrdering", SIMPLE_STRUCT))
             .field(
                 "arrayStructsWithMixedTypes",
                 createNestedArray("arrayStructsWithMixedTypes", SIMPLE_STRUCT_STRINGS))


### PR DESCRIPTION
 1. Where two struct types differ only where one has a field that the other does not.  In this case, the extra field is added to the combined schema
 2. Where two struct types differ only where one has a field that the other has a field whose value is null in the source document. In this case, the extra field is added to the combined schema with the type of the field that has the non-null value.
 3. Where two array types differ only in that one of the arrays is empty. In this case, the value schema for the empty array is changed to the one for the non-empty array

KAFKA-343