### PR TITLE
Fix schema inference

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/source/schema/SchemaDebugHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/SchemaDebugHelper.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.source.schema;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+
+public final class SchemaDebugHelper {
+
+  public static String prettyPrintSchema(final String name, final Schema schema) {
+    return appendSchemaInformation(new StringBuilder(), name, schema).toString();
+  }
+
+  static String prettyPrintSchemas(final Schema firstSchema, final Schema secondSchema) {
+    StringBuilder builder = new StringBuilder();
+    appendSchemaInformation(builder, "Schema one", firstSchema);
+    appendSchemaInformation(builder, "Schema two", secondSchema);
+    return builder.toString();
+  }
+
+  public static StringBuilder appendSchemaInformation(
+      final StringBuilder builder, final String name, final Schema schema) {
+    builder.append(name);
+    builder.append(":\n");
+    appendSchemaInformation(builder, schema, 0);
+    return builder;
+  }
+
+  private static void appendSchemaInformation(
+      final StringBuilder builder, final Schema schema, final int level) {
+    String padding = createPadding(level);
+    if (level > 10) {
+      builder.append(padding);
+      builder.append(" ... Very high level of nesting ...");
+      return;
+    }
+
+    switch (schema.type()) {
+      case ARRAY:
+        builder.append(padding);
+
+        StringBuilder arrayPostfix = new StringBuilder();
+        builder.append(" [");
+        arrayPostfix.append(" ]");
+        Schema valueSchema = schema.valueSchema();
+
+        while (valueSchema.type() == Schema.Type.ARRAY) {
+          builder.append(" [");
+          arrayPostfix.append(" ]");
+          valueSchema = valueSchema.valueSchema();
+        }
+
+        builder.append("\n");
+        appendSchemaInformation(builder, valueSchema, level);
+
+        builder.append(padding);
+        builder.append(arrayPostfix);
+        builder.append("\n");
+        break;
+      case STRUCT:
+        schema.fields().forEach(f -> appendFieldInformation(builder, f, level + 1));
+        break;
+      default:
+        builder.append(padding);
+        builder.append(schema.type().getName());
+        builder.append("\n");
+    }
+  }
+
+  private static void appendFieldInformation(
+      final StringBuilder builder, final Field field, final int level) {
+    String padding = createPadding(level);
+    builder.append(padding);
+    builder.append(field.name());
+    builder.append(": ");
+    builder.append(field.schema().type().getName());
+    builder.append(" (optional = ");
+    builder.append(field.schema().isOptional());
+    builder.append(")");
+    builder.append(" (name = ");
+    builder.append(field.schema().name());
+    builder.append(")");
+    builder.append("\n");
+
+    switch (field.schema().type()) {
+      case ARRAY:
+      case STRUCT:
+        appendSchemaInformation(builder, field.schema(), level);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private static String createPadding(final int level) {
+    StringBuilder stringBuilder = new StringBuilder();
+    stringBuilder.append(" ");
+    for (int i = 1; i <= level; i++) {
+      stringBuilder.append(" | ");
+    }
+    return stringBuilder.toString();
+  }
+
+  private SchemaDebugHelper() {}
+}

--- a/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
@@ -160,7 +160,7 @@ public class SchemaAndValueProducerTest {
                 SchemaBuilder.array(
                         SchemaBuilder.struct()
                             .field("a", Schema.OPTIONAL_INT32_SCHEMA)
-                            .name("arrayComplex_a")
+                            .name("arrayComplex")
                             .optional()
                             .build())
                     .optional()
@@ -171,7 +171,7 @@ public class SchemaAndValueProducerTest {
                 SchemaBuilder.array(
                         SchemaBuilder.struct()
                             .field("a", Schema.OPTIONAL_STRING_SCHEMA)
-                            .name("arrayComplexMixedTypes_a")
+                            .name("arrayComplexMixedTypes")
                             .optional()
                             .build())
                     .optional()

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/SchemaUtils.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/SchemaUtils.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.kafka.connect.source.schema;
 
+import static com.mongodb.kafka.connect.source.schema.SchemaDebugHelper.prettyPrintSchemas;
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
@@ -99,11 +100,11 @@ public final class SchemaUtils {
     } else {
       assertEquals(expectedDefaultValue, actualDefaultValue, "values differ");
     }
-    if (expected.type() == Type.MAP) {
-      assertEquals(expected.keySchema(), actual.keySchema(), "keySchema differs");
-      assertEquals(expected.valueSchema(), actual.valueSchema(), "valueSchema differs");
+
+    if (expected.type() == Type.ARRAY) {
+      assertSchemaEquals(expected.valueSchema(), actual.valueSchema());
     } else if (expected.type() == Type.STRUCT) {
-      assertStructSchemaEquals(expected, actual);
+      assertStructSchemaEquals(expected.schema(), actual.schema());
     }
     assertEquals(expected.parameters(), actual.parameters(), "parameters differs");
     assertEquals(expected.name(), actual.name(), "name differs: " + actual.schema());
@@ -127,7 +128,9 @@ public final class SchemaUtils {
         assertSchemaEquals(expectedField.schema(), actualField.schema());
       } catch (Throwable e) {
         throw new AssertionFailedError(
-            format("Field schema differed for: %s : %s", expectedField.name(), e.getMessage()));
+            format(
+                "Field schema differed for: %s : %s\n%s",
+                expectedField.name(), e.getMessage(), prettyPrintSchemas(expected, actual)));
       }
     }
   }


### PR DESCRIPTION
Fix nested structs recursion.
Ensure tests recurse correctly when evaluating schemas. Added debug schema helper for comparing and visualizing schemas.

KAFKA-349