### PR TITLE
Logging improvements when types are in compatible

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/source/schema/SchemaDebugHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/SchemaDebugHelper.java
@@ -27,6 +27,16 @@ public final class SchemaDebugHelper {
 
   static String prettyPrintSchemas(final Schema firstSchema, final Schema secondSchema) {
     StringBuilder builder = new StringBuilder();
+
+    builder.append(firstSchema.type());
+    builder.append(" : ");
+    builder.append(secondSchema.type());
+
+    if (firstSchema.type().isPrimitive() && secondSchema.type().isPrimitive()) {
+      return builder.toString();
+    }
+
+    builder.append("\n");
     appendSchemaInformation(builder, "Schema one", firstSchema);
     appendSchemaInformation(builder, "Schema two", secondSchema);
     return builder.toString();
@@ -65,7 +75,7 @@ public final class SchemaDebugHelper {
         }
 
         builder.append("\n");
-        appendSchemaInformation(builder, valueSchema, level);
+        appendSchemaInformation(builder, valueSchema, level + 1);
 
         builder.append(padding);
         builder.append(arrayPostfix);


### PR DESCRIPTION
I've updated the logging output to try and improve the debug-ability of inferring schema.


Example:

```
[2023-01-25 14:09:21,025] DEBUG Incompatible Schemas: STRUCT : STRUCT
Schema one:
  | a: int32 (optional = true) (name = null)
  | b: int32 (optional = true) (name = null)
  | c: int32 (optional = true) (name = null)
  | d: int32 (optional = true) (name = null)
  | e: int32 (optional = true) (name = null)
Schema two:
  | a: string (optional = true) (name = null)
  | b: string (optional = true) (name = null)
  | c: string (optional = true) (name = null)
  | d: string (optional = true) (name = null)
  | e: string (optional = true) (name = null)
 (com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema:224)
```