### PR TITLE
Kafka-348 SSL Support Added

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/MongoSinkConnector.java
+++ b/src/main/java/com/mongodb/kafka/connect/MongoSinkConnector.java
@@ -89,7 +89,7 @@ public class MongoSinkConnector extends SinkConnector {
     } catch (Exception e) {
       return config;
     }
-    
+
     setupSsl(sinkConfig);
 
     validateCanConnect(config, CONNECTION_URI_CONFIG)

--- a/src/main/java/com/mongodb/kafka/connect/MongoSinkConnector.java
+++ b/src/main/java/com/mongodb/kafka/connect/MongoSinkConnector.java
@@ -23,6 +23,7 @@ import static com.mongodb.kafka.connect.util.ConfigHelper.getConfigByName;
 import static com.mongodb.kafka.connect.util.ConnectionValidator.validateCanConnect;
 import static com.mongodb.kafka.connect.util.ConnectionValidator.validateUserHasActions;
 import static com.mongodb.kafka.connect.util.ServerApiConfig.validateServerApi;
+import static com.mongodb.kafka.connect.util.SslConfigs.setupSsl;
 import static com.mongodb.kafka.connect.util.TimeseriesValidation.validTopicRegexConfigAndCollection;
 import static com.mongodb.kafka.connect.util.TimeseriesValidation.validateConfigAndCollection;
 import static java.util.Arrays.asList;
@@ -88,6 +89,8 @@ public class MongoSinkConnector extends SinkConnector {
     } catch (Exception e) {
       return config;
     }
+    
+    setupSsl(sinkConfig);
 
     validateCanConnect(config, CONNECTION_URI_CONFIG)
         .ifPresent(

--- a/src/main/java/com/mongodb/kafka/connect/MongoSourceConnector.java
+++ b/src/main/java/com/mongodb/kafka/connect/MongoSourceConnector.java
@@ -19,6 +19,7 @@ package com.mongodb.kafka.connect;
 import static com.mongodb.kafka.connect.util.ConnectionValidator.validateCanConnect;
 import static com.mongodb.kafka.connect.util.ConnectionValidator.validateUserHasActions;
 import static com.mongodb.kafka.connect.util.ServerApiConfig.validateServerApi;
+import static com.mongodb.kafka.connect.util.SslConfigs.setupSsl;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
@@ -56,6 +57,8 @@ public class MongoSourceConnector extends SourceConnector {
     } catch (Exception e) {
       return config;
     }
+
+    setupSsl(sourceConfig);
 
     validateCanConnect(config, MongoSourceConfig.CONNECTION_URI_CONFIG)
         .ifPresent(

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
@@ -23,6 +23,7 @@ import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.TOPIC_OVERRIDE
 import static com.mongodb.kafka.connect.sink.SinkConfigSoftValidator.logIncompatibleProperties;
 import static com.mongodb.kafka.connect.sink.SinkConfigSoftValidator.logObsoleteProperties;
 import static com.mongodb.kafka.connect.util.ServerApiConfig.addServerApiConfig;
+import static com.mongodb.kafka.connect.util.SslConfigs.addSslConfigDef;
 import static com.mongodb.kafka.connect.util.Validators.errorCheckingValueValidator;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
@@ -282,6 +283,7 @@ public class MongoSinkConfig extends AbstractConfig {
         CONNECTION_URI_DISPLAY);
 
     addServerApiConfig(configDef);
+    addSslConfigDef(configDef);
 
     group = "Overrides";
     orderInGroup = 0;

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -30,6 +30,7 @@ import static com.mongodb.kafka.connect.util.ConfigHelper.fullDocumentBeforeChan
 import static com.mongodb.kafka.connect.util.ConfigHelper.fullDocumentFromString;
 import static com.mongodb.kafka.connect.util.ConfigHelper.jsonArrayFromString;
 import static com.mongodb.kafka.connect.util.ServerApiConfig.addServerApiConfig;
+import static com.mongodb.kafka.connect.util.SslConfigs.addSslConfigDef;
 import static com.mongodb.kafka.connect.util.Validators.emptyString;
 import static com.mongodb.kafka.connect.util.Validators.errorCheckingValueValidator;
 import static com.mongodb.kafka.connect.util.VisibleForTesting.AccessModifier.PACKAGE;
@@ -914,6 +915,7 @@ public class MongoSourceConfig extends AbstractConfig {
         COLLECTION_DISPLAY);
 
     addServerApiConfig(configDef);
+    addSslConfigDef(configDef);
 
     group = "Change stream";
     orderInGroup = 0;

--- a/src/main/java/com/mongodb/kafka/connect/util/SslConfigs.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/SslConfigs.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.util;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigDef.Width;
+import org.apache.kafka.common.config.types.Password;
+
+public class SslConfigs {
+    
+    private static final String EMPTY_STRING = "";
+    
+    public static final String CONNECTION_SSL_TRUSTSTORE_CONFIG = "connection.ssl.truststore";
+    private static final String CONNECTION_SSL_TRUSTSTORE_DOC =
+        "A trust store certificate location to be used for SSL enabled connections";
+    public static final String CONNECTION_SSL_TRUSTSTORE_DEFAULT = EMPTY_STRING;
+    private static final String CONNECTION_SSL_TRUSTSTORE_DISPLAY = "SSL TrustStore";
+
+    public static final String CONNECTION_SSL_TRUSTSTORE_PASSWORD_CONFIG = "connection.ssl.truststorePassword";
+    private static final String CONNECTION_SSL_TRUSTSTORE_PASSWORD_DOC =
+        "A trust store password to be used for SSL enabled connections";
+    public static final String CONNECTION_SSL_TRUSTSTORE_PASSWORD_DEFAULT = EMPTY_STRING;
+    private static final String CONNECTION_SSL_TRUSTSTORE_PASSWORD_DISPLAY = "SSL TrustStore Password";
+
+    public static final String CONNECTION_SSL_KEYSTORE_CONFIG = "connection.ssl.keystore";
+    private static final String CONNECTION_SSL_KEYSTORE_DOC =
+        "A key store certificate location to be used for SSL enabled connections";
+    public static final String CONNECTION_SSL_KEYSTORE_DEFAULT = EMPTY_STRING;
+    private static final String CONNECTION_SSL_KEYSTORE_DISPLAY = "SSL KeyStore";
+    
+    public static final String CONNECTION_SSL_KEYSTORE_PASSWORD_CONFIG = "connection.ssl.keystorePassword";
+    private static final String CONNECTION_SSL_KEYSTORE_PASSWORD_DOC =
+        "A key store password to be used for SSL enabled connections";
+    public static final String CONNECTION_SSL_KEYSTORE_PASSWORD_DEFAULT = EMPTY_STRING;
+    private static final String CONNECTION_SSL_KEYSTORE_PASSWORD_DISPLAY = "SSL KeyStore Password";
+    
+    public static ConfigDef addSslConfigDef(final ConfigDef configDef) {
+        
+        String group = "SSL";
+        int orderInGroup = 0;
+        configDef
+            .define(
+                    CONNECTION_SSL_TRUSTSTORE_CONFIG,
+                    Type.STRING,
+                    CONNECTION_SSL_TRUSTSTORE_DEFAULT,
+                    Importance.MEDIUM,
+                    CONNECTION_SSL_TRUSTSTORE_DOC,
+                    group,
+                    ++orderInGroup,
+                    Width.LONG,
+                    CONNECTION_SSL_TRUSTSTORE_DISPLAY)
+            .define(
+                    CONNECTION_SSL_TRUSTSTORE_PASSWORD_CONFIG,
+                    Type.PASSWORD,
+                    CONNECTION_SSL_TRUSTSTORE_PASSWORD_DEFAULT,
+                    Importance.MEDIUM,
+                    CONNECTION_SSL_TRUSTSTORE_PASSWORD_DOC,
+                    group,
+                    ++orderInGroup,
+                    Width.MEDIUM,
+                    CONNECTION_SSL_TRUSTSTORE_PASSWORD_DISPLAY)
+            .define(
+                    CONNECTION_SSL_KEYSTORE_CONFIG,
+                    Type.STRING,
+                    CONNECTION_SSL_KEYSTORE_DEFAULT,
+                    Importance.MEDIUM,
+                    CONNECTION_SSL_KEYSTORE_DOC,
+                    group,
+                    ++orderInGroup,
+                    Width.LONG,
+                    CONNECTION_SSL_KEYSTORE_DISPLAY)
+            .define(
+                    CONNECTION_SSL_KEYSTORE_PASSWORD_CONFIG,
+                    Type.PASSWORD,
+                    CONNECTION_SSL_KEYSTORE_PASSWORD_DEFAULT,
+                    Importance.MEDIUM,
+                    CONNECTION_SSL_KEYSTORE_PASSWORD_DOC,
+                    group,
+                    ++orderInGroup,
+                    Width.MEDIUM,
+                    CONNECTION_SSL_KEYSTORE_PASSWORD_DISPLAY)
+            ;
+        return configDef;
+    }
+    
+    /**
+     * Set key store and trust store parameters as system properties.
+     * This will programmatically implement the following action in the command line before executing Java process: <br>
+     * <pre>
+     * # > export KAFKA_OPTS="\
+     *         -Djavax.net.ssl.trustStore=<your path to truststore> \
+     *         -Djavax.net.ssl.trustStorePassword=<your truststore password> \
+     *         -Djavax.net.ssl.keyStore=<your path to keystore> \
+     *         -Djavax.net.ssl.keyStorePassword=<your keystore password>"
+     * </pre>
+     * 
+     * If set, default SslContext uses these parameters from Java System properties to establish SSL-enabled connection.        
+     * 
+     * @param connectorConfig - Sink our Source Connector properties with key/trust store parameters
+     */
+    public static void setupSsl(AbstractConfig connectorConfig){
+        
+        String val = connectorConfig.getString(SslConfigs.CONNECTION_SSL_TRUSTSTORE_CONFIG);
+        if (val != null && !val.isBlank()) {
+            System.setProperty("javax.net.ssl.trustStore", val);
+        }
+        
+        Password passwordField = connectorConfig.getPassword(SslConfigs.CONNECTION_SSL_TRUSTSTORE_PASSWORD_CONFIG);
+        if (passwordField != null && !(val=passwordField.value()).isBlank()) {
+            System.setProperty("javax.net.ssl.trustStorePassword", val);
+        }
+
+        val = connectorConfig.getString(SslConfigs.CONNECTION_SSL_KEYSTORE_CONFIG);
+        if (val != null && !val.isBlank()) {
+            System.setProperty("javax.net.ssl.keyStore", val);
+        }
+        
+        passwordField = connectorConfig.getPassword(SslConfigs.CONNECTION_SSL_KEYSTORE_PASSWORD_CONFIG);
+        if (passwordField != null && !(val=passwordField.value()).isBlank()) {
+            System.setProperty("javax.net.ssl.keyStorePassword", val);
+        }
+    }
+}

--- a/src/main/java/com/mongodb/kafka/connect/util/SslConfigs.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/SslConfigs.java
@@ -21,7 +21,7 @@ import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.types.Password;
 
-public class SslConfigs {
+public final class SslConfigs {
 
   private static final String EMPTY_STRING = "";
 
@@ -117,27 +117,34 @@ public class SslConfigs {
    *
    * @param connectorConfig - Sink our Source Connector properties with key/trust store parameters
    */
-  public static void setupSsl(AbstractConfig connectorConfig) {
+  public static void setupSsl(final AbstractConfig connectorConfig) {
 
     String val = connectorConfig.getString(SslConfigs.CONNECTION_SSL_TRUSTSTORE_CONFIG);
-    if (val != null && !(val = val.trim()).isEmpty()) {
+    val = val != null ? val.trim() : null;
+    if (val != null && !val.isEmpty()) {
       System.setProperty("javax.net.ssl.trustStore", val);
     }
 
     Password passwordField =
         connectorConfig.getPassword(SslConfigs.CONNECTION_SSL_TRUSTSTORE_PASSWORD_CONFIG);
-    if (passwordField != null && !(val = passwordField.value().trim()).isEmpty()) {
+    val = passwordField != null ? passwordField.value().trim() : null;
+    if (val != null && !val.isEmpty()) {
       System.setProperty("javax.net.ssl.trustStorePassword", val);
     }
 
     val = connectorConfig.getString(SslConfigs.CONNECTION_SSL_KEYSTORE_CONFIG);
-    if (val != null && !(val = val.trim()).isEmpty()) {
+    val = val != null ? val.trim() : null;
+    if (val != null && !val.isEmpty()) {
       System.setProperty("javax.net.ssl.keyStore", val);
     }
 
     passwordField = connectorConfig.getPassword(SslConfigs.CONNECTION_SSL_KEYSTORE_PASSWORD_CONFIG);
-    if (passwordField != null && !(val = passwordField.value().trim()).isEmpty()) {
+    val = passwordField != null ? passwordField.value().trim() : null;
+    if (val != null && !val.isEmpty()) {
       System.setProperty("javax.net.ssl.keyStorePassword", val);
     }
   }
+
+  // Utility classes should not have a public or default constructor
+  private SslConfigs() {}
 }

--- a/src/main/java/com/mongodb/kafka/connect/util/SslConfigs.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/SslConfigs.java
@@ -120,23 +120,23 @@ public class SslConfigs {
   public static void setupSsl(AbstractConfig connectorConfig) {
 
     String val = connectorConfig.getString(SslConfigs.CONNECTION_SSL_TRUSTSTORE_CONFIG);
-    if (val != null && !val.isBlank()) {
+    if (val != null && !(val = val.trim()).isEmpty()) {
       System.setProperty("javax.net.ssl.trustStore", val);
     }
 
     Password passwordField =
         connectorConfig.getPassword(SslConfigs.CONNECTION_SSL_TRUSTSTORE_PASSWORD_CONFIG);
-    if (passwordField != null && !(val = passwordField.value()).isBlank()) {
+    if (passwordField != null && !(val = passwordField.value().trim()).isEmpty()) {
       System.setProperty("javax.net.ssl.trustStorePassword", val);
     }
 
     val = connectorConfig.getString(SslConfigs.CONNECTION_SSL_KEYSTORE_CONFIG);
-    if (val != null && !val.isBlank()) {
+    if (val != null && !(val = val.trim()).isEmpty()) {
       System.setProperty("javax.net.ssl.keyStore", val);
     }
 
     passwordField = connectorConfig.getPassword(SslConfigs.CONNECTION_SSL_KEYSTORE_PASSWORD_CONFIG);
-    if (passwordField != null && !(val = passwordField.value()).isBlank()) {
+    if (passwordField != null && !(val = passwordField.value().trim()).isEmpty()) {
       System.setProperty("javax.net.ssl.keyStorePassword", val);
     }
   }

--- a/src/main/java/com/mongodb/kafka/connect/util/SslConfigs.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/SslConfigs.java
@@ -22,117 +22,122 @@ import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.types.Password;
 
 public class SslConfigs {
-    
-    private static final String EMPTY_STRING = "";
-    
-    public static final String CONNECTION_SSL_TRUSTSTORE_CONFIG = "connection.ssl.truststore";
-    private static final String CONNECTION_SSL_TRUSTSTORE_DOC =
-        "A trust store certificate location to be used for SSL enabled connections";
-    public static final String CONNECTION_SSL_TRUSTSTORE_DEFAULT = EMPTY_STRING;
-    private static final String CONNECTION_SSL_TRUSTSTORE_DISPLAY = "SSL TrustStore";
 
-    public static final String CONNECTION_SSL_TRUSTSTORE_PASSWORD_CONFIG = "connection.ssl.truststorePassword";
-    private static final String CONNECTION_SSL_TRUSTSTORE_PASSWORD_DOC =
-        "A trust store password to be used for SSL enabled connections";
-    public static final String CONNECTION_SSL_TRUSTSTORE_PASSWORD_DEFAULT = EMPTY_STRING;
-    private static final String CONNECTION_SSL_TRUSTSTORE_PASSWORD_DISPLAY = "SSL TrustStore Password";
+  private static final String EMPTY_STRING = "";
 
-    public static final String CONNECTION_SSL_KEYSTORE_CONFIG = "connection.ssl.keystore";
-    private static final String CONNECTION_SSL_KEYSTORE_DOC =
-        "A key store certificate location to be used for SSL enabled connections";
-    public static final String CONNECTION_SSL_KEYSTORE_DEFAULT = EMPTY_STRING;
-    private static final String CONNECTION_SSL_KEYSTORE_DISPLAY = "SSL KeyStore";
-    
-    public static final String CONNECTION_SSL_KEYSTORE_PASSWORD_CONFIG = "connection.ssl.keystorePassword";
-    private static final String CONNECTION_SSL_KEYSTORE_PASSWORD_DOC =
-        "A key store password to be used for SSL enabled connections";
-    public static final String CONNECTION_SSL_KEYSTORE_PASSWORD_DEFAULT = EMPTY_STRING;
-    private static final String CONNECTION_SSL_KEYSTORE_PASSWORD_DISPLAY = "SSL KeyStore Password";
-    
-    public static ConfigDef addSslConfigDef(final ConfigDef configDef) {
-        
-        String group = "SSL";
-        int orderInGroup = 0;
-        configDef
-            .define(
-                    CONNECTION_SSL_TRUSTSTORE_CONFIG,
-                    Type.STRING,
-                    CONNECTION_SSL_TRUSTSTORE_DEFAULT,
-                    Importance.MEDIUM,
-                    CONNECTION_SSL_TRUSTSTORE_DOC,
-                    group,
-                    ++orderInGroup,
-                    Width.LONG,
-                    CONNECTION_SSL_TRUSTSTORE_DISPLAY)
-            .define(
-                    CONNECTION_SSL_TRUSTSTORE_PASSWORD_CONFIG,
-                    Type.PASSWORD,
-                    CONNECTION_SSL_TRUSTSTORE_PASSWORD_DEFAULT,
-                    Importance.MEDIUM,
-                    CONNECTION_SSL_TRUSTSTORE_PASSWORD_DOC,
-                    group,
-                    ++orderInGroup,
-                    Width.MEDIUM,
-                    CONNECTION_SSL_TRUSTSTORE_PASSWORD_DISPLAY)
-            .define(
-                    CONNECTION_SSL_KEYSTORE_CONFIG,
-                    Type.STRING,
-                    CONNECTION_SSL_KEYSTORE_DEFAULT,
-                    Importance.MEDIUM,
-                    CONNECTION_SSL_KEYSTORE_DOC,
-                    group,
-                    ++orderInGroup,
-                    Width.LONG,
-                    CONNECTION_SSL_KEYSTORE_DISPLAY)
-            .define(
-                    CONNECTION_SSL_KEYSTORE_PASSWORD_CONFIG,
-                    Type.PASSWORD,
-                    CONNECTION_SSL_KEYSTORE_PASSWORD_DEFAULT,
-                    Importance.MEDIUM,
-                    CONNECTION_SSL_KEYSTORE_PASSWORD_DOC,
-                    group,
-                    ++orderInGroup,
-                    Width.MEDIUM,
-                    CONNECTION_SSL_KEYSTORE_PASSWORD_DISPLAY)
-            ;
-        return configDef;
+  public static final String CONNECTION_SSL_TRUSTSTORE_CONFIG = "connection.ssl.truststore";
+  private static final String CONNECTION_SSL_TRUSTSTORE_DOC =
+      "A trust store certificate location to be used for SSL enabled connections";
+  public static final String CONNECTION_SSL_TRUSTSTORE_DEFAULT = EMPTY_STRING;
+  private static final String CONNECTION_SSL_TRUSTSTORE_DISPLAY = "SSL TrustStore";
+
+  public static final String CONNECTION_SSL_TRUSTSTORE_PASSWORD_CONFIG =
+      "connection.ssl.truststorePassword";
+  private static final String CONNECTION_SSL_TRUSTSTORE_PASSWORD_DOC =
+      "A trust store password to be used for SSL enabled connections";
+  public static final String CONNECTION_SSL_TRUSTSTORE_PASSWORD_DEFAULT = EMPTY_STRING;
+  private static final String CONNECTION_SSL_TRUSTSTORE_PASSWORD_DISPLAY =
+      "SSL TrustStore Password";
+
+  public static final String CONNECTION_SSL_KEYSTORE_CONFIG = "connection.ssl.keystore";
+  private static final String CONNECTION_SSL_KEYSTORE_DOC =
+      "A key store certificate location to be used for SSL enabled connections";
+  public static final String CONNECTION_SSL_KEYSTORE_DEFAULT = EMPTY_STRING;
+  private static final String CONNECTION_SSL_KEYSTORE_DISPLAY = "SSL KeyStore";
+
+  public static final String CONNECTION_SSL_KEYSTORE_PASSWORD_CONFIG =
+      "connection.ssl.keystorePassword";
+  private static final String CONNECTION_SSL_KEYSTORE_PASSWORD_DOC =
+      "A key store password to be used for SSL enabled connections";
+  public static final String CONNECTION_SSL_KEYSTORE_PASSWORD_DEFAULT = EMPTY_STRING;
+  private static final String CONNECTION_SSL_KEYSTORE_PASSWORD_DISPLAY = "SSL KeyStore Password";
+
+  public static ConfigDef addSslConfigDef(final ConfigDef configDef) {
+
+    String group = "SSL";
+    int orderInGroup = 0;
+    configDef
+        .define(
+            CONNECTION_SSL_TRUSTSTORE_CONFIG,
+            Type.STRING,
+            CONNECTION_SSL_TRUSTSTORE_DEFAULT,
+            Importance.MEDIUM,
+            CONNECTION_SSL_TRUSTSTORE_DOC,
+            group,
+            ++orderInGroup,
+            Width.LONG,
+            CONNECTION_SSL_TRUSTSTORE_DISPLAY)
+        .define(
+            CONNECTION_SSL_TRUSTSTORE_PASSWORD_CONFIG,
+            Type.PASSWORD,
+            CONNECTION_SSL_TRUSTSTORE_PASSWORD_DEFAULT,
+            Importance.MEDIUM,
+            CONNECTION_SSL_TRUSTSTORE_PASSWORD_DOC,
+            group,
+            ++orderInGroup,
+            Width.MEDIUM,
+            CONNECTION_SSL_TRUSTSTORE_PASSWORD_DISPLAY)
+        .define(
+            CONNECTION_SSL_KEYSTORE_CONFIG,
+            Type.STRING,
+            CONNECTION_SSL_KEYSTORE_DEFAULT,
+            Importance.MEDIUM,
+            CONNECTION_SSL_KEYSTORE_DOC,
+            group,
+            ++orderInGroup,
+            Width.LONG,
+            CONNECTION_SSL_KEYSTORE_DISPLAY)
+        .define(
+            CONNECTION_SSL_KEYSTORE_PASSWORD_CONFIG,
+            Type.PASSWORD,
+            CONNECTION_SSL_KEYSTORE_PASSWORD_DEFAULT,
+            Importance.MEDIUM,
+            CONNECTION_SSL_KEYSTORE_PASSWORD_DOC,
+            group,
+            ++orderInGroup,
+            Width.MEDIUM,
+            CONNECTION_SSL_KEYSTORE_PASSWORD_DISPLAY);
+    return configDef;
+  }
+
+  /**
+   * Set key store and trust store parameters as system properties. This will programmatically
+   * implement the following action in the command line before executing Java process: <br>
+   *
+   * <pre>
+   * # > export KAFKA_OPTS="\
+   *         -Djavax.net.ssl.trustStore=<your path to truststore> \
+   *         -Djavax.net.ssl.trustStorePassword=<your truststore password> \
+   *         -Djavax.net.ssl.keyStore=<your path to keystore> \
+   *         -Djavax.net.ssl.keyStorePassword=<your keystore password>"
+   * </pre>
+   *
+   * If set, default SslContext uses these parameters from Java System properties to establish
+   * SSL-enabled connection.
+   *
+   * @param connectorConfig - Sink our Source Connector properties with key/trust store parameters
+   */
+  public static void setupSsl(AbstractConfig connectorConfig) {
+
+    String val = connectorConfig.getString(SslConfigs.CONNECTION_SSL_TRUSTSTORE_CONFIG);
+    if (val != null && !val.isBlank()) {
+      System.setProperty("javax.net.ssl.trustStore", val);
     }
-    
-    /**
-     * Set key store and trust store parameters as system properties.
-     * This will programmatically implement the following action in the command line before executing Java process: <br>
-     * <pre>
-     * # > export KAFKA_OPTS="\
-     *         -Djavax.net.ssl.trustStore=<your path to truststore> \
-     *         -Djavax.net.ssl.trustStorePassword=<your truststore password> \
-     *         -Djavax.net.ssl.keyStore=<your path to keystore> \
-     *         -Djavax.net.ssl.keyStorePassword=<your keystore password>"
-     * </pre>
-     * 
-     * If set, default SslContext uses these parameters from Java System properties to establish SSL-enabled connection.        
-     * 
-     * @param connectorConfig - Sink our Source Connector properties with key/trust store parameters
-     */
-    public static void setupSsl(AbstractConfig connectorConfig){
-        
-        String val = connectorConfig.getString(SslConfigs.CONNECTION_SSL_TRUSTSTORE_CONFIG);
-        if (val != null && !val.isBlank()) {
-            System.setProperty("javax.net.ssl.trustStore", val);
-        }
-        
-        Password passwordField = connectorConfig.getPassword(SslConfigs.CONNECTION_SSL_TRUSTSTORE_PASSWORD_CONFIG);
-        if (passwordField != null && !(val=passwordField.value()).isBlank()) {
-            System.setProperty("javax.net.ssl.trustStorePassword", val);
-        }
 
-        val = connectorConfig.getString(SslConfigs.CONNECTION_SSL_KEYSTORE_CONFIG);
-        if (val != null && !val.isBlank()) {
-            System.setProperty("javax.net.ssl.keyStore", val);
-        }
-        
-        passwordField = connectorConfig.getPassword(SslConfigs.CONNECTION_SSL_KEYSTORE_PASSWORD_CONFIG);
-        if (passwordField != null && !(val=passwordField.value()).isBlank()) {
-            System.setProperty("javax.net.ssl.keyStorePassword", val);
-        }
+    Password passwordField =
+        connectorConfig.getPassword(SslConfigs.CONNECTION_SSL_TRUSTSTORE_PASSWORD_CONFIG);
+    if (passwordField != null && !(val = passwordField.value()).isBlank()) {
+      System.setProperty("javax.net.ssl.trustStorePassword", val);
     }
+
+    val = connectorConfig.getString(SslConfigs.CONNECTION_SSL_KEYSTORE_CONFIG);
+    if (val != null && !val.isBlank()) {
+      System.setProperty("javax.net.ssl.keyStore", val);
+    }
+
+    passwordField = connectorConfig.getPassword(SslConfigs.CONNECTION_SSL_KEYSTORE_PASSWORD_CONFIG);
+    if (passwordField != null && !(val = passwordField.value()).isBlank()) {
+      System.setProperty("javax.net.ssl.keyStorePassword", val);
+    }
+  }
 }

--- a/src/test/java/com/mongodb/kafka/connect/util/SslConfigsTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/util/SslConfigsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.junit.jupiter.api.Test;
+
+import com.mongodb.kafka.connect.sink.MongoSinkConfig;
+import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
+import com.mongodb.kafka.connect.source.MongoSourceConfig;
+
+class SslConfigsTest {
+
+    private static final String TRUSTSTORE_LOCATION = "truststore.location";
+    private static final String TRUSTSTORE_PASSWORD = "truststore.password";
+    private static final String KEYSTORE_LOCATION = "keystore.location";
+    private static final String KEYSTORE_PASSWORD = "keystore.password";
+    
+    
+    @Test
+    void testSslMongoSourceConfig() {
+        
+        Map<String, String> originals = new HashMap<String, String>();
+        originals.put(SslConfigs.CONNECTION_SSL_TRUSTSTORE_CONFIG, TRUSTSTORE_LOCATION);
+        originals.put(SslConfigs.CONNECTION_SSL_TRUSTSTORE_PASSWORD_CONFIG, TRUSTSTORE_PASSWORD);
+        originals.put(SslConfigs.CONNECTION_SSL_KEYSTORE_CONFIG, KEYSTORE_LOCATION);
+        originals.put(SslConfigs.CONNECTION_SSL_KEYSTORE_PASSWORD_CONFIG, KEYSTORE_PASSWORD);
+        
+        AbstractConfig config = new MongoSourceConfig(originals);
+        
+        testSslConfigs(config);
+    }
+    
+    @Test
+    void testSslMongoSinkConfig() {
+        
+        Map<String, String> originals = new HashMap<String, String>();
+        originals.put(SslConfigs.CONNECTION_SSL_TRUSTSTORE_CONFIG, TRUSTSTORE_LOCATION);
+        originals.put(SslConfigs.CONNECTION_SSL_TRUSTSTORE_PASSWORD_CONFIG, TRUSTSTORE_PASSWORD);
+        originals.put(SslConfigs.CONNECTION_SSL_KEYSTORE_CONFIG, KEYSTORE_LOCATION);
+        originals.put(SslConfigs.CONNECTION_SSL_KEYSTORE_PASSWORD_CONFIG, KEYSTORE_PASSWORD);
+        originals.put(MongoSinkTopicConfig.DATABASE_CONFIG, "database");
+        originals.put(MongoSinkConfig.TOPICS_CONFIG, "topics");
+        
+        AbstractConfig config = new MongoSinkConfig(originals);
+        
+        testSslConfigs(config);
+    }
+
+    void testSslConfigs(AbstractConfig config) {
+        
+        SslConfigs.setupSsl(config);
+        
+        assertEquals(TRUSTSTORE_LOCATION, System.getProperty("javax.net.ssl.trustStore"));
+        assertEquals(TRUSTSTORE_PASSWORD, System.getProperty("javax.net.ssl.trustStorePassword"));
+        assertEquals(KEYSTORE_LOCATION, System.getProperty("javax.net.ssl.keyStore"));
+        assertEquals(KEYSTORE_PASSWORD, System.getProperty("javax.net.ssl.keyStorePassword"));
+    }
+}

--- a/src/test/java/com/mongodb/kafka/connect/util/SslConfigsTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/util/SslConfigsTest.java
@@ -28,49 +28,48 @@ import com.mongodb.kafka.connect.source.MongoSourceConfig;
 
 class SslConfigsTest {
 
-    private static final String TRUSTSTORE_LOCATION = "truststore.location";
-    private static final String TRUSTSTORE_PASSWORD = "truststore.password";
-    private static final String KEYSTORE_LOCATION = "keystore.location";
-    private static final String KEYSTORE_PASSWORD = "keystore.password";
-    
-    
-    @Test
-    void testSslMongoSourceConfig() {
-        
-        Map<String, String> originals = new HashMap<String, String>();
-        originals.put(SslConfigs.CONNECTION_SSL_TRUSTSTORE_CONFIG, TRUSTSTORE_LOCATION);
-        originals.put(SslConfigs.CONNECTION_SSL_TRUSTSTORE_PASSWORD_CONFIG, TRUSTSTORE_PASSWORD);
-        originals.put(SslConfigs.CONNECTION_SSL_KEYSTORE_CONFIG, KEYSTORE_LOCATION);
-        originals.put(SslConfigs.CONNECTION_SSL_KEYSTORE_PASSWORD_CONFIG, KEYSTORE_PASSWORD);
-        
-        AbstractConfig config = new MongoSourceConfig(originals);
-        
-        testSslConfigs(config);
-    }
-    
-    @Test
-    void testSslMongoSinkConfig() {
-        
-        Map<String, String> originals = new HashMap<String, String>();
-        originals.put(SslConfigs.CONNECTION_SSL_TRUSTSTORE_CONFIG, TRUSTSTORE_LOCATION);
-        originals.put(SslConfigs.CONNECTION_SSL_TRUSTSTORE_PASSWORD_CONFIG, TRUSTSTORE_PASSWORD);
-        originals.put(SslConfigs.CONNECTION_SSL_KEYSTORE_CONFIG, KEYSTORE_LOCATION);
-        originals.put(SslConfigs.CONNECTION_SSL_KEYSTORE_PASSWORD_CONFIG, KEYSTORE_PASSWORD);
-        originals.put(MongoSinkTopicConfig.DATABASE_CONFIG, "database");
-        originals.put(MongoSinkConfig.TOPICS_CONFIG, "topics");
-        
-        AbstractConfig config = new MongoSinkConfig(originals);
-        
-        testSslConfigs(config);
-    }
+  private static final String TRUSTSTORE_LOCATION = "truststore.location";
+  private static final String TRUSTSTORE_PASSWORD = "truststore.password";
+  private static final String KEYSTORE_LOCATION = "keystore.location";
+  private static final String KEYSTORE_PASSWORD = "keystore.password";
 
-    void testSslConfigs(AbstractConfig config) {
-        
-        SslConfigs.setupSsl(config);
-        
-        assertEquals(TRUSTSTORE_LOCATION, System.getProperty("javax.net.ssl.trustStore"));
-        assertEquals(TRUSTSTORE_PASSWORD, System.getProperty("javax.net.ssl.trustStorePassword"));
-        assertEquals(KEYSTORE_LOCATION, System.getProperty("javax.net.ssl.keyStore"));
-        assertEquals(KEYSTORE_PASSWORD, System.getProperty("javax.net.ssl.keyStorePassword"));
-    }
+  @Test
+  void testSslMongoSourceConfig() {
+
+    Map<String, String> originals = new HashMap<String, String>();
+    originals.put(SslConfigs.CONNECTION_SSL_TRUSTSTORE_CONFIG, TRUSTSTORE_LOCATION);
+    originals.put(SslConfigs.CONNECTION_SSL_TRUSTSTORE_PASSWORD_CONFIG, TRUSTSTORE_PASSWORD);
+    originals.put(SslConfigs.CONNECTION_SSL_KEYSTORE_CONFIG, KEYSTORE_LOCATION);
+    originals.put(SslConfigs.CONNECTION_SSL_KEYSTORE_PASSWORD_CONFIG, KEYSTORE_PASSWORD);
+
+    AbstractConfig config = new MongoSourceConfig(originals);
+
+    testSslConfigs(config);
+  }
+
+  @Test
+  void testSslMongoSinkConfig() {
+
+    Map<String, String> originals = new HashMap<String, String>();
+    originals.put(SslConfigs.CONNECTION_SSL_TRUSTSTORE_CONFIG, TRUSTSTORE_LOCATION);
+    originals.put(SslConfigs.CONNECTION_SSL_TRUSTSTORE_PASSWORD_CONFIG, TRUSTSTORE_PASSWORD);
+    originals.put(SslConfigs.CONNECTION_SSL_KEYSTORE_CONFIG, KEYSTORE_LOCATION);
+    originals.put(SslConfigs.CONNECTION_SSL_KEYSTORE_PASSWORD_CONFIG, KEYSTORE_PASSWORD);
+    originals.put(MongoSinkTopicConfig.DATABASE_CONFIG, "database");
+    originals.put(MongoSinkConfig.TOPICS_CONFIG, "topics");
+
+    AbstractConfig config = new MongoSinkConfig(originals);
+
+    testSslConfigs(config);
+  }
+
+  void testSslConfigs(final AbstractConfig config) {
+
+    SslConfigs.setupSsl(config);
+
+    assertEquals(TRUSTSTORE_LOCATION, System.getProperty("javax.net.ssl.trustStore"));
+    assertEquals(TRUSTSTORE_PASSWORD, System.getProperty("javax.net.ssl.trustStorePassword"));
+    assertEquals(KEYSTORE_LOCATION, System.getProperty("javax.net.ssl.keyStore"));
+    assertEquals(KEYSTORE_PASSWORD, System.getProperty("javax.net.ssl.keyStorePassword"));
+  }
 }


### PR DESCRIPTION
Adding SSL Support on connector level.

[KAFKA-348](https://jira.mongodb.org/browse/KAFKA-348)

Current state:
In order to support SSL, four ssl parameters should be defined on a system level.
It is described [in documentation](https://www.mongodb.com/docs/kafka-connector/current/security-and-authentication/tls-and-x509/#add-credentials-to-the-connector).

In managed environments, like MSK Connect, this is not possible as a user doesn't have an access to the OS.

New Feature:
I'm introducing four new connector properties:
```properties
connection.ssl.truststore=<your path to truststore>
connection.ssl.truststorePassword=<your truststore password>
connection.ssl.keystore=<your path to keystore>
connection.ssl.keystorePassword=<your keystore password>
```

Note, current implementations fully mimicking suggested approach for setting up default SSLConect using Java System Properties.