### PR TITLE
Kafka 322

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/MongoSinkConnector.java
+++ b/src/main/java/com/mongodb/kafka/connect/MongoSinkConnector.java
@@ -39,6 +39,7 @@ import org.apache.kafka.connect.sink.SinkConnector;
 import com.mongodb.kafka.connect.sink.MongoSinkConfig;
 import com.mongodb.kafka.connect.sink.MongoSinkTask;
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
+import com.mongodb.kafka.connect.util.ConfigHelper;
 
 public class MongoSinkConnector extends SinkConnector {
   private static final List<String> REQUIRED_SINK_ACTIONS = asList("insert", "update", "remove");
@@ -80,14 +81,16 @@ public class MongoSinkConnector extends SinkConnector {
 
   @Override
   public Config validate(final Map<String, String> connectorConfigs) {
-    Config config = super.validate(connectorConfigs);
+    Config rawConfig = super.validate(connectorConfigs);
 
     MongoSinkConfig sinkConfig;
     try {
       sinkConfig = new MongoSinkConfig(connectorConfigs);
     } catch (Exception e) {
-      return config;
+      return rawConfig;
     }
+
+    final Config config = ConfigHelper.evaluateConfigValues(rawConfig, sinkConfig);
 
     validateCanConnect(config, CONNECTION_URI_CONFIG)
         .ifPresent(

--- a/src/main/java/com/mongodb/kafka/connect/MongoSourceConnector.java
+++ b/src/main/java/com/mongodb/kafka/connect/MongoSourceConnector.java
@@ -32,6 +32,7 @@ import org.apache.kafka.connect.source.SourceConnector;
 
 import com.mongodb.kafka.connect.source.MongoSourceConfig;
 import com.mongodb.kafka.connect.source.MongoSourceTask;
+import com.mongodb.kafka.connect.util.ConfigHelper;
 
 public class MongoSourceConnector extends SourceConnector {
   private static final List<String> REQUIRED_SOURCE_ACTIONS = asList("changeStream", "find");
@@ -49,13 +50,15 @@ public class MongoSourceConnector extends SourceConnector {
 
   @Override
   public Config validate(final Map<String, String> connectorConfigs) {
-    Config config = super.validate(connectorConfigs);
+    Config rawConfig = super.validate(connectorConfigs);
     MongoSourceConfig sourceConfig;
     try {
       sourceConfig = new MongoSourceConfig(connectorConfigs);
     } catch (Exception e) {
-      return config;
+      return rawConfig;
     }
+
+    final Config config = ConfigHelper.evaluateConfigValues(rawConfig, sourceConfig);
 
     validateCanConnect(config, MongoSourceConfig.CONNECTION_URI_CONFIG)
         .ifPresent(

--- a/src/main/java/com/mongodb/kafka/connect/util/ConfigHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/ConfigHelper.java
@@ -18,6 +18,7 @@ package com.mongodb.kafka.connect.util;
 import static java.lang.String.format;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
@@ -188,5 +189,20 @@ public final class ConfigHelper {
       return configByName;
     }
     return Optional.empty();
+  }
+
+  public static Config evaluateConfigValues(
+      final Config rawConfig, final AbstractConfig resolvedConfig) {
+    final Map<String, ?> evalValues = resolvedConfig.values();
+    rawConfig
+        .configValues()
+        .forEach(
+            configValue -> {
+              Object ev = evalValues.get(configValue.name());
+              if (ev != null) {
+                configValue.value(ev);
+              }
+            });
+    return rawConfig;
   }
 }


### PR DESCRIPTION
Adding evaluation of config values from the sinkConfig or sourceConfig. this will resolve issues with using config providers in a `connection.uri` attribute in `validate` function of both Sink and Source connectors.
This is to fix: https://jira.mongodb.org/browse/KAFKA-322