### PR TITLE
Enable MongoDB sink with unique fields

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/ChangeStreamHandler.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/ChangeStreamHandler.java
@@ -31,7 +31,9 @@ public class ChangeStreamHandler extends MongoDbHandler {
         {
           put(OperationType.CREATE, new MongoDbInsert());
           put(OperationType.READ, new MongoDbInsert());
-          put(OperationType.UPDATE, new MongoDbUpdate(MongoDbUpdate.EventFormat.ChangeStream));
+          put(
+              OperationType.UPDATE,
+              new MongoDbUpdate(MongoDbUpdate.EventFormat.ChangeStream, false));
           put(OperationType.DELETE, new MongoDbDelete());
         }
       };

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbHandler.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbHandler.java
@@ -44,7 +44,7 @@ public class MongoDbHandler extends DebeziumCdcHandler {
         {
           put(OperationType.CREATE, new MongoDbInsert());
           put(OperationType.READ, new MongoDbInsert());
-          put(OperationType.UPDATE, new MongoDbUpdate(MongoDbUpdate.EventFormat.Oplog));
+          put(OperationType.UPDATE, new MongoDbUpdate(MongoDbUpdate.EventFormat.Oplog, false));
           put(OperationType.DELETE, new MongoDbDelete());
         }
       };

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbUniqueFieldHandler.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbUniqueFieldHandler.java
@@ -1,0 +1,24 @@
+package com.mongodb.kafka.connect.sink.cdc.debezium.mongodb;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
+import com.mongodb.kafka.connect.sink.cdc.CdcOperation;
+import com.mongodb.kafka.connect.sink.cdc.debezium.OperationType;
+
+public class MongoDbUniqueFieldHandler extends MongoDbHandler {
+  private static final Map<OperationType, CdcOperation> DEFAULT_OPERATIONS =
+      new HashMap<OperationType, CdcOperation>() {
+        {
+          put(OperationType.CREATE, new MongoDbInsert());
+          put(OperationType.READ, new MongoDbInsert());
+          put(OperationType.UPDATE, new MongoDbUpdate(MongoDbUpdate.EventFormat.Oplog, true));
+          put(OperationType.DELETE, new MongoDbDelete());
+        }
+      };
+
+  public MongoDbUniqueFieldHandler(final MongoSinkTopicConfig config) {
+    super(config, DEFAULT_OPERATIONS);
+  }
+}

--- a/src/test/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbUniqueFieldHandlerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbUniqueFieldHandlerTest.java
@@ -1,0 +1,205 @@
+package com.mongodb.kafka.connect.sink.cdc.debezium.mongodb;
+
+import static com.mongodb.kafka.connect.sink.SinkTestHelper.createTopicConfig;
+import static java.util.Collections.emptyMap;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.apache.kafka.connect.errors.DataException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonNull;
+import org.bson.BsonString;
+
+import com.mongodb.client.model.DeleteOneModel;
+import com.mongodb.client.model.ReplaceOneModel;
+import com.mongodb.client.model.UpdateOneModel;
+import com.mongodb.client.model.WriteModel;
+
+import com.mongodb.kafka.connect.sink.cdc.debezium.OperationType;
+import com.mongodb.kafka.connect.sink.converter.SinkDocument;
+
+class MongoDbUniqueFieldHandlerTest {
+
+  private static final MongoDbUniqueFieldHandler HANDLER_DEFAULT_MAPPING =
+      new MongoDbUniqueFieldHandler(createTopicConfig());
+
+  @Test
+  @DisplayName("verify existing default config from base class")
+  void testExistingDefaultConfig() {
+    assertAll(
+        () ->
+            assertNotNull(
+                HANDLER_DEFAULT_MAPPING.getConfig(), "default config for handler must not be null"),
+        () ->
+            assertNotNull(
+                new MongoDbHandler(createTopicConfig(), emptyMap()).getConfig(),
+                "default config for handler must not be null"));
+  }
+
+  @Test
+  @DisplayName("when key document missing then DataException")
+  void testMissingKeyDocument() {
+    assertThrows(
+        DataException.class, () -> HANDLER_DEFAULT_MAPPING.handle(new SinkDocument(null, null)));
+  }
+
+  @Test
+  @DisplayName("when key doc contains 'id' field but value is empty then null due to tombstone")
+  void testTombstoneEvent() {
+    assertEquals(
+        Optional.empty(),
+        HANDLER_DEFAULT_MAPPING.handle(
+            new SinkDocument(new BsonDocument("id", new BsonInt32(1234)), new BsonDocument())),
+        "tombstone event must result in Optional.empty()");
+  }
+
+  @Test
+  @DisplayName("when value doc contains unknown operation type then DataException")
+  void testUnknownCdcOperationType() {
+    SinkDocument cdcEvent =
+        new SinkDocument(
+            new BsonDocument("id", new BsonInt32(1234)),
+            new BsonDocument("op", new BsonString("x")));
+    assertThrows(DataException.class, () -> HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
+  }
+
+  @Test
+  @DisplayName("when value doc contains unmapped operation type then DataException")
+  void testUnmappedCdcOperationType() {
+    SinkDocument cdcEvent =
+        new SinkDocument(
+            new BsonDocument("_id", new BsonInt32(1234)),
+            new BsonDocument("op", new BsonString("z"))
+                .append("after", new BsonString("{_id:1234,foo:\"blah\"}")));
+
+    assertThrows(DataException.class, () -> HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
+  }
+
+  @Test
+  @DisplayName("when value doc contains operation type other than string then DataException")
+  void testInvalidCdcOperationType() {
+    SinkDocument cdcEvent =
+        new SinkDocument(
+            new BsonDocument("id", new BsonInt32(1234)),
+            new BsonDocument("op", new BsonInt32('c')));
+
+    assertThrows(DataException.class, () -> HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
+  }
+
+  @Test
+  @DisplayName("when value doc is missing operation type then DataException")
+  void testMissingCdcOperationType() {
+    SinkDocument cdcEvent =
+        new SinkDocument(
+            new BsonDocument("id", new BsonInt32(1234)), new BsonDocument("po", BsonNull.VALUE));
+
+    assertThrows(DataException.class, () -> HANDLER_DEFAULT_MAPPING.handle(cdcEvent));
+  }
+
+  @TestFactory
+  @DisplayName("when valid CDC event then correct WriteModel")
+  Stream<DynamicTest> testValidCdcDocument() {
+
+    return Stream.of(
+        dynamicTest(
+            "test operation " + OperationType.CREATE,
+            () -> {
+              Optional<WriteModel<BsonDocument>> result =
+                  HANDLER_DEFAULT_MAPPING.handle(
+                      new SinkDocument(
+                          new BsonDocument("_id", new BsonString("1234")),
+                          new BsonDocument("op", new BsonString("c"))
+                              .append("after", new BsonString("{_id:1234,foo:\"blah\"}"))));
+              assertTrue(result.isPresent());
+              assertTrue(
+                  result.get() instanceof ReplaceOneModel,
+                  "result expected to be of type ReplaceOneModel");
+            }),
+        dynamicTest(
+            "test operation " + OperationType.READ,
+            () -> {
+              Optional<WriteModel<BsonDocument>> result =
+                  HANDLER_DEFAULT_MAPPING.handle(
+                      new SinkDocument(
+                          new BsonDocument("_id", new BsonString("1234")),
+                          new BsonDocument("op", new BsonString("r"))
+                              .append("after", new BsonString("{_id:1234,foo:\"blah\"}"))));
+              assertTrue(result.isPresent());
+              assertTrue(
+                  result.get() instanceof ReplaceOneModel,
+                  "result expected to be of type ReplaceOneModel");
+            }),
+        dynamicTest(
+            "test operation " + OperationType.UPDATE,
+            () -> {
+              Optional<WriteModel<BsonDocument>> result =
+                  HANDLER_DEFAULT_MAPPING.handle(
+                      new SinkDocument(
+                          new BsonDocument("id", new BsonString("1234")),
+                          new BsonDocument("op", new BsonString("u"))
+                              .append("patch", new BsonString("{\"$set\":{foo:\"blah\"}}"))
+                              .append("filter", new BsonString("{_id:1234,email:\"blah\"}"))));
+              assertTrue(result.isPresent());
+              assertTrue(
+                  result.get() instanceof UpdateOneModel,
+                  "result expected to be of type UpdateOneModel");
+            }),
+        dynamicTest(
+            "test operation " + OperationType.DELETE,
+            () -> {
+              Optional<WriteModel<BsonDocument>> result =
+                  HANDLER_DEFAULT_MAPPING.handle(
+                      new SinkDocument(
+                          new BsonDocument("id", new BsonString("1234")),
+                          new BsonDocument("op", new BsonString("d"))));
+              assertTrue(result.isPresent(), "write model result must be present");
+              assertTrue(
+                  result.get() instanceof DeleteOneModel,
+                  "result expected to be of type DeleteOneModel");
+            }));
+  }
+
+  @TestFactory
+  @DisplayName("when valid cdc operation type then correct MongoDB CdcOperation")
+  Stream<DynamicTest> testValidCdcOpertionTypes() {
+
+    return Stream.of(
+        dynamicTest(
+            "test operation " + OperationType.CREATE,
+            () ->
+                assertTrue(
+                    HANDLER_DEFAULT_MAPPING.getCdcOperation(
+                            new BsonDocument("op", new BsonString("c")))
+                        instanceof MongoDbInsert)),
+        dynamicTest(
+            "test operation " + OperationType.READ,
+            () ->
+                assertTrue(
+                    HANDLER_DEFAULT_MAPPING.getCdcOperation(
+                            new BsonDocument("op", new BsonString("r")))
+                        instanceof MongoDbInsert)),
+        dynamicTest(
+            "test operation " + OperationType.UPDATE,
+            () ->
+                assertTrue(
+                    HANDLER_DEFAULT_MAPPING.getCdcOperation(
+                            new BsonDocument("op", new BsonString("u")))
+                        instanceof MongoDbUpdate)),
+        dynamicTest(
+            "test operation " + OperationType.DELETE,
+            () ->
+                assertTrue(
+                    HANDLER_DEFAULT_MAPPING.getCdcOperation(
+                            new BsonDocument("op", new BsonString("d")))
+                        instanceof MongoDbDelete)));
+  }
+}


### PR DESCRIPTION
## Updates:
- Create a new toggle (`isUseFilterInValueDoc`) in the `MongoDbUpdate` to enable using the `filter` field provided by Debezium.
- Create a new class (`MongoDbUniqueFieldHandler`) to provide default operations with the `isUseFilterInValueDoc` enabled.
- Update `MongoDbHandler` and `ChangeStreamHandler` to adjust default operations with the `isUseFilterInValueDoc` disabled.
- Add some new unit tests.

## Problem Statements
Our use case is to migrate data to **a new MongoDB Sharded cluster**. Our approach is to use CDC (Debezium). When replicating data to the new cluster, we got an error regarding the shard key with the following details.
```
Failed to target upsert by query :: could not extract exact shard key
```
The current situation is that we have unique fields enabled for some collections in our Sharded cluster. We also use the same unique fields in our new Sharded cluster. The error happened because the **MongoDB Sink connector** doesn't provide the unique fields information when upserting data.

## Solution
As you may know, Debezium provides a `filter` field in its payload, as shown below.
```json
{
  "after": null,
  "patch": "{\"$v\": 1,\"$set\": {\"updated_at\": {\"$date\": 1678606630819}}}",
  "filter": "{\"transaction_id\": {\"$numberLong\": \"1234\"},\"_id\": {\"$oid\": \"63a3edd806add30266cb831f\"}}"
}
```
Thus, we want to use the `filter` information as a filter when upserting data to solve our problem.