### PR TITLE
Improve "Could not convert value ..." messages

### DIFF
--- a/src/integrationTest/java/com/mongodb/kafka/connect/sink/MongoSinkTaskIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/sink/MongoSinkTaskIntegrationTest.java
@@ -338,7 +338,10 @@ public class MongoSinkTaskIntegrationTest extends MongoKafkaTestCase {
       task.start(cfg);
 
       DataException e = assertThrows(DataException.class, () -> task.put(sinkRecords));
-      assertTrue(e.getMessage().contains("Could not convert value `a` into a BsonDocument"));
+      assertTrue(
+          e.getMessage()
+              .contains(
+                  "Could not convert value 'a' (class java.lang.String) into a BsonDocument"));
     }
   }
 

--- a/src/integrationTest/java/com/mongodb/kafka/connect/sink/MongoSinkTaskIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/sink/MongoSinkTaskIntegrationTest.java
@@ -340,8 +340,7 @@ public class MongoSinkTaskIntegrationTest extends MongoKafkaTestCase {
       DataException e = assertThrows(DataException.class, () -> task.put(sinkRecords));
       assertTrue(
           e.getMessage()
-              .contains(
-                  "Could not convert value 'a' (class java.lang.String) into a BsonDocument"));
+              .contains("Could not convert value 'a' (java.lang.String) into a BsonDocument"));
     }
   }
 

--- a/src/main/java/com/mongodb/kafka/connect/sink/converter/LazyBsonDocument.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/converter/LazyBsonDocument.java
@@ -199,9 +199,9 @@ public class LazyBsonDocument extends BsonDocument {
     if (v == null) {
       return format("'%s' (null reference)", vToString);
     } else if (vToString.equals(String.valueOf((Object) null))) {
-      return format("'%s' (%s, not a null reference)", vToString, v.getClass());
+      return format("'%s' (%s, not a null reference)", vToString, v.getClass().getName());
     } else {
-      return format("'%s' (%s)", vToString, v.getClass());
+      return format("'%s' (%s)", vToString, v.getClass().getName());
     }
   }
 }


### PR DESCRIPTION
A viewer should not be left guessing whether the value was a null reference, or a `"null"` `CharSequence`.