### PR TITLE
Logging incompatible properties no longer NPEs on null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Changelog
 
+## 1.11.1
+
+### Bug Fixes
+- [KAFKA-390](https://jira.mongodb.org/browse/KAFKA-390) Logging incompatible properties no longer NPEs on null values
+
 ## 1.11.0
 
 ### Improvements

--- a/src/test/java/com/mongodb/kafka/connect/util/config/ConfigSoftValidatorTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/util/config/ConfigSoftValidatorTest.java
@@ -19,6 +19,7 @@ import static com.mongodb.kafka.connect.sink.MongoSinkConfig.TOPIC_OVERRIDE_CONF
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -106,6 +107,27 @@ final class ConfigSoftValidatorTest {
     Set<String> actualMessages = new HashSet<>();
     ConfigSoftValidator.logIncompatibleProperties(incompatibleConfigs, props, actualMessages::add);
     assertEquals(expectedMessages, actualMessages);
+  }
+
+  @Test
+  void logIncompatiblePropertiesWithNullValues() {
+    Set<IncompatiblePropertiesPair> incompatibleConfigs =
+        Stream.of(IncompatiblePropertiesPair.latterIgnored("a", "", "c", null))
+            .collect(Collectors.toSet());
+    Map<String, String> props = new HashMap<>();
+    props.put("a", "valueA");
+    props.put("c", null);
+    props.put(topicOverridePropertyName("t", "c"), "valueC");
+    Set<String> expectedMessages =
+        Stream.of(latterIgnoredMsg("a", topicOverridePropertyName("t", "c"))).collect(toSet());
+    Set<String> actualMessages = new HashSet<>();
+    ConfigSoftValidator.logIncompatibleProperties(incompatibleConfigs, props, actualMessages::add);
+    assertEquals(expectedMessages, actualMessages);
+
+    props.put(topicOverridePropertyName("t", "c"), null);
+    actualMessages = new HashSet<>();
+    ConfigSoftValidator.logIncompatibleProperties(incompatibleConfigs, props, actualMessages::add);
+    assertTrue(actualMessages.isEmpty());
   }
 
   private static String topicOverridePropertyName(


### PR DESCRIPTION
KAFKA-390

----

When performing REST call on `/connector-plugins/com.mongodb.kafka.connect.MongoSinkConnector/config/validate` it appears that some configs can have a `null` value. Use of the stream API caused a NPE, so this change uses `Optional.ofNullable` to work around possible `null` values.