### PR TITLE
Add wildcard support for starts with field name matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ## 1.11.1
 
 ### Bug Fixes
-- [KAFKA-390](https://jira.mongodb.org/browse/KAFKA-390) Logging incompatible properties no longer NPEs on null values
+  - [KAFKA-391](https://jira.mongodb.org/browse/KAFKA-391) Add wildcard support for starts with field name matching
+  - [KAFKA-390](https://jira.mongodb.org/browse/KAFKA-390) Logging incompatible properties no longer NPEs on null values
 
 ## 1.11.0
 

--- a/src/test/java/com/mongodb/kafka/connect/sink/processor/field/projection/FieldProjectorTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/processor/field/projection/FieldProjectorTest.java
@@ -89,6 +89,9 @@ class FieldProjectorTest {
         BsonDocument.parse(
             "{myBoolean: true, myInt: 42, "
                 + "myBytes: {$binary: 'QUJD', $type: '00'}, myArray: []}");
+    BsonDocument keyDocument6 = BsonDocument.parse("{_id: 'ABC-123', myInt: 42, myArray: []}");
+    BsonDocument keyDocument7 =
+        BsonDocument.parse("{myBoolean: true, myBytes: {$binary: 'QUJD', $type: '00'}}");
 
     flatKeyFieldsMapBlockList =
         new HashMap<String, BsonDocument>() {
@@ -96,6 +99,7 @@ class FieldProjectorTest {
             put("", keyDocument1);
             put("*", keyDocument2);
             put("**", keyDocument2);
+            put("myB*", keyDocument6);
             put("_id", keyDocument5);
             put("myBoolean, myInt", keyDocument3);
             put("missing1, unknown2", keyDocument1);
@@ -108,6 +112,7 @@ class FieldProjectorTest {
             put("", keyDocument2);
             put("*", keyDocument1);
             put("**", keyDocument1);
+            put("myB*", keyDocument7);
             put("missing1, unknown2", keyDocument2);
             put("myBoolean, myBytes, myArray", keyDocument4);
           }
@@ -131,6 +136,7 @@ class FieldProjectorTest {
         BsonDocument.parse(
             "{ myLong: {$numberLong: '42'}, myDouble: 23.23, myString: 'BSON', "
                 + "myBytes: {$binary: 'eHl6', $type: '00'}, myArray: []}");
+    BsonDocument valueDocument6 = BsonDocument.parse("{_id: 'XYZ-789'}");
 
     flatValueFieldsMapBlockList =
         new HashMap<String, BsonDocument>() {
@@ -138,6 +144,7 @@ class FieldProjectorTest {
             put("", valueDocument1);
             put("*", valueDocument2);
             put("**", valueDocument2);
+            put("my*", valueDocument6);
             put("_id", valueDocument5);
             put("myLong, myDouble", valueDocument3);
             put("missing1,unknown2", valueDocument1);
@@ -150,6 +157,8 @@ class FieldProjectorTest {
             put("", valueDocument2);
             put("*", valueDocument1);
             put("**", valueDocument1);
+            put("my*", valueDocument5);
+            put("_id", valueDocument6);
             put("missing1,unknown2", valueDocument2);
             put("myDouble, myBytes,myArray", valueDocument4);
           }
@@ -364,7 +373,7 @@ class FieldProjectorTest {
                   entry.getKey()));
       tests.add(
           buildDynamicTestFor(
-              entry, buildSinkDocumentNestedStruct(), new WhitelistKeyProjector(cfg)));
+              entry, buildSinkDocumentNestedStruct(), new AllowListKeyProjector(cfg)));
     }
 
     for (Map.Entry<String, BsonDocument> entry : nestedValueFieldsMapBlockList.entrySet()) {
@@ -378,7 +387,7 @@ class FieldProjectorTest {
                   entry.getKey()));
       tests.add(
           buildDynamicTestFor(
-              entry, buildSinkDocumentNestedStruct(), new BlacklistValueProjector(cfg)));
+              entry, buildSinkDocumentNestedStruct(), new BlockListValueProjector(cfg)));
     }
 
     for (Map.Entry<String, BsonDocument> entry : nestedValueFieldsMapAllowList.entrySet()) {
@@ -392,7 +401,7 @@ class FieldProjectorTest {
                   entry.getKey()));
       tests.add(
           buildDynamicTestFor(
-              entry, buildSinkDocumentNestedStruct(), new WhitelistValueProjector(cfg)));
+              entry, buildSinkDocumentNestedStruct(), new AllowListValueProjector(cfg)));
     }
 
     return tests;


### PR DESCRIPTION
KAFKA-391

----

This sink connector has a post processor that allows for field name matching.
(https://www.mongodb.com/docs/kafka-connector/current/sink-connector/fundamentals/post-processors/#projection-wildcard-pattern-matching-examples)

The documentation states:

> Projection Wildcard Pattern Matching Examples
> This section shows how you can configure the projector post processors to match wildcard patterns to match field names.
> 
> Pattern   Description
>   \*  Matches any number of characters in the current level.
>   **  Matches any characters in the current level and all nested levels.

The issue is while matching against fields with subdocuments would work eg: `wind_speed*.average` would match against: `{wind_speed_10ms: {average: x}}`. Just using `wind_speed*` would not match against: `{wind_speed_10ms: x}`.

Note:

This PR **_only implements_** partial field name matching at the top level where the `*` is at the end of the field name. So `wind*speed_10ms` would not be expected to match any fields.

A separate ticket will handle clarifying the limitations in the documentation.

