### PR TITLE
KAFKA-395

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/DeleteOneDefaultStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/DeleteOneDefaultStrategy.java
@@ -43,6 +43,10 @@ public class DeleteOneDefaultStrategy implements WriteModelStrategy {
     this.idStrategy = idStrategy;
   }
 
+  public IdStrategy getIdStrategy() {
+    return this.idStrategy;
+  } // Temporary method for testing purposes
+
   @Override
   public WriteModel<BsonDocument> createWriteModel(final SinkDocument document) {
 

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
@@ -834,6 +834,27 @@ class MongoSinkConfigTest {
   }
 
   @Test
+  @DisplayName("test Default DELETE_WRITEMODEL_STRATEGY_CONFIG")
+  void testDeletStrategyDefaultConfig() {
+    Map<String, String> map = createConfigMap();
+    map.put(DELETE_ON_NULL_VALUES_CONFIG, "true");
+    map.put(DOCUMENT_ID_STRATEGY_CONFIG, FullKeyStrategy.class.getName());
+    MongoSinkConfig cfg = new MongoSinkConfig(map);
+    /*
+     static final String DELETE_WRITEMODEL_STRATEGY_DEFAULT = "com.mongodb.kafka.connect.sink.writemodel.strategy.DeleteOneDefaultStrategy";
+     DELETE_WRITEMODEL_STRATEGY_CONFIG Default value is DELETE_WRITEMODEL_STRATEGY_DEFAULT
+     It cannot be NULL or "".
+    */
+    DeleteOneDefaultStrategy deleteOneDefaultStrategy =
+        (DeleteOneDefaultStrategy)
+            cfg.getMongoSinkTopicConfig(TEST_TOPIC).getDeleteWriteModelStrategy().get();
+    System.out.println(
+        "deleteOneDefaultStrategy IdStrategy is " + deleteOneDefaultStrategy.getIdStrategy());
+    assert deleteOneDefaultStrategy.getIdStrategy() instanceof FullKeyStrategy
+        : "IdStrategy is FullKeyStrategy";
+  }
+
+  @Test
   @DisplayName("test timeseries validation")
   void testTimeseries() {
     assertAll(

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
@@ -835,16 +835,13 @@ class MongoSinkConfigTest {
 
   @Test
   @DisplayName("test Default DELETE_WRITEMODEL_STRATEGY_CONFIG")
-  void testDeletStrategyDefaultConfig() {
+  void testDeleteStrategyDefaultConfig() {
     Map<String, String> map = createConfigMap();
+
     map.put(DELETE_ON_NULL_VALUES_CONFIG, "true");
     map.put(DOCUMENT_ID_STRATEGY_CONFIG, FullKeyStrategy.class.getName());
     MongoSinkConfig cfg = new MongoSinkConfig(map);
-    /*
-     static final String DELETE_WRITEMODEL_STRATEGY_DEFAULT = "com.mongodb.kafka.connect.sink.writemodel.strategy.DeleteOneDefaultStrategy";
-     DELETE_WRITEMODEL_STRATEGY_CONFIG Default value is DELETE_WRITEMODEL_STRATEGY_DEFAULT
-     It cannot be NULL or "".
-    */
+
     DeleteOneDefaultStrategy deleteOneDefaultStrategy =
         (DeleteOneDefaultStrategy)
             cfg.getMongoSinkTopicConfig(TEST_TOPIC).getDeleteWriteModelStrategy().get();

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
@@ -848,8 +848,7 @@ class MongoSinkConfigTest {
     DeleteOneDefaultStrategy deleteOneDefaultStrategy =
         (DeleteOneDefaultStrategy)
             cfg.getMongoSinkTopicConfig(TEST_TOPIC).getDeleteWriteModelStrategy().get();
-    System.out.println(
-        "deleteOneDefaultStrategy IdStrategy is " + deleteOneDefaultStrategy.getIdStrategy());
+
     assert deleteOneDefaultStrategy.getIdStrategy() instanceof FullKeyStrategy
         : "IdStrategy is FullKeyStrategy";
   }


### PR DESCRIPTION
https://jira.mongodb.org/browse/KAFKA-395

Refactored getDeleteWriteModelStrategy method to correctly handle the case when DELETE_WRITEMODEL_STRATEGY_CONFIG is set to DELETE_WRITEMODEL_STRATEGY_DEFAULT. 
Now, the method returns a new DeleteOneDefaultStrategy instance only if the IdStrategy is an instance of FullKeyStrategy, PartialKeyStrategy, or ProvidedInKeyStrategy. 
This ensures proper behavior for the specified configuration.
