### PR TITLE
Adding DeleteExactKeyStrategy

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/DeleteExactKeyStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/DeleteExactKeyStrategy.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: Apache License, Version 2.0, Copyright 2017 Hans-Peter Grahsl.
+ */
+
+package com.mongodb.kafka.connect.sink.writemodel.strategy;
+
+import org.apache.kafka.connect.errors.DataException;
+
+import org.bson.BsonDocument;
+
+import com.mongodb.client.model.DeleteOneModel;
+import com.mongodb.client.model.WriteModel;
+
+import com.mongodb.kafka.connect.sink.converter.SinkDocument;
+
+public class DeleteExactKeyStrategy implements WriteModelStrategy {
+
+  @Override
+  public WriteModel<BsonDocument> createWriteModel(final SinkDocument document) {
+    BsonDocument kd =
+        document
+            .getKeyDoc()
+            .orElseThrow(
+                () ->
+                    new DataException(
+                        "Could not build the WriteModel,the key document was missing unexpectedly"));
+
+    return new DeleteOneModel<>(kd);
+  }
+}

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
@@ -106,6 +106,7 @@ import com.mongodb.kafka.connect.sink.processor.id.strategy.ProvidedInValueStrat
 import com.mongodb.kafka.connect.sink.processor.id.strategy.UuidStrategy;
 import com.mongodb.kafka.connect.sink.writemodel.strategy.CustomDeleteWriteModelStrategy;
 import com.mongodb.kafka.connect.sink.writemodel.strategy.DefaultWriteModelStrategy;
+import com.mongodb.kafka.connect.sink.writemodel.strategy.DeleteExactKeyStrategy;
 import com.mongodb.kafka.connect.sink.writemodel.strategy.DeleteOneBusinessKeyStrategy;
 import com.mongodb.kafka.connect.sink.writemodel.strategy.DeleteOneDefaultStrategy;
 import com.mongodb.kafka.connect.sink.writemodel.strategy.InsertOneDefaultStrategy;
@@ -712,6 +713,7 @@ class MongoSinkConfigTest {
                 UpdateOneBusinessKeyTimestampStrategy.class.getName(),
                 UpdateOneBusinessKeyTimestampStrategy.class);
             put(DeleteOneBusinessKeyStrategy.class.getName(), DeleteOneBusinessKeyStrategy.class);
+            put(DeleteExactKeyStrategy.class.getName(), DeleteExactKeyStrategy.class);
           }
         };
 
@@ -796,6 +798,7 @@ class MongoSinkConfigTest {
                 UpdateOneBusinessKeyTimestampStrategy.class.getName(),
                 UpdateOneBusinessKeyTimestampStrategy.class);
             put(DeleteOneBusinessKeyStrategy.class.getName(), DeleteOneBusinessKeyStrategy.class);
+            put(DeleteExactKeyStrategy.class.getName(), DeleteExactKeyStrategy.class);
           }
         };
 


### PR DESCRIPTION
Allows for the Mongo filter opreation to be set to the exact key coming from the key doc rather than having a superfluous _id key.

This is needed for a few use cases I can imagine, but the one in particular is when the key doc is inserting into a sharded collection and already has an _id field with another field and the document.id.strategy is set to PartialValueStrategy for inserts/updates. When deleting, I would like to simply directly set the key (as the key already has the required fields) instead of generating an additional _id key that the DeleteOneDefaultStrategy seems to add:

` if (idStrategy instanceof DefaultIdFieldStrategy) {
      deleteFilter = idStrategy.generateId(document, null).asDocument();
    } else {
      deleteFilter = new BsonDocument(ID_FIELD, idStrategy.generateId(document, null));
    }`

Notice if the ID strategy is anything other than the default ID strategy, the DeleteOneDefaultStrategy adds the `ID_FIELD` key.

With this, I can now simply specify the delete.writemodel.strategy as DeleteExactKeyStrategy and it will properly format the filter expression.

I could not find any way to get this behaviour out of the current write strategies.