### PR TITLE
KAFKA-374: Implement an error handler to address specific scenarios.

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
@@ -332,8 +332,8 @@ public class MongoSinkTopicConfig extends AbstractConfig {
 
   public static final String ERRORS_RETRIES_COUNT_DISPLAY = "Error Retries Count";
   public static final String ERRORS_RETRIES_INTERVAL_MS_DISPLAY = "Error Retries Interval(ms)";
-  public static final String ERRORS_RETRIES_COUNT_CONFIG = "mongo.error.retries.count";
-  public static final String ERRORS_RETRIES_INTERVAL_MS_CONFIG = "mongo.error.retries.interval.ms";
+  public static final String ERRORS_RETRIES_COUNT_CONFIG = "mongo.errors.retries.count";
+  public static final String ERRORS_RETRIES_INTERVAL_MS_CONFIG = "mongo.errors.retries.interval.ms";
   public static final String ERRORS_RETRIES_COUNT_CONFIG_DOC =
       "Use this property if you would like to make the connector retry up to the number specified. "
           + "This configuration will work only when errors.tolerance is specified as data.";

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
@@ -336,10 +336,12 @@ public class MongoSinkTopicConfig extends AbstractConfig {
   public static final String ERRORS_RETRIES_INTERVAL_MS_CONFIG = "mongo.errors.retries.interval.ms";
   public static final String ERRORS_RETRIES_COUNT_CONFIG_DOC =
       "Use this property if you would like to make the connector retry up to the number specified. "
-          + "This configuration will work only when errors.tolerance is specified as data.";
+          + "This configuration will work only when mongo.errors.tolerance is specified as data.";
   public static final String ERRORS_RETRIES_INTERVAL_MS_CONFIG_DOC =
       "Use this property if you would like to make the connector retry after interval seconds. "
-          + "This configuration will work only when errors.tolerance is specified as data.";
+          + "This configuration will work only when mongo.errors.tolerance is specified as data.";
+  public static final int ERRORS_RETRIES_COUNT_DEFAULT = 3;
+  public static final long ERRORS_RETRIES_INTERVAL_MS_DEFAULT = 1000; // 10 seconds
 
   public static final String ERRORS_LOG_ENABLE_CONFIG = "errors.log.enable";
   public static final String ERRORS_LOG_ENABLE_DISPLAY = "Log Errors";
@@ -1105,7 +1107,7 @@ public class MongoSinkTopicConfig extends AbstractConfig {
     configDef.define(
         ERRORS_RETRIES_COUNT_CONFIG,
         ConfigDef.Type.INT,
-        3,
+        ERRORS_RETRIES_COUNT_DEFAULT,
         ConfigDef.Range.atLeast(0),
         Importance.MEDIUM,
         ERRORS_RETRIES_COUNT_CONFIG_DOC,
@@ -1116,7 +1118,7 @@ public class MongoSinkTopicConfig extends AbstractConfig {
     configDef.define(
         ERRORS_RETRIES_INTERVAL_MS_CONFIG,
         ConfigDef.Type.LONG,
-        10000, /* 10 seconds */
+        ERRORS_RETRIES_INTERVAL_MS_DEFAULT,
         ConfigDef.Range.atLeast(0),
         Importance.MEDIUM,
         ERRORS_RETRIES_INTERVAL_MS_CONFIG_DOC,


### PR DESCRIPTION
Kafka connector currently supports two error modes. (This is controlled by "errors.tolerance" config parameter.). When this error mode is "all" and the sink is mongodb, the connector would dlq any errors and move on.  When the error mode ls set to "none", the connector would throw an exception causing the connector to stop.

This PR adds an additional tolerance mode for mongo sink.
when `mongo.errors.tolerance` is set to data, the connector will take into account the following additional configuration values.  

`mongo.errors.retries.count`
`mongo.errors.retries.interval.ms`

In this new mode, the connector would retry for any retryable errors the specified number of times each time waiting for specified interval time. (An error is retryable if we are sure that we have not written the data to the database.)  For data errors like duplicate key, the connector would write to dlq and move on to process further data.  We would also treat errors that we detect after we issue a bulk write call as data errors.   