### PR TITLE
KAFKA-374: Implement an error handler to address transient database errors.

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordData.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordData.java
@@ -108,7 +108,7 @@ final class MongoProcessedSinkRecordData {
       if (config.logErrors()) {
         LOGGER.error("Unable to process record {}", sinkRecord, e);
       }
-      if (!config.tolerateErrors()) {
+      if (!(config.tolerateErrors() || config.tolerateDataErrors())) {
         throw e;
       }
     }

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
@@ -79,6 +79,7 @@ public class MongoSinkTopicConfig extends AbstractConfig {
 
   public enum ErrorTolerance {
     NONE,
+    DATA,
     ALL;
 
     public String value() {
@@ -323,7 +324,8 @@ public class MongoSinkTopicConfig extends AbstractConfig {
   public static final String ERRORS_TOLERANCE_DOC =
       "Behavior for tolerating errors during connector operation. 'none' is the default value "
           + "and signals that any error will result in an immediate connector task failure; 'all' "
-          + "changes the behavior to skip over problematic records.";
+          + "changes the behavior to skip over problematic records,"
+          + "'data' will try for network/server unreachable errors.";
 
   public static final String OVERRIDE_ERRORS_TOLERANCE_CONFIG = "mongo.errors.tolerance";
   public static final String OVERRIDE_ERRORS_TOLERANCE_DOC =
@@ -465,7 +467,7 @@ public class MongoSinkTopicConfig extends AbstractConfig {
   }
 
   boolean logErrors() {
-    return !tolerateErrors()
+    return !(tolerateErrors() || tolerateDataErrors())
         || ConfigHelper.getOverrideOrFallback(
             this,
             AbstractConfig::getBoolean,
@@ -481,6 +483,16 @@ public class MongoSinkTopicConfig extends AbstractConfig {
             OVERRIDE_ERRORS_TOLERANCE_CONFIG,
             ERRORS_TOLERANCE_CONFIG);
     return ErrorTolerance.valueOf(errorsTolerance.toUpperCase()).equals(ErrorTolerance.ALL);
+  }
+
+  boolean tolerateDataErrors() {
+    String errorsTolerance =
+        ConfigHelper.getOverrideOrFallback(
+            this,
+            AbstractConfig::getString,
+            OVERRIDE_ERRORS_TOLERANCE_CONFIG,
+            ERRORS_TOLERANCE_CONFIG);
+    return ErrorTolerance.valueOf(errorsTolerance.toUpperCase()).equals(ErrorTolerance.DATA);
   }
 
   public boolean isTimeseries() {

--- a/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.errors.DataException;
-import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import org.bson.BsonDocument;
@@ -110,9 +109,6 @@ final class StartedMongoSinkTask implements AutoCloseable {
       if (records.isEmpty()) {
         LOGGER.debug("No sink records to process for current poll operation");
       } else {
-        if (!mongoClient.getClusterDescription().hasWritableServer()) {
-          throw new RetriableException("database is not writable");
-        }
         Timer processingTime = Timer.start();
         List<List<MongoProcessedSinkRecordData>> batches =
             MongoSinkRecordProcessor.orderedGroupByTopicAndNamespace(
@@ -170,6 +166,9 @@ final class StartedMongoSinkTask implements AutoCloseable {
     } catch (RuntimeException e) {
       statistics.getBatchWritesFailed().sample(writeTime.getElapsedTime().toMillis());
       statistics.getRecordsFailed().sample(batch.size());
+      if (config.tolerateDataErrors() && !(e instanceof MongoBulkWriteException)) {
+        throw new DataException("non Data Error, fail the connector.", e);
+      }
       handleTolerableWriteException(
           batch.stream()
               .map(MongoProcessedSinkRecordData::getSinkRecord)
@@ -177,7 +176,7 @@ final class StartedMongoSinkTask implements AutoCloseable {
           bulkWriteOrdered,
           e,
           config.logErrors(),
-          config.tolerateErrors());
+          config.tolerateErrors() || config.tolerateDataErrors());
     }
     checkRateLimit(config);
   }


### PR DESCRIPTION
1. This error handler creates a new mode for mongo.error.tolerance=data. 
2. When a sink connector sees this error mode, any write failures other MongoBulkWriteException will cause the connector to fail.  
3. DLQ records will not be written for the batch that failed due to these exceptions.  The assumption is that these records can be retried in subsequent restart of the connector.
