### PR TITLE
KAFKA-404: Support for extending MongoClient to allow for users to add custom auth such as AWS IAM / Assume Role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,16 @@
 
 ## Changelog
 
-## 1.12.1
+## 1.13.0
 
 ### Improvements
 - [KAFKA-404](https://jira.mongodb.org/browse/KAFKA-404) Support for extending MongoClient to allow for users to add custom auth such as AWS IAM / Assume Role.
 
 ## 1.12.0
 
-### Improvements 
+### Improvements
 - [KAFKA-374](https://jira.mongodb.org/browse/KAFKA-374) Implement an error handler to address specific scenarios.
-  
+
 
 ## 1.11.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Changelog
 
+## 1.12.1
+
+### Improvements
+- [KAFKA-404](https://jira.mongodb.org/browse/KAFKA-404) Support for extending MongoClient to allow for users to add custom auth such as AWS IAM / Assume Role.
+
+## 1.12.0
+
+### Improvements 
+- [KAFKA-374](https://jira.mongodb.org/browse/KAFKA-374) Implement an error handler to address specific scenarios.
+  
+
 ## 1.11.2
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -99,3 +99,116 @@ When using MONGODB-AWS authentication mechanism for atlas, one can specify the f
 "mongodbaws.auth.mechanism.roleArn": "arn:aws:iam::<ACCOUNTID>:role/<ROLENAME>"
 ```
 Here the `sample.AwsAssumeRoleCredentialProvider` must be available on the classpath. `mongodbaws.auth.mechanism.roleArn` is an example of custom properties that can be read by `sample.AwsAssumeRoleCredentialProvider`.
+
+### How to build sample.jar
+Here is sample code that can work.
+
+```java
+public class AwsAssumeRoleCredentialProvider implements CustomCredentialProvider {
+
+  public AwsAssumeRoleCredentialProvider() {}
+  @Override
+  public MongoCredential getCustomCredential(Map<?, ?> map) {
+    AWSCredentialsProvider provider = new DefaultAWSCredentialsProviderChain();
+    Supplier<AwsCredential> awsFreshCredentialSupplier = () -> {
+      AWSSecurityTokenService stsClient = AWSSecurityTokenServiceAsyncClientBuilder.standard()
+          .withCredentials(provider)
+          .withRegion("us-east-1")
+          .build();
+      AssumeRoleRequest assumeRoleRequest = new AssumeRoleRequest().withDurationSeconds(3600)
+          .withRoleArn((String)map.get("mongodbaws.auth.mechanism.roleArn"))
+          .withRoleSessionName("Test_Session");
+      AssumeRoleResult assumeRoleResult = stsClient.assumeRole(assumeRoleRequest);
+      Credentials creds = assumeRoleResult.getCredentials();
+      // Add your code to fetch new credentials
+      return new AwsCredential(creds.getAccessKeyId(), creds.getSecretAccessKey(), creds.getSessionToken());
+    };
+    return MongoCredential.createAwsCredential(null, null)
+        .withMechanismProperty(MongoCredential.AWS_CREDENTIAL_PROVIDER_KEY, awsFreshCredentialSupplier);
+  }
+
+  @Override
+  public void validate(Map<?, ?> map) {
+    String roleArn = (String) map.get("mongodbaws.auth.mechanism.roleArn");
+    if (StringUtils.isNullOrEmpty(roleArn)) {
+      throw new RuntimeException("Invalid value set for customProperty");
+    }
+  }
+
+  @Override
+  public void init(Map<?, ?> map) {
+
+  }
+}
+```
+Here is the pom.xml that can build the complete jar containing the AwsAssumeRoleCredentialProvider
+
+```java
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>sample</groupId>
+    <artifactId>AwsAssumeRoleCredentialProvider</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.3</version>
+                <configuration>
+                    <!-- put your configurations here -->
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- Java MongoDB Driver dependency -->
+        <!-- https://mvnrepository.com/artifact/org.mongodb/mongodb-driver-sync -->
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <version>5.1.0</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk</artifactId>
+            <version>1.12.723</version>
+        </dependency>
+
+        <!-- slf4j logging dependency, required for logging output from the MongoDB Java Driver -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>1.7.28</version>
+        </dependency>
+
+        <dependency>
+            <groupId>kafka-connect</groupId>
+            <artifactId>kafka-connect</artifactId>
+            <scope>system</scope>
+            <version>1.12.1-SNAPSHOT</version>
+            <systemPath>/Users/jagadish.nallapaneni/mongo-kafka/build/libs/mongo-kafka-connect-1.12.1-SNAPSHOT-confluent.jar</systemPath>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+</project>
+```

--- a/README.md
+++ b/README.md
@@ -76,3 +76,26 @@ A couple of manual configuration steps are required to run the code in IntelliJ:
       - Run the `compileBuildConfig` task: eg: `./gradlew compileBuildConfig` or via Gradle > mongo-kafka > Tasks > other > compileBuildConfig
       - Set `compileBuildConfig` to execute Before Build. via Gradle > Tasks > other > right click compileBuildConfig - click on "Execute Before Build"
       - Delegate all build actions to Gradle: Settings > Build, Execution, Deployment > Build Tools > Gradle > Runner - tick "Delegate IDE build/run actions to gradle"
+
+## Custom Auth Provider Interface
+
+The `com.mongodb.kafka.connect.util.custom.credentials.CustomCredentialProvider` interface can be implemented to provide an object of type `com.mongodb.MongoCredential` which gets wrapped in the MongoClient that is constructed for the sink and source connector.
+The following properties need to be set -
+
+```
+mongo.custom.auth.mechanism.enable - set to true.
+mongo.custom.auth.mechanism.providerClass - qualified class name of the implementation class
+```
+Additional properties and can be set as required within the implementation class.
+The init and validate methods of the implementation class get called when the connector initializes.
+
+### Example
+When using MONGODB-AWS authentication mechanism for atlas, one can specify the following configuration -
+
+```
+"connection.uri": "mongodb+srv://<sever>/?authMechanism=MONGODB-AWS"
+"mongo.custom.auth.mechanism.enable": true,
+"mongo.custom.auth.mechanism.providerClass": "sample.AwsAssumeRoleCredentialProvider"
+"mongodbaws.auth.mechanism.roleArn": "arn:aws:iam::<ACCOUNTID>:role/<ROLENAME>"
+```
+Here the `sample.AwsAssumeRoleCredentialProvider` must be available on the classpath. `mongodbaws.auth.mechanism.roleArn` is an example of custom properties that can be read by `sample.AwsAssumeRoleCredentialProvider`.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ When using MONGODB-AWS authentication mechanism for atlas, one can specify the f
 ```
 Here the `sample.AwsAssumeRoleCredentialProvider` must be available on the classpath. `mongodbaws.auth.mechanism.roleArn` is an example of custom properties that can be read by `sample.AwsAssumeRoleCredentialProvider`.
 
-### How to build sample.jar
+### Sample code for implementing Custom role provider
 Here is sample code that can work.
 
 ```java
@@ -141,6 +141,7 @@ public class AwsAssumeRoleCredentialProvider implements CustomCredentialProvider
   }
 }
 ```
+### pom file to build the sample CustomRoleProvider into a jar
 Here is the pom.xml that can build the complete jar containing the AwsAssumeRoleCredentialProvider
 
 ```java

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ repositories {
 }
 
 extra.apply {
-    set("mongodbDriverVersion", "4.9.1")
+    set("mongodbDriverVersion", "[4.7,4.7.99]")
     set("kafkaVersion", "2.6.0")
     set("avroVersion", "1.9.2")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ repositories {
 }
 
 extra.apply {
-    set("mongodbDriverVersion", "[4.7,4.7.99)")
+    set("mongodbDriverVersion", "4.9.1")
     set("kafkaVersion", "2.6.0")
     set("avroVersion", "1.9.2")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ plugins {
 }
 
 group = "org.mongodb.kafka"
-version = "1.12.1-SNAPSHOT"
+version = "1.13.0"
 description = "The official MongoDB Apache Kafka Connect Connector."
 
 repositories {

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
@@ -25,6 +25,8 @@ import static com.mongodb.kafka.connect.sink.SinkConfigSoftValidator.logObsolete
 import static com.mongodb.kafka.connect.util.ServerApiConfig.addServerApiConfig;
 import static com.mongodb.kafka.connect.util.SslConfigs.addSslConfigDef;
 import static com.mongodb.kafka.connect.util.Validators.errorCheckingPasswordValueValidator;
+import static com.mongodb.kafka.connect.util.custom.credentials.CustomCredentialProviderConstants.*;
+import static com.mongodb.kafka.connect.util.custom.credentials.CustomCredentialProviderGenericInitializer.initializeCustomProvider;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -50,6 +52,7 @@ import com.mongodb.ConnectionString;
 
 import com.mongodb.kafka.connect.MongoSinkConnector;
 import com.mongodb.kafka.connect.util.Validators;
+import com.mongodb.kafka.connect.util.custom.credentials.CustomCredentialProvider;
 
 public class MongoSinkConfig extends AbstractConfig {
   private static final String EMPTY_STRING = "";
@@ -100,6 +103,7 @@ public class MongoSinkConfig extends AbstractConfig {
   private final Optional<Pattern> topicsRegex;
   private Map<String, MongoSinkTopicConfig> topicSinkConnectorConfigMap;
   private ConnectionString connectionString;
+  private CustomCredentialProvider customCredentialProvider;
 
   public MongoSinkConfig(final Map<String, String> originals) {
     super(CONFIG, originals, false);
@@ -146,6 +150,10 @@ public class MongoSinkConfig extends AbstractConfig {
                 }
               });
     }
+    // Initialize CustomCredentialProvider if mongo.custom.auth.mechanism.enable is set to true
+    if (Boolean.parseBoolean(originals.get(CUSTOM_AUTH_ENABLE_CONFIG))) {
+      customCredentialProvider = initializeCustomProvider(originals);
+    }
   }
 
   public static final ConfigDef CONFIG = createConfigDef();
@@ -155,6 +163,10 @@ public class MongoSinkConfig extends AbstractConfig {
       throw new ConfigException("Unknown configuration key: " + config);
     }
     return format(TOPIC_OVERRIDE_CONFIG, topic, config);
+  }
+
+  public CustomCredentialProvider getCustomCredentialProvider() {
+    return customCredentialProvider;
   }
 
   public ConnectionString getConnectionString() {

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
@@ -25,7 +25,7 @@ import static com.mongodb.kafka.connect.sink.SinkConfigSoftValidator.logObsolete
 import static com.mongodb.kafka.connect.util.ServerApiConfig.addServerApiConfig;
 import static com.mongodb.kafka.connect.util.SslConfigs.addSslConfigDef;
 import static com.mongodb.kafka.connect.util.Validators.errorCheckingPasswordValueValidator;
-import static com.mongodb.kafka.connect.util.custom.credentials.CustomCredentialProviderConstants.*;
+import static com.mongodb.kafka.connect.util.custom.credentials.CustomCredentialProviderConstants.CUSTOM_AUTH_ENABLE_CONFIG;
 import static com.mongodb.kafka.connect.util.custom.credentials.CustomCredentialProviderGenericInitializer.initializeCustomProvider;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTask.java
@@ -155,6 +155,10 @@ public class MongoSinkTask extends SinkTask {
         MongoClientSettings.builder()
             .applyConnectionString(sinkConfig.getConnectionString())
             .applyToSslSettings(sslBuilder -> setupSsl(sslBuilder, sinkConfig));
+    if (sinkConfig.getCustomCredentialProvider() != null) {
+      builder.credential(
+          sinkConfig.getCustomCredentialProvider().getCustomCredential(sinkConfig.getOriginals()));
+    }
     setServerApi(builder, sinkConfig);
 
     return MongoClients.create(

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -35,6 +35,8 @@ import static com.mongodb.kafka.connect.util.Validators.emptyString;
 import static com.mongodb.kafka.connect.util.Validators.errorCheckingPasswordValueValidator;
 import static com.mongodb.kafka.connect.util.Validators.errorCheckingValueValidator;
 import static com.mongodb.kafka.connect.util.VisibleForTesting.AccessModifier.PACKAGE;
+import static com.mongodb.kafka.connect.util.custom.credentials.CustomCredentialProviderConstants.CUSTOM_AUTH_ENABLE_CONFIG;
+import static com.mongodb.kafka.connect.util.custom.credentials.CustomCredentialProviderGenericInitializer.initializeCustomProvider;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -78,6 +80,7 @@ import com.mongodb.kafka.connect.util.ConnectConfigException;
 import com.mongodb.kafka.connect.util.Validators;
 import com.mongodb.kafka.connect.util.VisibleForTesting;
 import com.mongodb.kafka.connect.util.config.BsonTimestampParser;
+import com.mongodb.kafka.connect.util.custom.credentials.CustomCredentialProvider;
 
 public class MongoSourceConfig extends AbstractConfig {
 
@@ -583,6 +586,11 @@ public class MongoSourceConfig extends AbstractConfig {
           + "connection details will be used.";
 
   static final String PROVIDER_CONFIG = "provider";
+  private CustomCredentialProvider customCredentialProvider;
+
+  public CustomCredentialProvider getCustomCredentialProvider() {
+    return customCredentialProvider;
+  }
 
   public static final ConfigDef CONFIG = createConfigDef();
   private static final List<Consumer<MongoSourceConfig>> INITIALIZERS =
@@ -745,6 +753,9 @@ public class MongoSourceConfig extends AbstractConfig {
 
   public MongoSourceConfig(final Map<?, ?> originals) {
     this(originals, true);
+    if (Boolean.parseBoolean((String) originals.get(CUSTOM_AUTH_ENABLE_CONFIG))) {
+      customCredentialProvider = initializeCustomProvider(originals);
+    }
   }
 
   private MongoSourceConfig(final Map<?, ?> originals, final boolean validateAll) {

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -133,6 +133,14 @@ public final class MongoSourceTask extends SourceTask {
               .applyConnectionString(sourceConfig.getConnectionString())
               .addCommandListener(statisticsCommandListener)
               .applyToSslSettings(sslBuilder -> setupSsl(sslBuilder, sourceConfig));
+
+      if (sourceConfig.getCustomCredentialProvider() != null) {
+        builder.credential(
+            sourceConfig
+                .getCustomCredentialProvider()
+                .getCustomCredential(sourceConfig.originals()));
+      }
+
       setServerApi(builder, sourceConfig);
 
       mongoClient =

--- a/src/main/java/com/mongodb/kafka/connect/util/custom/credentials/CustomCredentialProvider.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/custom/credentials/CustomCredentialProvider.java
@@ -1,0 +1,13 @@
+package com.mongodb.kafka.connect.util.custom.credentials;
+
+import java.util.Map;
+
+import com.mongodb.MongoCredential;
+
+public interface CustomCredentialProvider {
+  MongoCredential getCustomCredential(Map<?, ?> configs);
+
+  void validate(Map<?, ?> configs);
+
+  void init(Map<?, ?> configs);
+}

--- a/src/main/java/com/mongodb/kafka/connect/util/custom/credentials/CustomCredentialProvider.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/custom/credentials/CustomCredentialProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mongodb.kafka.connect.util.custom.credentials;
 
 import java.util.Map;

--- a/src/main/java/com/mongodb/kafka/connect/util/custom/credentials/CustomCredentialProviderConstants.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/custom/credentials/CustomCredentialProviderConstants.java
@@ -1,0 +1,10 @@
+package com.mongodb.kafka.connect.util.custom.credentials;
+
+public final class CustomCredentialProviderConstants {
+  private CustomCredentialProviderConstants() {}
+
+  public static final String CUSTOM_AUTH_ENABLE_CONFIG = "mongo.custom.auth.mechanism.enable";
+
+  public static final String CUSTOM_AUTH_PROVIDER_CLASS =
+      "mongo.custom.auth.mechanism.providerClass";
+}

--- a/src/main/java/com/mongodb/kafka/connect/util/custom/credentials/CustomCredentialProviderConstants.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/custom/credentials/CustomCredentialProviderConstants.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mongodb.kafka.connect.util.custom.credentials;
 
 public final class CustomCredentialProviderConstants {

--- a/src/main/java/com/mongodb/kafka/connect/util/custom/credentials/CustomCredentialProviderGenericInitializer.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/custom/credentials/CustomCredentialProviderGenericInitializer.java
@@ -1,0 +1,76 @@
+package com.mongodb.kafka.connect.util.custom.credentials;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CustomCredentialProviderGenericInitializer {
+
+  static final Logger LOGGER =
+      LoggerFactory.getLogger(CustomCredentialProviderGenericInitializer.class);
+
+  public static CustomCredentialProvider initializeCustomProvider(Map<?, ?> originals)
+      throws ConfigException {
+    // Validate if CUSTOM_AUTH_ENABLE_CONFIG is set to true
+    String customAuthMechanismEnabled =
+        String.valueOf(originals.get(CustomCredentialProviderConstants.CUSTOM_AUTH_ENABLE_CONFIG));
+    if (customAuthMechanismEnabled == null
+        || customAuthMechanismEnabled.equals("null")
+        || customAuthMechanismEnabled.isEmpty()) {
+      throw new ConfigException(
+          CustomCredentialProviderConstants.CUSTOM_AUTH_ENABLE_CONFIG
+              + " is not set to true. "
+              + "CustomCredentialProvider should not be used.");
+    }
+    // Validate if CUSTOM_AUTH_PROVIDER_CLASS is provided
+    String qualifiedAuthProviderClassName =
+        String.valueOf(originals.get(CustomCredentialProviderConstants.CUSTOM_AUTH_PROVIDER_CLASS));
+    if (qualifiedAuthProviderClassName == null
+        || qualifiedAuthProviderClassName.equals("null")
+        || qualifiedAuthProviderClassName.isEmpty()) {
+      throw new ConfigException(
+          CustomCredentialProviderConstants.CUSTOM_AUTH_PROVIDER_CLASS
+              + " is required when "
+              + CustomCredentialProviderConstants.CUSTOM_AUTH_ENABLE_CONFIG
+              + " is set to true.");
+    }
+    try {
+      // Validate if qualifiedAuthProviderClassName is on the class path.
+      Class<?> authProviderClass =
+          Class.forName(
+              qualifiedAuthProviderClassName,
+              false,
+              CustomCredentialProviderGenericInitializer.class.getClassLoader());
+      // Validate if qualifiedAuthProviderClassName implements CustomCredentialProvider interface.
+      if (!CustomCredentialProvider.class.isAssignableFrom(authProviderClass)) {
+        throw new ConfigException(
+            "Provided Class does not implement CustomCredentialProvider interface.");
+      }
+      CustomCredentialProvider customCredentialProvider =
+          initializeCustomProvider(authProviderClass);
+      // Perform config validations specific to CustomCredentialProvider impl provided
+      customCredentialProvider.validate(originals);
+      // Initialize custom variables required by implementation of CustomCredentialProvider
+      customCredentialProvider.init(originals);
+      return customCredentialProvider;
+    } catch (ClassNotFoundException e) {
+      throw new ConfigException(
+          "Unable to find " + qualifiedAuthProviderClassName + " on the classpath.");
+    }
+  }
+
+  private static CustomCredentialProvider initializeCustomProvider(Class<?> authProviderClass) {
+    try {
+      return (CustomCredentialProvider) authProviderClass.getDeclaredConstructor().newInstance();
+    } catch (InstantiationException
+        | IllegalAccessException
+        | InvocationTargetException
+        | NoSuchMethodException e) {
+      LOGGER.error("Error while instantiating " + authProviderClass + " class");
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/com/mongodb/kafka/connect/util/custom/credentials/CustomCredentialProviderGenericInitializer.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/custom/credentials/CustomCredentialProviderGenericInitializer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mongodb.kafka.connect.util.custom.credentials;
 
 import java.lang.reflect.InvocationTargetException;
@@ -7,12 +22,12 @@ import org.apache.kafka.common.config.ConfigException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CustomCredentialProviderGenericInitializer {
+public final class CustomCredentialProviderGenericInitializer {
 
   static final Logger LOGGER =
       LoggerFactory.getLogger(CustomCredentialProviderGenericInitializer.class);
 
-  public static CustomCredentialProvider initializeCustomProvider(Map<?, ?> originals)
+  public static CustomCredentialProvider initializeCustomProvider(final Map<?, ?> originals)
       throws ConfigException {
     // Validate if CUSTOM_AUTH_ENABLE_CONFIG is set to true
     String customAuthMechanismEnabled =
@@ -62,7 +77,8 @@ public class CustomCredentialProviderGenericInitializer {
     }
   }
 
-  private static CustomCredentialProvider initializeCustomProvider(Class<?> authProviderClass) {
+  private static CustomCredentialProvider initializeCustomProvider(
+      final Class<?> authProviderClass) {
     try {
       return (CustomCredentialProvider) authProviderClass.getDeclaredConstructor().newInstance();
     } catch (InstantiationException
@@ -73,4 +89,6 @@ public class CustomCredentialProviderGenericInitializer {
       throw new RuntimeException(e);
     }
   }
+
+  private CustomCredentialProviderGenericInitializer() {}
 }

--- a/src/test/java/com/mongodb/kafka/connect/util/custom/credentials/CustomCredentialProviderGenericInitializerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/util/custom/credentials/CustomCredentialProviderGenericInitializerTest.java
@@ -1,0 +1,113 @@
+package com.mongodb.kafka.connect.util.custom.credentials;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class CustomCredentialProviderGenericInitializerTest {
+
+  @Test
+  @DisplayName("Test Exception scenarios")
+  void testExceptions() {
+    Map<String, Object> props = new HashMap<>();
+    ConfigException configException =
+        assertThrows(
+            ConfigException.class,
+            () -> CustomCredentialProviderGenericInitializer.initializeCustomProvider(props),
+            "Expected initializeCustomProvider() to throw, but it didn't");
+    assertEquals(
+        CustomCredentialProviderConstants.CUSTOM_AUTH_ENABLE_CONFIG
+            + " is not set to true. "
+            + "CustomCredentialProvider should not be used.",
+        configException.getMessage());
+    props.put(CustomCredentialProviderConstants.CUSTOM_AUTH_ENABLE_CONFIG, true);
+    configException =
+        assertThrows(
+            ConfigException.class,
+            () -> CustomCredentialProviderGenericInitializer.initializeCustomProvider(props),
+            "Expected initializeCustomProvider() to throw, but it didn't");
+    assertEquals(
+        CustomCredentialProviderConstants.CUSTOM_AUTH_PROVIDER_CLASS
+            + " is required when "
+            + CustomCredentialProviderConstants.CUSTOM_AUTH_ENABLE_CONFIG
+            + " is set to true.",
+        configException.getMessage());
+    String qualifiedAuthProviderClassName = "com.nonexistant.package.Test";
+    props.put(
+        CustomCredentialProviderConstants.CUSTOM_AUTH_PROVIDER_CLASS,
+        qualifiedAuthProviderClassName);
+    configException =
+        assertThrows(
+            ConfigException.class,
+            () -> CustomCredentialProviderGenericInitializer.initializeCustomProvider(props),
+            "Expected initializeCustomProvider() to throw, but it didn't");
+    assertEquals(
+        "Unable to find " + qualifiedAuthProviderClassName + " on the classpath.",
+        configException.getMessage());
+    qualifiedAuthProviderClassName =
+        "com.mongodb.kafka.connect.util.custom.credentials.TestInvalidCustomCredentialProvider";
+    props.put(
+        CustomCredentialProviderConstants.CUSTOM_AUTH_PROVIDER_CLASS,
+        qualifiedAuthProviderClassName);
+    configException =
+        assertThrows(
+            ConfigException.class,
+            () -> CustomCredentialProviderGenericInitializer.initializeCustomProvider(props),
+            "Expected initializeCustomProvider() to throw, but it didn't");
+    assertEquals(
+        "Provided Class does not implement CustomCredentialProvider interface.",
+        configException.getMessage());
+  }
+
+  @Test
+  @DisplayName("Test CustomCredentialProvider initialization")
+  void testInitializeCustomCredentialProvider() {
+    Map<String, Object> props = new HashMap<>();
+    props.put(CustomCredentialProviderConstants.CUSTOM_AUTH_ENABLE_CONFIG, true);
+    props.put(
+        CustomCredentialProviderConstants.CUSTOM_AUTH_PROVIDER_CLASS,
+        "com.mongodb.kafka.connect.util.custom.credentials.TestCustomCredentialProvider");
+    props.put("customProperty", "customValue");
+    CustomCredentialProvider customCredentialProvider =
+        CustomCredentialProviderGenericInitializer.initializeCustomProvider(props);
+    assertEquals(TestCustomCredentialProvider.class, customCredentialProvider.getClass());
+  }
+
+  @Test
+  @DisplayName("Test CustomCredentialProvider custom props initialization")
+  void testCustomPropsInit() {
+    Map<String, Object> props = new HashMap<>();
+    props.put(CustomCredentialProviderConstants.CUSTOM_AUTH_ENABLE_CONFIG, true);
+    props.put(
+        CustomCredentialProviderConstants.CUSTOM_AUTH_PROVIDER_CLASS,
+        "com.mongodb.kafka.connect.util.custom.credentials.TestCustomCredentialProvider");
+    props.put("customProperty", "customValue");
+    TestCustomCredentialProvider customCredentialProvider =
+        (TestCustomCredentialProvider)
+            CustomCredentialProviderGenericInitializer.initializeCustomProvider(props);
+    assertEquals("customValue", customCredentialProvider.getCustomProperty());
+  }
+
+  @Test
+  @DisplayName("Test CustomCredentialProvider custom props validation")
+  void testCustomPropsValidate() {
+    Map<String, Object> props = new HashMap<>();
+    props.put(CustomCredentialProviderConstants.CUSTOM_AUTH_ENABLE_CONFIG, true);
+    props.put(
+        CustomCredentialProviderConstants.CUSTOM_AUTH_PROVIDER_CLASS,
+        "com.mongodb.kafka.connect.util.custom.credentials.TestCustomCredentialProvider");
+    props.put("customProperty", "invalidValue");
+    ConfigException configException =
+        assertThrows(
+            ConfigException.class,
+            () -> CustomCredentialProviderGenericInitializer.initializeCustomProvider(props),
+            "Expected initializeCustomProvider() to throw, but it didn't");
+    assertEquals("Invalid value set for customProperty", configException.getMessage());
+  }
+}

--- a/src/test/java/com/mongodb/kafka/connect/util/custom/credentials/CustomCredentialProviderGenericInitializerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/util/custom/credentials/CustomCredentialProviderGenericInitializerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mongodb.kafka.connect.util.custom.credentials;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/mongodb/kafka/connect/util/custom/credentials/TestCustomCredentialProvider.java
+++ b/src/test/java/com/mongodb/kafka/connect/util/custom/credentials/TestCustomCredentialProvider.java
@@ -1,0 +1,34 @@
+package com.mongodb.kafka.connect.util.custom.credentials;
+
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigException;
+
+import com.mongodb.MongoCredential;
+
+public class TestCustomCredentialProvider implements CustomCredentialProvider {
+
+  private String customProperty;
+
+  public String getCustomProperty() {
+    return customProperty;
+  }
+
+  @Override
+  public MongoCredential getCustomCredential(Map<?, ?> configs) {
+    return MongoCredential.createAwsCredential("userName", "password".toCharArray());
+  }
+
+  @Override
+  public void validate(Map<?, ?> configs) {
+    String customProperty = (String) configs.get("customProperty");
+    if (customProperty.equals("invalidValue")) {
+      throw new ConfigException("Invalid value set for customProperty");
+    }
+  }
+
+  @Override
+  public void init(Map<?, ?> configs) {
+    customProperty = (String) configs.get("customProperty");
+  }
+}

--- a/src/test/java/com/mongodb/kafka/connect/util/custom/credentials/TestCustomCredentialProvider.java
+++ b/src/test/java/com/mongodb/kafka/connect/util/custom/credentials/TestCustomCredentialProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mongodb.kafka.connect.util.custom.credentials;
 
 import java.util.Map;
@@ -15,12 +30,12 @@ public class TestCustomCredentialProvider implements CustomCredentialProvider {
   }
 
   @Override
-  public MongoCredential getCustomCredential(Map<?, ?> configs) {
+  public MongoCredential getCustomCredential(final Map<?, ?> configs) {
     return MongoCredential.createAwsCredential("userName", "password".toCharArray());
   }
 
   @Override
-  public void validate(Map<?, ?> configs) {
+  public void validate(final Map<?, ?> configs) {
     String customProperty = (String) configs.get("customProperty");
     if (customProperty.equals("invalidValue")) {
       throw new ConfigException("Invalid value set for customProperty");
@@ -28,7 +43,7 @@ public class TestCustomCredentialProvider implements CustomCredentialProvider {
   }
 
   @Override
-  public void init(Map<?, ?> configs) {
+  public void init(final Map<?, ?> configs) {
     customProperty = (String) configs.get("customProperty");
   }
 }

--- a/src/test/java/com/mongodb/kafka/connect/util/custom/credentials/TestInvalidCustomCredentialProvider.java
+++ b/src/test/java/com/mongodb/kafka/connect/util/custom/credentials/TestInvalidCustomCredentialProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mongodb.kafka.connect.util.custom.credentials;
 
 public class TestInvalidCustomCredentialProvider {}

--- a/src/test/java/com/mongodb/kafka/connect/util/custom/credentials/TestInvalidCustomCredentialProvider.java
+++ b/src/test/java/com/mongodb/kafka/connect/util/custom/credentials/TestInvalidCustomCredentialProvider.java
@@ -1,0 +1,3 @@
+package com.mongodb.kafka.connect.util.custom.credentials;
+
+public class TestInvalidCustomCredentialProvider {}


### PR DESCRIPTION
Implements a framework for injecting a custom credential provider in the mongo client for sink and source connectors.