### PR TITLE
KAFKA-414: External secrets in connection.uri attribute runs into validation error during connector deployment if config providers is not set on the connect worker level

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/MongoSinkConnector.java
+++ b/src/main/java/com/mongodb/kafka/connect/MongoSinkConnector.java
@@ -81,16 +81,17 @@ public class MongoSinkConnector extends SinkConnector {
 
   @Override
   public Config validate(final Map<String, String> connectorConfigs) {
-    Config rawConfig = super.validate(connectorConfigs);
-
     MongoSinkConfig sinkConfig;
     try {
       sinkConfig = new MongoSinkConfig(connectorConfigs);
     } catch (Exception e) {
-      return rawConfig;
+      return super.validate(connectorConfigs);
     }
 
-    final Config config = ConfigHelper.evaluateConfigValues(rawConfig, sinkConfig);
+    final Map<String, String> resolvedConnectorConfigs =
+        ConfigHelper.evaluateConfigValues(connectorConfigs, sinkConfig);
+
+    final Config config = super.validate(resolvedConnectorConfigs);
 
     validateCanConnect(sinkConfig, config, CONNECTION_URI_CONFIG)
         .ifPresent(

--- a/src/main/java/com/mongodb/kafka/connect/MongoSourceConnector.java
+++ b/src/main/java/com/mongodb/kafka/connect/MongoSourceConnector.java
@@ -50,15 +50,17 @@ public class MongoSourceConnector extends SourceConnector {
 
   @Override
   public Config validate(final Map<String, String> connectorConfigs) {
-    Config rawConfig = super.validate(connectorConfigs);
     MongoSourceConfig sourceConfig;
     try {
       sourceConfig = new MongoSourceConfig(connectorConfigs);
     } catch (Exception e) {
-      return rawConfig;
+      return super.validate(connectorConfigs);
     }
 
-    final Config config = ConfigHelper.evaluateConfigValues(rawConfig, sourceConfig);
+    final Map<String, String> resolvedConnectorConfigs =
+        ConfigHelper.evaluateConfigValues(connectorConfigs, sourceConfig);
+
+    final Config config = super.validate(resolvedConnectorConfigs);
 
     validateCanConnect(sourceConfig, config, MongoSourceConfig.CONNECTION_URI_CONFIG)
         .ifPresent(

--- a/src/main/java/com/mongodb/kafka/connect/util/ConfigHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/ConfigHelper.java
@@ -17,6 +17,7 @@ package com.mongodb.kafka.connect.util;
 
 import static java.lang.String.format;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -191,18 +192,17 @@ public final class ConfigHelper {
     return Optional.empty();
   }
 
-  public static Config evaluateConfigValues(
-      final Config rawConfig, final AbstractConfig resolvedConfig) {
-    final Map<String, ?> evalValues = resolvedConfig.values();
-    rawConfig
-        .configValues()
-        .forEach(
-            configValue -> {
-              Object ev = evalValues.get(configValue.name());
-              if (ev != null) {
-                configValue.value(ev);
-              }
-            });
-    return rawConfig;
+  public static Map<String, String> evaluateConfigValues(
+      final Map<String, String> rawConfigs, final AbstractConfig resolvedConfig) {
+    Map<String, String> resolvedRawConfigs = new HashMap<>(rawConfigs);
+    final Map<String, Object> originals = resolvedConfig.originals();
+    rawConfigs.forEach(
+        (key, val) -> {
+          Object ev = originals.get(key);
+          if (ev instanceof String) {
+            resolvedRawConfigs.put(key, (String) ev);
+          }
+        });
+    return resolvedRawConfigs;
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/util/ConfigHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/ConfigHelper.java
@@ -195,10 +195,10 @@ public final class ConfigHelper {
   public static Map<String, String> evaluateConfigValues(
       final Map<String, String> rawConfigs, final AbstractConfig resolvedConfig) {
     Map<String, String> resolvedRawConfigs = new HashMap<>(rawConfigs);
-    final Map<String, Object> originals = resolvedConfig.originals();
+    final Map<String, ?> values = resolvedConfig.values();
     rawConfigs.forEach(
         (key, val) -> {
-          Object ev = originals.get(key);
+          Object ev = values.get(key);
           if (ev instanceof String) {
             resolvedRawConfigs.put(key, (String) ev);
           }


### PR DESCRIPTION
When we use custom config providers, user specified configs are replaced with config provider provided values.  Current mongo source/sink connectors try to validate connection uri attribute using user specified config. 