### PR TITLE
KAFKA-428: Mark the copy complete in the source offset for the last copied document

### DIFF
--- a/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
@@ -548,6 +548,7 @@ public class MongoSourceTaskIntegrationTest extends MongoKafkaTestCase {
   @Test
   @DisplayName("Copy existing with a restart midway through")
   void testCopyingExistingWithARestartMidwayThrough() {
+    assumeTrue(isGreaterThanThreeDotSix());
     try (AutoCloseableSourceTask task = createSourceTask()) {
 
       MongoCollection<Document> coll = getCollection();
@@ -620,6 +621,7 @@ public class MongoSourceTaskIntegrationTest extends MongoKafkaTestCase {
   @Test
   @DisplayName("Copy existing with a restart after finishing")
   void testCopyingExistingWithARestartAfterFinishing() {
+    assumeTrue(isGreaterThanThreeDotSix());
     try (AutoCloseableSourceTask task = createSourceTask()) {
 
       MongoCollection<Document> coll = getCollection();

--- a/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
@@ -212,9 +212,8 @@ final class StartedMongoSourceTask implements AutoCloseable {
 
     List<SourceRecord> sourceRecords = new ArrayList<>();
     Iterator<BsonDocument> batchIterator = getNextBatch().iterator();
-    BsonDocument changeStreamDocument;
     while (batchIterator.hasNext()) {
-      changeStreamDocument = batchIterator.next();
+      BsonDocument changeStreamDocument = batchIterator.next();
       Map<String, String> sourceOffset = new HashMap<>();
       sourceOffset.put(ID_FIELD, changeStreamDocument.getDocument(ID_FIELD).toJson());
       if (isCopying) {

--- a/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
@@ -225,9 +225,11 @@ final class StartedMongoSourceTask implements AutoCloseable {
       // this flag because the copy has completed, otherwise we are relying on future change stream
       // events to signify that we are no longer copying. We also need to set the _id field to be a
       // valid resume token, which during copying exists in the cachedResumeToken variable.
+      // In version 3.6 of mongodb the cachedResumeToken initializes to null so we need to avoid
+      // this null pointer exception.
       boolean lastDocument = !batchIterator.hasNext();
       boolean noMoreDataToCopy = copyDataManager != null && !copyDataManager.isCopying();
-      if (isCopying && lastDocument && noMoreDataToCopy) {
+      if (isCopying && lastDocument && noMoreDataToCopy && cachedResumeToken != null) {
         sourceOffset.put(ID_FIELD, cachedResumeToken.toJson());
         sourceOffset.remove(COPY_KEY);
       }

--- a/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
@@ -48,6 +48,7 @@ import static java.util.Collections.singletonList;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -210,68 +211,80 @@ final class StartedMongoSourceTask implements AutoCloseable {
         createValueSchemaAndValueProvider(sourceConfig);
 
     List<SourceRecord> sourceRecords = new ArrayList<>();
-    getNextBatch()
-        .forEach(
-            changeStreamDocument -> {
-              Map<String, String> sourceOffset = new HashMap<>();
-              sourceOffset.put(ID_FIELD, changeStreamDocument.getDocument(ID_FIELD).toJson());
-              if (isCopying) {
-                sourceOffset.put(COPY_KEY, "true");
-              }
+    Iterator<BsonDocument> batchIterator = getNextBatch().iterator();
+    BsonDocument changeStreamDocument;
+    while (batchIterator.hasNext()) {
+      changeStreamDocument = batchIterator.next();
+      Map<String, String> sourceOffset = new HashMap<>();
+      sourceOffset.put(ID_FIELD, changeStreamDocument.getDocument(ID_FIELD).toJson());
+      if (isCopying) {
+        sourceOffset.put(COPY_KEY, "true");
+      }
 
-              String topicName = topicMapper.getTopic(changeStreamDocument);
-              if (topicName.isEmpty()) {
-                LOGGER.warn(
-                    "No topic set. Could not publish the message: {}",
-                    changeStreamDocument.toJson());
-              } else {
+      // if isCopying is true, we want to set the COPY_KEY flag so that kafka has context that a
+      // copy is in progress. However, for the last document that we are copying, we should not set
+      // this flag because the copy has completed, otherwise we are relying on future change stream
+      // events to signify that we are no longer copying. We also need to set the _id field to be a
+      // valid resume token, which during copying exists in the cachedResumeToken variable.
+      boolean lastDocument = !batchIterator.hasNext();
+      boolean noMoreDataToCopy = copyDataManager != null && !copyDataManager.isCopying();
+      if (isCopying && lastDocument && noMoreDataToCopy) {
+        sourceOffset.put(ID_FIELD, cachedResumeToken.toJson());
+        sourceOffset.remove(COPY_KEY);
+      }
 
-                Optional<BsonDocument> valueDocument = Optional.empty();
+      String topicName = topicMapper.getTopic(changeStreamDocument);
+      if (topicName.isEmpty()) {
+        LOGGER.warn(
+            "No topic set. Could not publish the message: {}", changeStreamDocument.toJson());
+      } else {
 
-                boolean isTombstoneEvent =
-                    publishFullDocumentOnlyTombstoneOnDelete
-                        && !changeStreamDocument.containsKey(FULL_DOCUMENT);
-                if (publishFullDocumentOnly) {
-                  if (changeStreamDocument.containsKey(FULL_DOCUMENT)
-                      && changeStreamDocument.get(FULL_DOCUMENT).isDocument()) {
-                    valueDocument = Optional.of(changeStreamDocument.getDocument(FULL_DOCUMENT));
-                  }
-                } else {
-                  valueDocument = Optional.of(changeStreamDocument);
-                }
+        Optional<BsonDocument> valueDocument = Optional.empty();
 
-                if (valueDocument.isPresent() || isTombstoneEvent) {
-                  BsonDocument valueDoc = valueDocument.orElse(new BsonDocument());
-                  LOGGER.trace("Adding {} to {}: {}", valueDoc, topicName, sourceOffset);
+        boolean isTombstoneEvent =
+            publishFullDocumentOnlyTombstoneOnDelete
+                && !changeStreamDocument.containsKey(FULL_DOCUMENT);
+        if (publishFullDocumentOnly) {
+          if (changeStreamDocument.containsKey(FULL_DOCUMENT)
+              && changeStreamDocument.get(FULL_DOCUMENT).isDocument()) {
+            valueDocument = Optional.of(changeStreamDocument.getDocument(FULL_DOCUMENT));
+          }
+        } else {
+          valueDocument = Optional.of(changeStreamDocument);
+        }
 
-                  if (valueDoc instanceof RawBsonDocument) {
-                    int sizeBytes = ((RawBsonDocument) valueDoc).getByteBuffer().limit();
-                    statisticsManager.currentStatistics().getMongodbBytesRead().sample(sizeBytes);
-                  }
+        if (valueDocument.isPresent() || isTombstoneEvent) {
+          BsonDocument valueDoc = valueDocument.orElse(new BsonDocument());
+          LOGGER.trace("Adding {} to {}: {}", valueDoc, topicName, sourceOffset);
 
-                  BsonDocument keyDocument;
-                  if (sourceConfig.getKeyOutputFormat() == MongoSourceConfig.OutputFormat.SCHEMA) {
-                    keyDocument = changeStreamDocument;
-                  } else if (sourceConfig.getBoolean(DOCUMENT_KEY_AS_KEY_CONFIG)
-                      && changeStreamDocument.containsKey(DOCUMENT_KEY_FIELD)) {
-                    keyDocument = changeStreamDocument.getDocument(DOCUMENT_KEY_FIELD);
-                  } else {
-                    keyDocument = new BsonDocument(ID_FIELD, changeStreamDocument.get(ID_FIELD));
-                  }
+          if (valueDoc instanceof RawBsonDocument) {
+            int sizeBytes = ((RawBsonDocument) valueDoc).getByteBuffer().limit();
+            statisticsManager.currentStatistics().getMongodbBytesRead().sample(sizeBytes);
+          }
 
-                  createSourceRecord(
-                          keySchemaAndValueProducer,
-                          isTombstoneEvent
-                              ? TOMBSTONE_SCHEMA_AND_VALUE_PRODUCER
-                              : valueSchemaAndValueProducer,
-                          sourceOffset,
-                          topicName,
-                          keyDocument,
-                          valueDoc)
-                      .map(sourceRecords::add);
-                }
-              }
-            });
+          BsonDocument keyDocument;
+          if (sourceConfig.getKeyOutputFormat() == MongoSourceConfig.OutputFormat.SCHEMA) {
+            keyDocument = changeStreamDocument;
+          } else if (sourceConfig.getBoolean(DOCUMENT_KEY_AS_KEY_CONFIG)
+              && changeStreamDocument.containsKey(DOCUMENT_KEY_FIELD)) {
+            keyDocument = changeStreamDocument.getDocument(DOCUMENT_KEY_FIELD);
+          } else {
+            keyDocument = new BsonDocument(ID_FIELD, changeStreamDocument.get(ID_FIELD));
+          }
+
+          createSourceRecord(
+                  keySchemaAndValueProducer,
+                  isTombstoneEvent
+                      ? TOMBSTONE_SCHEMA_AND_VALUE_PRODUCER
+                      : valueSchemaAndValueProducer,
+                  sourceOffset,
+                  topicName,
+                  keyDocument,
+                  valueDoc)
+              .map(sourceRecords::add);
+        }
+      }
+    }
     LOGGER.debug("Return batch of {}", sourceRecords.size());
 
     if (sourceRecords.isEmpty()) {


### PR DESCRIPTION
This fixes an issue that was occurring when:
1. startup mode `COPY_EXISTING` is used
2. the copy has completed
3. but no new has been sent
4. then the kafka connector restarts

The resulting behavior of this scenario is that the copy would occur again on restart.

---

This was happening because sourceOffets for copied records specify `copy: true`, so the restart thinks that the copy was in progress and it tries again. (_note that restarts that occur during a copy is expected to reattempt the copy, which will duplicate data_)

Here is an example of what that copy offset looks like:
```
{"_id":"{\"_id\": {\"$oid\": \"670ee1efaa5a9af80d592c47\"}, \"copyingData\": true}","copy":"true"}
```

---

It does look like we have [logic](https://github.com/mongodb/mongo-kafka/blob/1a09960e1f90c7ab077c1f1d6a502d162f88e5fb/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java#L583-L589) which appears to try to `"mark copying ended"` but this doesn't work when the `cachedResult` is null. 
```
      // Copying finished - mark copying ended and add cached result
      isCopying = false;
      LOGGER.info("Finished copying existing data from the collection(s).");
      if (cachedResult != null) {
        batch.add(cachedResult);
        cachedResult = null;
      }
```
(I'm not actually sure if this logic ever worked, but I could see a future where the `cachedResult` concept is removed. I haven't thought about this enough to form a strong enough opinion yet)

---

The fix for this issue was to identify when we are creating the `sourceOffset` for the last copied document and in that case go ahead and `"mark copying ended"` by removing the `copy: true` flag and setting the '_id' field to the `cachedResumeToken`.

