### PR TITLE
KAFKA-388: Add NullFieldValueRemover post processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 1.13.1
 
 ### Bug Fixes
-  - [KAFKA-428](https://jira.mongodb.org/browse/KAFKA-428) Avoid unnecessary copy of data on restart 
+  - [KAFKA-428](https://jira.mongodb.org/browse/KAFKA-428) Avoid unnecessary copy of data on restart
 
 ## 1.13.0
 

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/NullFieldValueRemover.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/NullFieldValueRemover.java
@@ -1,0 +1,33 @@
+package com.mongodb.kafka.connect.sink.processor;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+
+import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
+import com.mongodb.kafka.connect.sink.converter.SinkDocument;
+
+public class NullFieldValueRemover extends PostProcessor {
+
+  public NullFieldValueRemover(MongoSinkTopicConfig config) {
+    super(config);
+  }
+
+  @Override
+  public void process(SinkDocument doc, SinkRecord orig) {
+    doc.getValueDoc().ifPresent(this::removeNullFieldValues);
+  }
+
+  private void removeNullFieldValues(final BsonDocument doc) {
+    doc.entrySet()
+        .removeIf(
+            entry -> {
+              BsonValue value = entry.getValue();
+              if (value.isDocument()) {
+                removeNullFieldValues(value.asDocument());
+              }
+              return value.isNull();
+            });
+  }
+}

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/NullFieldValueRemover.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/NullFieldValueRemover.java
@@ -27,6 +27,11 @@ public class NullFieldValueRemover extends PostProcessor {
               if (value.isDocument()) {
                 removeNullFieldValues(value.asDocument());
               }
+              if (value.isArray()) {
+                value.asArray().stream()
+                    .filter(BsonValue::isDocument)
+                    .forEach(element -> removeNullFieldValues(element.asDocument()));
+              }
               return value.isNull();
             });
   }

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/NullFieldValueRemover.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/NullFieldValueRemover.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.kafka.connect.sink.processor;
 
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -10,12 +26,12 @@ import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 
 public class NullFieldValueRemover extends PostProcessor {
 
-  public NullFieldValueRemover(MongoSinkTopicConfig config) {
+  public NullFieldValueRemover(final MongoSinkTopicConfig config) {
     super(config);
   }
 
   @Override
-  public void process(SinkDocument doc, SinkRecord orig) {
+  public void process(final SinkDocument doc, final SinkRecord orig) {
     doc.getValueDoc().ifPresent(this::removeNullFieldValues);
   }
 

--- a/src/test/java/com/mongodb/kafka/connect/sink/processor/NullFieldValueRemoverTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/processor/NullFieldValueRemoverTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.kafka.connect.sink.processor;
 
 import static com.mongodb.kafka.connect.sink.SinkTestHelper.createTopicConfig;
@@ -120,7 +136,9 @@ public class NullFieldValueRemoverTest {
     new NullFieldValueRemover(createTopicConfig()).process(sinkDocWithValueDoc, null);
     BsonDocument expected =
         BsonDocument.parse(
-            "{'mySubDoc1': {'myDocumentString': 'a', 'mySubDoc2': {'myDocumentString': 'b', 'mySubDoc3': {'myDocumentString': 'c'}}}, 'myArray': [null, 'a', {}, 123], 'myDocument': {'myDocumentString': 'a'}, 'myDocumentAllNullFields': {}}");
+            "{'mySubDoc1': {'myDocumentString': 'a', 'mySubDoc2': {'myDocumentString': 'b', "
+                + "'mySubDoc3': {'myDocumentString': 'c'}}}, 'myArray': [null, 'a', {}, 123], "
+                + "'myDocument': {'myDocumentString': 'a'}, 'myDocumentAllNullFields': {}}");
 
     assertEquals(Optional.of(expected), sinkDocWithValueDoc.getValueDoc());
   }

--- a/src/test/java/com/mongodb/kafka/connect/sink/processor/NullFieldValueRemoverTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/processor/NullFieldValueRemoverTest.java
@@ -1,0 +1,127 @@
+package com.mongodb.kafka.connect.sink.processor;
+
+import static com.mongodb.kafka.connect.sink.SinkTestHelper.createTopicConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.bson.BsonArray;
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonElement;
+import org.bson.BsonInt32;
+import org.bson.BsonNull;
+import org.bson.BsonString;
+
+import com.mongodb.kafka.connect.sink.converter.SinkDocument;
+
+public class NullFieldValueRemoverTest {
+  @Test
+  @DisplayName("test NullFieldValueRemoverTest flat document")
+  void testNullFieldValueRemoverFlatDocument() {
+    List<BsonElement> elements =
+        Arrays.asList(
+            new BsonElement("myNull1", new BsonNull()),
+            new BsonElement("myString", new BsonString("a")),
+            new BsonElement("myEmptyString", new BsonString("")),
+            new BsonElement("myNull2", new BsonNull()),
+            new BsonElement("myTrueBool", new BsonBoolean(true)),
+            new BsonElement("myFalseBool", new BsonBoolean(false)),
+            new BsonElement("myInt", new BsonInt32(123)),
+            new BsonElement("myNull3", new BsonNull()));
+    BsonDocument containsNullFieldValues = new BsonDocument(elements);
+    SinkDocument sinkDocWithValueDoc = new SinkDocument(null, containsNullFieldValues);
+    new NullFieldValueRemover(createTopicConfig()).process(sinkDocWithValueDoc, null);
+    BsonDocument expected =
+        BsonDocument.parse(
+            "{'myString': 'a', 'myEmptyString': '', 'myTrueBool': true, 'myFalseBool': false, 'myInt': 123}");
+
+    assertEquals(Optional.of(expected), sinkDocWithValueDoc.getValueDoc());
+
+    elements =
+        Arrays.asList(
+            new BsonElement("myNull1", new BsonNull()),
+            new BsonElement("myNull2", new BsonNull()),
+            new BsonElement("myNull3", new BsonNull()));
+    BsonDocument containsOnlyNullFieldValues = new BsonDocument(elements);
+    sinkDocWithValueDoc = new SinkDocument(null, containsOnlyNullFieldValues);
+    new NullFieldValueRemover(createTopicConfig()).process(sinkDocWithValueDoc, null);
+    expected = BsonDocument.parse("{}");
+
+    assertEquals(Optional.of(expected), sinkDocWithValueDoc.getValueDoc());
+
+    BsonDocument empty = new BsonDocument();
+    sinkDocWithValueDoc = new SinkDocument(null, empty);
+    new NullFieldValueRemover(createTopicConfig()).process(sinkDocWithValueDoc, null);
+    expected = BsonDocument.parse("{}");
+
+    assertEquals(Optional.of(expected), sinkDocWithValueDoc.getValueDoc());
+  }
+
+  @Test
+  @DisplayName("test NullFieldValueRemoverTest nested document")
+  void testNullFieldValueRemoverNestedDocument() {
+    List<BsonElement> elements =
+        Arrays.asList(
+            new BsonElement("myNull1", new BsonNull()),
+            new BsonElement(
+                "mySubDoc1",
+                new BsonDocument(
+                    Arrays.asList(
+                        new BsonElement("myDocumentString", new BsonString("a")),
+                        new BsonElement("myDocumentNull", new BsonNull()),
+                        new BsonElement(
+                            "mySubDoc2",
+                            new BsonDocument(
+                                Arrays.asList(
+                                    new BsonElement("myDocumentString", new BsonString("b")),
+                                    new BsonElement("myDocumentNull", new BsonNull()),
+                                    new BsonElement(
+                                        "mySubDoc3",
+                                        new BsonDocument(
+                                            Arrays.asList(
+                                                new BsonElement(
+                                                    "myDocumentString", new BsonString("c")),
+                                                new BsonElement(
+                                                    "myDocumentNull", new BsonNull())))))))))),
+            new BsonElement(
+                "myArray",
+                new BsonArray(
+                    Arrays.asList(
+                        new BsonNull(),
+                        new BsonString("a"),
+                        new BsonDocument(
+                            Arrays.asList(
+                                new BsonElement("myArrayValueDocumentNull1", new BsonNull()),
+                                new BsonElement("myArrayValueDocumentNull2", new BsonNull()),
+                                new BsonElement("myArrayValueDocumentNull3", new BsonNull()))),
+                        new BsonInt32(123)))),
+            new BsonElement("myNull3", new BsonNull()),
+            new BsonElement(
+                "myDocument",
+                new BsonDocument(
+                    Arrays.asList(
+                        new BsonElement("myDocumentString", new BsonString("a")),
+                        new BsonElement("myDocumentNull", new BsonNull())))),
+            new BsonElement(
+                "myDocumentAllNullFields",
+                new BsonDocument(
+                    Arrays.asList(
+                        new BsonElement("myDocumentNull1", new BsonNull()),
+                        new BsonElement("myDocumentNull2", new BsonNull()),
+                        new BsonElement("myDocumentNull3", new BsonNull())))));
+    BsonDocument containsNullFieldValues = new BsonDocument(elements);
+    SinkDocument sinkDocWithValueDoc = new SinkDocument(null, containsNullFieldValues);
+    new NullFieldValueRemover(createTopicConfig()).process(sinkDocWithValueDoc, null);
+    BsonDocument expected =
+        BsonDocument.parse(
+            "{'mySubDoc1': {'myDocumentString': 'a', 'mySubDoc2': {'myDocumentString': 'b', 'mySubDoc3': {'myDocumentString': 'c'}}}, 'myArray': [null, 'a', {'myArrayValueDocumentNull1': null, 'myArrayValueDocumentNull2': null, 'myArrayValueDocumentNull3': null}, 123], 'myDocument': {'myDocumentString': 'a'}, 'myDocumentAllNullFields': {}}");
+
+    assertEquals(Optional.of(expected), sinkDocWithValueDoc.getValueDoc());
+  }
+}

--- a/src/test/java/com/mongodb/kafka/connect/sink/processor/NullFieldValueRemoverTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/processor/NullFieldValueRemoverTest.java
@@ -120,7 +120,7 @@ public class NullFieldValueRemoverTest {
     new NullFieldValueRemover(createTopicConfig()).process(sinkDocWithValueDoc, null);
     BsonDocument expected =
         BsonDocument.parse(
-            "{'mySubDoc1': {'myDocumentString': 'a', 'mySubDoc2': {'myDocumentString': 'b', 'mySubDoc3': {'myDocumentString': 'c'}}}, 'myArray': [null, 'a', {'myArrayValueDocumentNull1': null, 'myArrayValueDocumentNull2': null, 'myArrayValueDocumentNull3': null}, 123], 'myDocument': {'myDocumentString': 'a'}, 'myDocumentAllNullFields': {}}");
+            "{'mySubDoc1': {'myDocumentString': 'a', 'mySubDoc2': {'myDocumentString': 'b', 'mySubDoc3': {'myDocumentString': 'c'}}}, 'myArray': [null, 'a', {}, 123], 'myDocument': {'myDocumentString': 'a'}, 'myDocumentAllNullFields': {}}");
 
     assertEquals(Optional.of(expected), sinkDocWithValueDoc.getValueDoc());
   }

--- a/src/test/java/com/mongodb/kafka/connect/sink/processor/NullFieldValueRemoverTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/processor/NullFieldValueRemoverTest.java
@@ -58,23 +58,30 @@ public class NullFieldValueRemoverTest {
             "{'myString': 'a', 'myEmptyString': '', 'myTrueBool': true, 'myFalseBool': false, 'myInt': 123}");
 
     assertEquals(Optional.of(expected), sinkDocWithValueDoc.getValueDoc());
+  }
 
-    elements =
+  @Test
+  @DisplayName("test NullFieldValueRemoverTest document with only null values")
+  void testNullFieldValueRemoverObjectWithOnlyNullValues() {
+    List<BsonElement> elements =
         Arrays.asList(
             new BsonElement("myNull1", new BsonNull()),
             new BsonElement("myNull2", new BsonNull()),
             new BsonElement("myNull3", new BsonNull()));
     BsonDocument containsOnlyNullFieldValues = new BsonDocument(elements);
-    sinkDocWithValueDoc = new SinkDocument(null, containsOnlyNullFieldValues);
+    SinkDocument sinkDocWithValueDoc = new SinkDocument(null, containsOnlyNullFieldValues);
     new NullFieldValueRemover(createTopicConfig()).process(sinkDocWithValueDoc, null);
-    expected = BsonDocument.parse("{}");
-
+    BsonDocument expected = BsonDocument.parse("{}");
     assertEquals(Optional.of(expected), sinkDocWithValueDoc.getValueDoc());
+  }
 
+  @Test
+  @DisplayName("test NullFieldValueRemoverTest empty document")
+  void testNullFieldValueRemoverEmptyDocument() {
     BsonDocument empty = new BsonDocument();
-    sinkDocWithValueDoc = new SinkDocument(null, empty);
+    SinkDocument sinkDocWithValueDoc = new SinkDocument(null, empty);
     new NullFieldValueRemover(createTopicConfig()).process(sinkDocWithValueDoc, null);
-    expected = BsonDocument.parse("{}");
+    BsonDocument expected = BsonDocument.parse("{}");
 
     assertEquals(Optional.of(expected), sinkDocWithValueDoc.getValueDoc());
   }
@@ -136,9 +143,22 @@ public class NullFieldValueRemoverTest {
     new NullFieldValueRemover(createTopicConfig()).process(sinkDocWithValueDoc, null);
     BsonDocument expected =
         BsonDocument.parse(
-            "{'mySubDoc1': {'myDocumentString': 'a', 'mySubDoc2': {'myDocumentString': 'b', "
-                + "'mySubDoc3': {'myDocumentString': 'c'}}}, 'myArray': [null, 'a', {}, 123], "
-                + "'myDocument': {'myDocumentString': 'a'}, 'myDocumentAllNullFields': {}}");
+            "{"
+                + "  'mySubDoc1': {"
+                + "    'myDocumentString': 'a',"
+                + "    'mySubDoc2': {"
+                + "      'myDocumentString': 'b',"
+                + "      'mySubDoc3': {"
+                + "        'myDocumentString': 'c'"
+                + "      }"
+                + "    }"
+                + "  }, "
+                + "  'myArray': [null, 'a', {}, 123],"
+                + "  'myDocument': {"
+                + "    'myDocumentString': 'a'"
+                + "  },"
+                + "  'myDocumentAllNullFields': {}"
+                + "}");
 
     assertEquals(Optional.of(expected), sinkDocWithValueDoc.getValueDoc());
   }

--- a/src/test/java/com/mongodb/kafka/connect/sink/processor/NullFieldValueRemoverTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/processor/NullFieldValueRemoverTest.java
@@ -19,20 +19,12 @@ package com.mongodb.kafka.connect.sink.processor;
 import static com.mongodb.kafka.connect.sink.SinkTestHelper.createTopicConfig;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import org.bson.BsonArray;
-import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
-import org.bson.BsonElement;
-import org.bson.BsonInt32;
-import org.bson.BsonNull;
-import org.bson.BsonString;
 
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 
@@ -40,22 +32,29 @@ public class NullFieldValueRemoverTest {
   @Test
   @DisplayName("test NullFieldValueRemoverTest flat document")
   void testNullFieldValueRemoverFlatDocument() {
-    List<BsonElement> elements =
-        Arrays.asList(
-            new BsonElement("myNull1", new BsonNull()),
-            new BsonElement("myString", new BsonString("a")),
-            new BsonElement("myEmptyString", new BsonString("")),
-            new BsonElement("myNull2", new BsonNull()),
-            new BsonElement("myTrueBool", new BsonBoolean(true)),
-            new BsonElement("myFalseBool", new BsonBoolean(false)),
-            new BsonElement("myInt", new BsonInt32(123)),
-            new BsonElement("myNull3", new BsonNull()));
-    BsonDocument containsNullFieldValues = new BsonDocument(elements);
-    SinkDocument sinkDocWithValueDoc = new SinkDocument(null, containsNullFieldValues);
+    BsonDocument document =
+        BsonDocument.parse(
+            "{"
+                + "  'myNull1': null,"
+                + "  'myString': 'a',"
+                + "  'myEmptyString': ''"
+                + "  'myNull2': null,"
+                + "  'myTrueBool': true,"
+                + "  'myFalseBool': false,"
+                + "  'myInt': 123,"
+                + "  'myNull3': null"
+                + "}");
+    SinkDocument sinkDocWithValueDoc = new SinkDocument(null, document);
     new NullFieldValueRemover(createTopicConfig()).process(sinkDocWithValueDoc, null);
     BsonDocument expected =
         BsonDocument.parse(
-            "{'myString': 'a', 'myEmptyString': '', 'myTrueBool': true, 'myFalseBool': false, 'myInt': 123}");
+            "{"
+                + "  'myString': 'a',"
+                + "  'myEmptyString': '',"
+                + "  'myTrueBool': true,"
+                + "  'myFalseBool': false,"
+                + "  'myInt': 123"
+                + "}");
 
     assertEquals(Optional.of(expected), sinkDocWithValueDoc.getValueDoc());
   }
@@ -63,13 +62,9 @@ public class NullFieldValueRemoverTest {
   @Test
   @DisplayName("test NullFieldValueRemoverTest document with only null values")
   void testNullFieldValueRemoverObjectWithOnlyNullValues() {
-    List<BsonElement> elements =
-        Arrays.asList(
-            new BsonElement("myNull1", new BsonNull()),
-            new BsonElement("myNull2", new BsonNull()),
-            new BsonElement("myNull3", new BsonNull()));
-    BsonDocument containsOnlyNullFieldValues = new BsonDocument(elements);
-    SinkDocument sinkDocWithValueDoc = new SinkDocument(null, containsOnlyNullFieldValues);
+    BsonDocument document =
+        BsonDocument.parse("{ 'myNull1': null, 'myNull2': null, 'myNull3': null }");
+    SinkDocument sinkDocWithValueDoc = new SinkDocument(null, document);
     new NullFieldValueRemover(createTopicConfig()).process(sinkDocWithValueDoc, null);
     BsonDocument expected = BsonDocument.parse("{}");
     assertEquals(Optional.of(expected), sinkDocWithValueDoc.getValueDoc());
@@ -89,57 +84,27 @@ public class NullFieldValueRemoverTest {
   @Test
   @DisplayName("test NullFieldValueRemoverTest nested document")
   void testNullFieldValueRemoverNestedDocument() {
-    List<BsonElement> elements =
-        Arrays.asList(
-            new BsonElement("myNull1", new BsonNull()),
-            new BsonElement(
-                "mySubDoc1",
-                new BsonDocument(
-                    Arrays.asList(
-                        new BsonElement("myDocumentString", new BsonString("a")),
-                        new BsonElement("myDocumentNull", new BsonNull()),
-                        new BsonElement(
-                            "mySubDoc2",
-                            new BsonDocument(
-                                Arrays.asList(
-                                    new BsonElement("myDocumentString", new BsonString("b")),
-                                    new BsonElement("myDocumentNull", new BsonNull()),
-                                    new BsonElement(
-                                        "mySubDoc3",
-                                        new BsonDocument(
-                                            Arrays.asList(
-                                                new BsonElement(
-                                                    "myDocumentString", new BsonString("c")),
-                                                new BsonElement(
-                                                    "myDocumentNull", new BsonNull())))))))))),
-            new BsonElement(
-                "myArray",
-                new BsonArray(
-                    Arrays.asList(
-                        new BsonNull(),
-                        new BsonString("a"),
-                        new BsonDocument(
-                            Arrays.asList(
-                                new BsonElement("myArrayValueDocumentNull1", new BsonNull()),
-                                new BsonElement("myArrayValueDocumentNull2", new BsonNull()),
-                                new BsonElement("myArrayValueDocumentNull3", new BsonNull()))),
-                        new BsonInt32(123)))),
-            new BsonElement("myNull3", new BsonNull()),
-            new BsonElement(
-                "myDocument",
-                new BsonDocument(
-                    Arrays.asList(
-                        new BsonElement("myDocumentString", new BsonString("a")),
-                        new BsonElement("myDocumentNull", new BsonNull())))),
-            new BsonElement(
-                "myDocumentAllNullFields",
-                new BsonDocument(
-                    Arrays.asList(
-                        new BsonElement("myDocumentNull1", new BsonNull()),
-                        new BsonElement("myDocumentNull2", new BsonNull()),
-                        new BsonElement("myDocumentNull3", new BsonNull())))));
-    BsonDocument containsNullFieldValues = new BsonDocument(elements);
-    SinkDocument sinkDocWithValueDoc = new SinkDocument(null, containsNullFieldValues);
+    BsonDocument document =
+        BsonDocument.parse(
+            "{"
+                + "  'myNull1': null,"
+                + "  'mySubDoc1': {"
+                + "    'myDocumentString': 'a',"
+                + "    'myDocumentNull': null,"
+                + "    'mySubDoc2': {"
+                + "      'myDocumentString': 'b',"
+                + "      'myDocumentNull': null,"
+                + "      'mySubDoc3': {"
+                + "        'myDocumentString': 'c',"
+                + "        'myDocumentNull': null"
+                + "      }"
+                + "    }"
+                + "  },"
+                + "  'myArray': [null, 'a', { 'a': null, 'b': null, 'c': null }, 123],"
+                + "  'myNull2': null,"
+                + "  'myDocument': { 'myDocumentString': 'a', 'myDocumentNull': null }"
+                + "}");
+    SinkDocument sinkDocWithValueDoc = new SinkDocument(null, document);
     new NullFieldValueRemover(createTopicConfig()).process(sinkDocWithValueDoc, null);
     BsonDocument expected =
         BsonDocument.parse(
@@ -156,8 +121,7 @@ public class NullFieldValueRemoverTest {
                 + "  'myArray': [null, 'a', {}, 123],"
                 + "  'myDocument': {"
                 + "    'myDocumentString': 'a'"
-                + "  },"
-                + "  'myDocumentAllNullFields': {}"
+                + "  }"
                 + "}");
 
     assertEquals(Optional.of(expected), sinkDocWithValueDoc.getValueDoc());


### PR DESCRIPTION
This adds a new post processor to support removing fields that have null values.

e.g.
`{ foo: { a: null, b: 1, c: null } }` is transformed into `{ foo: { b: 1 } }`
`{ foo: { 'myNull1': null, 'myNull2': null, 'myNull3': null } }` is transformed into `{ foo: {} }`
`{ 'myArray': ['a', {'myArrayValueDocumentNull1': null}] }` is transformed into `{ 'myArray': ['a', {}] }`

note that null elements in arrays will be kept
`'myArray': [null, 'a']` is not impacted `'myArray': [null, 'a']`