### PR TITLE
KAFKA-431: Use Time.SYSTEM for initializing system time

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
@@ -58,7 +58,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
@@ -155,7 +154,7 @@ final class StartedMongoSourceTask implements AutoCloseable {
       assertTrue(sourceConfig.getStartupConfig().startupMode() == COPY_EXISTING);
     }
     isCopying = shouldCopyData;
-    time = new SystemTime();
+    time = Time.SYSTEM;
     partitionMap = createPartitionMap(sourceConfig);
     this.copyDataManager = copyDataManager;
     if (shouldCopyData) {


### PR DESCRIPTION
Kafka removed support for the `new SystemTime()` instantiation as part of [version 3.9](https://downloads.apache.org/kafka/3.9.0/RELEASE_NOTES.html)

Specifically as part of this [PR](https://github.com/apache/kafka/pull/16266/files).

This change should be safe as far as backwards compatibility goes because that Time.SYSTEM singleton interface [has existed for a long time](https://github.com/dujian0068/kafka/commit/128d0ff91d84a3a1f5a5237133f9ec01caf18d66).